### PR TITLE
chore(claude): migrate MCP sync to user-scope npx setup

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -83,11 +83,11 @@ claude:
     # Third-party accounts (format: provider@label)
     # Add your own: deepseek@work, kimi@personal, etc.
     doubao@private:
-      model: ark-code-latest
-      small_model: ark-code-latest
-      haiku_model: ark-code-latest
-      sonnet_model: ark-code-latest
-      opus_model: ark-code-latest
+      model: kimi-k2.5
+      small_model: kimi-k2.5
+      haiku_model: kimi-k2.5
+      sonnet_model: kimi-k2.5
+      opus_model: kimi-k2.5
     kimi@private:
       model: kimi-k2.5
       small_model: kimi-k2.5
@@ -97,9 +97,9 @@ claude:
     wanxiaot@private:
       provider: wanxiaot
       model: gpt-5.3-codex
-      small_model: claude-opus-4-5-20251101
-      haiku_model: claude-opus-4-5-20251101
-      sonnet_model: claude-opus-4-5-20251101
+      small_model: gpt-5.2-codex(medium)
+      haiku_model: gpt-5.2-codex(low)
+      sonnet_model: gpt-5.2-codex(medium)
       opus_model: gpt-5.3-codex
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)

--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -96,11 +96,11 @@ claude:
       opus_model: kimi-k2.5
     wanxiaot@private:
       provider: wanxiaot
-      model: gpt-5.3-codex
+      model: gpt-5.2-codex(xhigh)
       small_model: gpt-5.2-codex(medium)
       haiku_model: gpt-5.2-codex(low)
       sonnet_model: gpt-5.2-codex(medium)
-      opus_model: gpt-5.3-codex
+      opus_model: gpt-5.2-codex(xhigh)
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)
   # All skills are hardcoded in .chezmoiexternal.toml.tmpl

--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -97,9 +97,9 @@ claude:
     wanxiaot@private:
       provider: wanxiaot
       model: gpt-5.3-codex
-      small_model: gpt-5.3-codex
+      small_model: claude-opus-4-5-20251101
       haiku_model: claude-opus-4-5-20251101
-      sonnet_model: gpt-5.2-codex
+      sonnet_model: claude-opus-4-5-20251101
       opus_model: gpt-5.3-codex
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)

--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -96,11 +96,11 @@ claude:
       opus_model: kimi-k2.5
     wanxiaot@private:
       provider: wanxiaot
-      model: gpt-5.2-codex(xhigh)
-      small_model: gpt-5.2-codex(medium)
-      haiku_model: gpt-5.2-codex(low)
-      sonnet_model: gpt-5.2-codex(medium)
-      opus_model: gpt-5.2-codex(xhigh)
+      model: gpt-5.3-codex
+      small_model: gpt-5.3-codex
+      haiku_model: claude-opus-4-5-20251101
+      sonnet_model: gpt-5.2-codex
+      opus_model: gpt-5.3-codex
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)
   # All skills are hardcoded in .chezmoiexternal.toml.tmpl

