### PR TITLE
chore(claude): update provider configs

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -32,8 +32,7 @@ claude:
     kimi:
       base_url: https://api.kimi.com/coding
       models:
-        - kimi-k2.5
-        - kimi-k2
+        - kimi-k2-thinking-turbo
     # GLM (Zhipu AI): https://docs.bigmodel.cn/cn/guide/develop/claude
     glm:
       base_url: https://open.bigmodel.cn/api/anthropic


### PR DESCRIPTION
## Provider Config Update

Updated Claude Code provider configurations from official documentation.

### Provider(s) Updated
- kimi

### Changes
```diff
diff --git a/.chezmoidata/claude.yaml b/.chezmoidata/claude.yaml
index 313a88f..3ffe53d 100644
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -32,8 +32,7 @@ claude:
     kimi:
       base_url: https://api.kimi.com/coding
       models:
-        - kimi-k2.5
-        - kimi-k2
+        - kimi-k2-thinking-turbo
     # GLM (Zhipu AI): https://docs.bigmodel.cn/cn/guide/develop/claude
     glm:
       base_url: https://open.bigmodel.cn/api/anthropic
```

### Sources
- [DeepSeek](https://api-docs.deepseek.com/guides/anthropic_api)
- [Kimi](https://github.com/MoonshotAI/kimi-cli/blob/main/docs/en/configuration/providers.md)
- [GLM](https://docs.bigmodel.cn/cn/guide/develop/claude)
- [Qwen](https://help.aliyun.com/zh/model-studio/claude-code)
- [MiniMax](https://platform.minimax.io/docs/coding-plan/claude-code)
- [Doubao](https://www.volcengine.com/docs/82379/1928261)

---
*Auto-generated by [update-claude-providers](https://github.com/signalridge/dotfiles/actions/runs/21551023279)*