--- a/.chezmoiscripts/run_after_09_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_09_sync-claude-mcp.sh.tmpl
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Sync Claude Code MCP servers on every chezmoi apply.
+# Fast path: only add when missing, avoid remove+add churn.
+
+echo ":: [09] Syncing Claude Code MCP servers"
+
+if ! command -v claude &>/dev/null; then
+    echo "    Skipped (claude not found)"
+    exit 0
+fi
+
+check_user_mcp_json() {
+    local name="$1"
+    local expected_json="$2"
+    python3 - "$name" "$expected_json" <<'PY'
+import json
+import os
+import sys
+
+name = sys.argv[1]
+expected = json.loads(sys.argv[2])
+path = os.path.expanduser("~/.claude.json")
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    print("missing")
+    sys.exit(0)
+
+server = data.get("mcpServers", {}).get(name)
+if not server:
+    print("missing")
+    sys.exit(0)
+
+actual_cmp = {
+    "command": server.get("command"),
+    "args": server.get("args", []),
+    "env": server.get("env", {}),
+}
+expected_cmp = {
+    "command": expected.get("command"),
+    "args": expected.get("args", []),
+    "env": expected.get("env", {}),
+}
+actual_type = server.get("type", "stdio")
+
+print("match" if actual_type == "stdio" and actual_cmp == expected_cmp else "mismatch")
+PY
+}
+
+check_user_mcp_sse() {
+    local name="$1"
+    local expected_url="$2"
+    python3 - "$name" "$expected_url" <<'PY'
+import json
+import os
+import sys
+
+name = sys.argv[1]
+expected_url = sys.argv[2]
+path = os.path.expanduser("~/.claude.json")
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    print("missing")
+    sys.exit(0)
+
+server = data.get("mcpServers", {}).get(name)
+if not server:
+    print("missing")
+    sys.exit(0)
+
+actual_type = server.get("type", "stdio")
+actual_url = server.get("url")
+print("match" if actual_type == "sse" and actual_url == expected_url else "mismatch")
+PY
+}
+
+ensure_user_mcp_json() {
+    local name="$1"
+    local json="$2"
+
+    local status
+    status="$(check_user_mcp_json "$name" "$json")"
+
+    case "$status" in
+    match)
+        echo "    Exists: $name"
+        ;;
+    missing)
+        claude mcp add-json -s user "$name" "$json"
+        ;;
+    mismatch)
+        echo "    Updating: $name"
+        claude mcp remove -s user "$name" >/dev/null 2>&1 || true
+        claude mcp add-json -s user "$name" "$json"
+        ;;
+    *)
+        echo "    Skipped: $name (unknown check status: $status)"
+        ;;
+    esac
+}
+
+ensure_user_mcp_sse() {
+    local name="$1"
+    local url="$2"
+
+    local status
+    status="$(check_user_mcp_sse "$name" "$url")"
+
+    case "$status" in
+    match)
+        echo "    Exists: $name"
+        ;;
+    missing)
+        claude mcp add --transport sse -s user "$name" "$url"
+        ;;
+    mismatch)
+        echo "    Updating: $name"
+        claude mcp remove -s user "$name" >/dev/null 2>&1 || true
+        claude mcp add --transport sse -s user "$name" "$url"
+        ;;
+    *)
+        echo "    Skipped: $name (unknown check status: $status)"
+        ;;
+    esac
+}
+
+ensure_user_mcp_json "slack" '{"command":"npx","args":["-y","@anthropic/mcp-server-slack"],"env":{"SLACK_BOT_TOKEN":"${SLACK_BOT_TOKEN}","SLACK_TEAM_ID":"${SLACK_TEAM_ID}"}}'
+
+if command -v docker &>/dev/null && [[ -n "${SLACK_USER_TOKEN:-}" ]]; then
+    ensure_user_mcp_json "slack-explorer" '{"command":"docker","args":["run","-i","--rm","--pull","always","ghcr.io/shibayu36/slack-explorer-mcp:latest"],"env":{"SLACK_USER_TOKEN":"${SLACK_USER_TOKEN}"}}'
+else
+    echo "    Skipped: slack-explorer (docker or SLACK_USER_TOKEN missing)"
+fi
+
+ensure_user_mcp_sse "notion" "https://mcp.notion.com/sse"
+ensure_user_mcp_json "sequential-thinking" '{"command":"npx","args":["-y","@anthropic/mcp-server-sequential-thinking"]}'
+ensure_user_mcp_json "playwright" '{"command":"npx","args":["-y","@playwright/mcp@latest"]}'
+ensure_user_mcp_json "context7" '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
+ensure_user_mcp_json "markitdown" '{"command":"uvx","args":["markitdown-mcp"]}'
+ensure_user_mcp_json "arxiv-mcp-server" '{"command":"uv","args":["tool","run","arxiv-mcp-server"]}'
+ensure_user_mcp_json "tavily" '{"command":"~/.local/bin/mcp-tavily","args":[]}'
+ensure_user_mcp_json "postgres" '{"command":"~/.local/bin/mcp-postgres","args":[]}'

--- a/.chezmoiscripts/run_after_09_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_09_sync-claude-mcp.sh.tmpl
@@ -134,11 +134,7 @@ ensure_user_mcp_sse() {
 
 ensure_user_mcp_json "slack" '{"command":"npx","args":["-y","@anthropic/mcp-server-slack"],"env":{"SLACK_BOT_TOKEN":"${SLACK_BOT_TOKEN}","SLACK_TEAM_ID":"${SLACK_TEAM_ID}"}}'
 
-if command -v docker &>/dev/null && [[ -n "${SLACK_USER_TOKEN:-}" ]]; then
-    ensure_user_mcp_json "slack-explorer" '{"command":"docker","args":["run","-i","--rm","--pull","always","ghcr.io/shibayu36/slack-explorer-mcp:latest"],"env":{"SLACK_USER_TOKEN":"${SLACK_USER_TOKEN}"}}'
-else
-    echo "    Skipped: slack-explorer (docker or SLACK_USER_TOKEN missing)"
-fi
+ensure_user_mcp_json "slack-explorer" '{"command":"docker","args":["run","-i","--rm","--pull","always","ghcr.io/shibayu36/slack-explorer-mcp:latest"],"env":{"SLACK_USER_TOKEN":"${SLACK_USER_TOKEN}"}}'
 
 ensure_user_mcp_sse "notion" "https://mcp.notion.com/sse"
 ensure_user_mcp_json "sequential-thinking" '{"command":"npx","args":["-y","@anthropic/mcp-server-sequential-thinking"]}'

--- a/.chezmoiscripts/run_onchange_after_05_mise-install.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_05_mise-install.sh.tmpl
@@ -10,7 +10,6 @@ echo ":: [05] Installing mise tools"
 
 if command -v mise &>/dev/null; then
     mise install --yes
-    mise tasks run ensure-openspec --raw
 else
     echo "    Skipped (mise not found)"
     exit 0

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -18,41 +18,7 @@
 {{- $defaults := .claude.defaults -}}
 
 {
-  "apiKeyHelper": "~/.local/bin/claude-token",
-  "mcpServers": {
-    "slack": {
-      "command": "bunx",
-      "args": ["-y", "@anthropic/mcp-server-slack"],
-      "env": {
-        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
-        "SLACK_TEAM_ID": "${SLACK_TEAM_ID}"
-      }
-    },
-    "notion": {
-      "command": "bunx",
-      "args": ["-y", "@anthropic/mcp-server-notion"],
-      "env": {
-        "NOTION_API_KEY": "${NOTION_API_KEY}"
-      }
-    },
-    "sequential-thinking": {
-      "command": "bunx",
-      "args": ["-y", "@anthropic/mcp-server-sequential-thinking"]
-    },
-    "playwright": {
-      "command": "bunx",
-      "args": ["-y", "@playwright/mcp@latest"],
-      "description": "Browser automation for JS-rendered pages"
-    },
-    "tavily": {
-      "command": "~/.local/bin/mcp-tavily",
-      "args": []
-    },
-    "postgres": {
-      "command": "~/.local/bin/mcp-postgres",
-      "args": []
-    }
-  },
+  "apiKeyHelper": "{{- if and $provider (hasKey $provider "base_url") -}}~/.local/bin/claude-token{{- end -}}",
   "permissions": {
     "deny": [
       "Bash(sudo rm -rf:*)",
@@ -95,8 +61,8 @@
       "Bash(gh:*)",
       "Bash(just:*)",
       "Bash(mise:*)",
-      "Bash(bun:*)",
-      "Bash(bunx:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
       "Bash(openspec:*)",
       "Bash(nix:*)",
       "Bash(chezmoi:*)"

--- a/dot_local/bin/executable_mcp-postgres.tmpl
+++ b/dot_local/bin/executable_mcp-postgres.tmpl
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib/common"
 
-require_cmd gopass bunx
+require_cmd gopass npx
 
 PG_DSN_GOPASS_PATH="postgres/api_key"
 
@@ -22,4 +22,4 @@ if [[ -z "$PG_DSN" ]]; then
 fi
 
 # Reference server: read-only Postgres MCP
-exec bunx @modelcontextprotocol/server-postgres "$PG_DSN" "$@"
+exec npx @modelcontextprotocol/server-postgres "$PG_DSN" "$@"

--- a/dot_local/bin/executable_mcp-tavily.tmpl
+++ b/dot_local/bin/executable_mcp-tavily.tmpl
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib/common"
 
-require_cmd gopass bunx
+require_cmd gopass npx
 
 # Keep path simple as requested.
 TAVILY_GOPASS_PATH="tavily/api_key"
@@ -25,4 +25,4 @@ fi
 export TAVILY_API_KEY
 
 # Use latest package tag.
-exec bunx tavily-mcp@latest "$@"
+exec npx tavily-mcp@latest "$@"

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -2,8 +2,8 @@
 # https://mise.jdx.dev/configuration.html
 
 [tools]
-# Bun (used for global JS CLIs)
-bun = "latest"
+# Node.js (used for global JS CLIs via npm/npx)
+node = "lts"
 
 # Terraform (replaces tenv)
 terraform = "latest"
@@ -31,29 +31,8 @@ rust = "latest"
 # pre-commit (avoid Swift compilation from nixpkgs dotnet dependency)
 pre-commit = "latest"
 
-[tasks.ensure-openspec]
-description = "Ensure OpenSpec CLI is available (installed via bun)"
-run = '''
-set -euo pipefail
-
-if command -v openspec >/dev/null 2>&1; then
-  openspec --version >/dev/null 2>&1 || true
-  exit 0
-fi
-
-if ! command -v bun >/dev/null 2>&1; then
-  echo "bun not found; install via mise first" >&2
-  exit 1
-fi
-
-bun add -g @fission-ai/openspec@${OPEN_SPEC_VERSION}
-
-command -v openspec >/dev/null 2>&1 || {
-  echo "OpenSpec install finished but 'openspec' not on PATH" >&2
-  echo "Ensure ~/.bun/bin is in PATH" >&2
-  exit 1
-}
-'''
+# OpenSpec CLI managed declaratively via mise npm backend
+"npm:@fission-ai/openspec" = "1.1.1"
 
 [settings]
 # Automatically install tools when entering directory
@@ -77,8 +56,5 @@ always_keep_download = false
 always_keep_install = false
 
 [env]
-# Pinned OpenSpec version used by mise task and Justfile bunx fallback
-OPEN_SPEC_VERSION = "1.1.1"
-
 # Add local bin to PATH
 _.path = ["./node_modules/.bin", "./bin"]


### PR DESCRIPTION
## Summary
Refactors Claude MCP bootstrap to use a stable user-scope sync flow and aligns model defaults across private provider profiles.

## Changes
- Add `run_after_09_sync-claude-mcp.sh.tmpl` to idempotently sync MCP servers via `claude mcp` (including slack-explorer, context7, markitdown, arxiv, tavily, postgres)
- Migrate JS CLI runtime usage from `bun/bunx` to `node + npx` in scripts, permissions, and mise toolchain configuration
- Remove the old `mise ensure-openspec` install task and manage OpenSpec via declarative `npm:@fission-ai/openspec`
- Update Claude provider defaults in `.chezmoidata/claude.yaml`, including private account model alias alignment
- Simplify `dot_claude/settings.json.tmpl` by dropping embedded MCP server definitions and making `apiKeyHelper` conditional

## Testing
- [x] Pre-commit checks pass on commit
- [x] Template and formatting hooks pass
- [ ] Manual `chezmoi apply` verification in a fresh environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)