### PR TITLE
feat(skills): add local zig development playbook

### DIFF
--- a/dot_agents/skills/local/zig-development-playbook/SKILL.md
+++ b/dot_agents/skills/local/zig-development-playbook/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: zig-development-playbook
+description: End-to-end Zig engineering workflow for implementation, refactoring, debugging, testing, build.zig authoring, allocator and error-handling correctness, C interop, cross-compilation, and release checks. Use when tasks touch Zig source files, build.zig/build.zig.zon, Zig toolchain setup, or Zig project quality gates.
+---
+
+# Zig Development Playbook
+
+Production workflow for Zig projects, designed in the same practical style as the existing Go engineering skills: clear triggers, reusable patterns, and strict verification gates.
+
+## When to Use This Skill
+
+- Building or modifying Zig applications/libraries.
+- Creating or updating `build.zig` and `build.zig.zon`.
+- Fixing Zig compile/test/build failures.
+- Implementing allocator-sensitive code and ownership boundaries.
+- Writing C interop code in Zig.
+- Cross-compiling or preparing release artifacts.
+- Performing Zig quality acceptance before merge/release.
+
+## Core Concepts
+
+### 1. Zig Engineering Primitives
+
+| Primitive            | Purpose                                 |
+| -------------------- | --------------------------------------- |
+| `try` / `catch`      | Explicit error propagation and recovery |
+| `defer` / `errdefer` | Deterministic cleanup and rollback      |
+| `std.mem.Allocator`  | Explicit memory ownership and lifecycle |
+| `build.zig`          | Reproducible project build graph        |
+| `-Dtarget`           | Cross-compilation target selection      |
+| `-Doptimize`         | Safety/performance trade-off            |
+
+### 2. Zig Safety Model in Practice
+
+- Prefer `Debug` and `ReleaseSafe` while implementing and validating behavior.
+- Move to `ReleaseFast`/`ReleaseSmall` only when requested and measured.
+- Treat unchecked ownership as a defect: allocation path and free path must be explicit.
+
+## Quick Start
+
+### New Project
+
+```bash
+mkdir <project-name>
+cd <project-name>
+zig init
+zig build run
+zig build test
+```
+
+### Existing Project
+
+```bash
+zig version
+zig build --help
+zig build test
+```
+
+If `zig` is missing, use `references/official-learning-path.md` for installation routes.
+
+## Patterns
+
+### Pattern 1: Standard `build.zig` Base
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "app",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    b.installArtifact(exe);
+
+    const run_exe = b.addRunArtifact(exe);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_exe.step);
+}
+```
+
+Use this as the default template unless the project has a stronger existing convention.
+
+### Pattern 2: Error-Handling Contract
+
+```zig
+const std = @import("std");
+
+fn readConfig(path: []const u8) ![]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    return try file.readToEndAlloc(std.heap.page_allocator, 1024 * 1024);
+}
+```
+
+Rules:
+
+- Never discard an error union.
+- Prefer `try` for direct propagation.
+- Use `catch` only for true fallback or context enrichment.
+
+### Pattern 3: Allocator Ownership (`init`/`deinit`)
+
+```zig
+const std = @import("std");
+
+const App = struct {
+    allocator: std.mem.Allocator,
+    buf: []u8,
+
+    fn init(allocator: std.mem.Allocator, n: usize) !App {
+        const buf = try allocator.alloc(u8, n);
+        errdefer allocator.free(buf);
+
+        return .{
+            .allocator = allocator,
+            .buf = buf,
+        };
+    }
+
+    fn deinit(self: *App) void {
+        self.allocator.free(self.buf);
+    }
+};
+```
+
+Rules:
+
+- Define exactly who frees returned memory.
+- Use `errdefer` when partial initialization can fail.
+- Keep cleanup paths obvious and testable.
+
+### Pattern 4: Testing Flow
+
+```bash
+zig test src/main.zig
+zig build test
+zig build -Doptimize=ReleaseSafe
+```
+
+Use file-level tests for isolation, then project-level tests for integration.
+
+### Pattern 5: Cross-Compilation and Release
+
+```bash
+zig build -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseSafe
+zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSafe
+```
+
+Report success/failure for each target explicitly; do not summarize ambiguous outcomes.
+
+### Pattern 6: C Interop Baseline
+
+```zig
+const c = @cImport({
+    @cInclude("stdio.h");
+});
+
+pub fn main() void {
+    _ = c.printf("hello from C interop\n");
+}
+```
+
+For nontrivial interop tasks, validate include paths and target ABI settings through `build.zig`.
+For production-ready scaffolding, use `references/zig-c-interop-deep-template.md`.
+
+## Operational Workflow
+
+1. Discover context.
+
+- Locate `build.zig`, source roots, tests, target requirements.
+
+2. Implement minimally.
+
+- Keep scope tight; avoid opportunistic refactors.
+
+3. Verify in order.
+
+- Format check, tests, primary build, optional cross-target builds.
+
+4. Report clearly.
+
+- Commands run, outcomes, residual risk.
+
+## Acceptance Gate
+
+Run the bundled quality gate script before claiming completion:
+
+```bash
+scripts/zig_quality_gate.sh <project-dir>
+```
+
+For release/cross-target tasks:
+
+```bash
+scripts/zig_quality_gate.sh <project-dir> --release-mode ReleaseSafe --targets x86_64-linux-gnu,aarch64-macos
+```
+
+Dotfiles integration acceptance is defined in `references/dotfiles-integration-standard.md`.
+
+## Best Practices
+
+### Do
+
+- Use explicit ownership and cleanup semantics.
+- Keep build options discoverable with `zig build --help`.
+- Keep `build.zig` readable and composable.
+- Prefer `ReleaseSafe` as the default release validation mode.
+
+### Don't
+
+- Don't hide allocation ownership.
+- Don't swallow errors without intent.
+- Don't claim cross-target support without building targets.
+- Don't place custom skills under externally managed exact-sync namespaces.
+
+## Resources
+
+- Official learning and docs map: `references/official-learning-path.md`
+- Zig coding/process standards: `references/development-standards.md`
+- Zig ecosystem case studies (`Ghostty` etc.): `references/zig-ecosystem-projects.md`
+- Deep C interop templates and checklists: `references/zig-c-interop-deep-template.md`
+- Dotfiles namespace and conflict rules: `references/dotfiles-integration-standard.md`
+- Reusable quality gate script: `scripts/zig_quality_gate.sh`

--- a/dot_agents/skills/local/zig-development-playbook/references/development-standards.md
+++ b/dot_agents/skills/local/zig-development-playbook/references/development-standards.md
@@ -1,0 +1,53 @@
+# Zig Development Standards
+
+## 1. Structure
+
+- Keep `build.zig` and `build.zig.zon` at project root.
+- Keep source layout predictable (`src/main.zig`, module roots).
+
+## 2. Formatting and Naming
+
+- Run `zig fmt --check .`.
+- Prefer community naming style:
+  - functions: `camelCase`
+  - variables: `snake_case`
+  - types: `PascalCase`
+
+## 3. Error Handling
+
+- Never ignore error unions.
+- Use `try` for direct propagation.
+- Use `catch` only for fallback or wrapping.
+- Use `switch` on errors for exhaustive handling when needed.
+
+## 4. Allocator and Ownership
+
+- Pass allocator explicitly to APIs that allocate.
+- Pair allocation/free paths explicitly.
+- Prefer `init`/`deinit` lifecycle APIs for owned structures.
+- Use `errdefer` to roll back partial state on failure.
+
+## 5. Build Modes
+
+- `Debug`: diagnostics-first.
+- `ReleaseSafe`: optimized with safety checks.
+- `ReleaseFast`: speed-first.
+- `ReleaseSmall`: size-first.
+
+Default release verification target: `ReleaseSafe`.
+
+## 6. build.zig Conventions
+
+- Prefer `b.standardTargetOptions(.{})` and `b.standardOptimizeOption(.{})`.
+- Keep install behavior explicit via `b.installArtifact(...)`.
+- Keep `run` step for local dev where appropriate.
+
+## 7. Verification Minimum
+
+```bash
+zig fmt --check .
+zig build test
+zig build -Doptimize=ReleaseSafe
+```
+
+Add `-Dtarget=...` builds for each required release target.

--- a/dot_agents/skills/local/zig-development-playbook/references/dotfiles-integration-standard.md
+++ b/dot_agents/skills/local/zig-development-playbook/references/dotfiles-integration-standard.md
@@ -1,0 +1,32 @@
+# Dotfiles Integration Standard for Local Skills
+
+This project manages upstream skills through `.chezmoiexternal.toml.tmpl` with many `exact = true` destinations.
+
+## Placement Rule
+
+Custom/local skills must live under:
+
+- `.agents/skills/local/<skill-name>/`
+
+In this repository layout, that maps to:
+
+- `dot_agents/skills/local/<skill-name>/`
+
+## Conflict Rule
+
+Do not place custom skills under externally managed exact-sync paths such as:
+
+- `.agents/skills/systems-programming/`
+- `.agents/skills/backend-development/`
+- `.agents/skills/python-development/`
+- `.agents/skills/ecosystem/...`
+
+Reason: these paths are populated by archives and may overwrite/remove unmanaged content.
+
+## Acceptance Checklist
+
+1. Skill exists under `dot_agents/skills/local/<skill-name>/`.
+2. `.chezmoiexternal.toml.tmpl` has no external target for `.agents/skills/local`.
+3. `quick_validate.py` passes.
+4. `package_skill.py` produces a `.skill` artifact.
+5. Skill includes only necessary files (`SKILL.md`, optional `references/`, optional `scripts/`, optional `assets/`).

--- a/dot_agents/skills/local/zig-development-playbook/references/official-learning-path.md
+++ b/dot_agents/skills/local/zig-development-playbook/references/official-learning-path.md
@@ -1,0 +1,51 @@
+# Zig Official Learning Path
+
+## Primary Sources
+
+1. Learn portal:
+
+- https://ziglang.org/learn/
+
+2. Getting started:
+
+- https://ziglang.org/learn/getting-started/
+
+3. Build system guide:
+
+- https://ziglang.org/learn/build-system/
+
+4. Language reference:
+
+- Stable: https://ziglang.org/documentation/0.15.2/
+- Master: https://ziglang.org/documentation/master/
+
+5. Standard library docs:
+
+- Stable: https://ziglang.org/documentation/0.15.2/std/
+- Master: https://ziglang.org/documentation/master/std/
+
+## Recommended Reading Sequence
+
+1. `getting-started`
+2. `overview`
+3. `build-system`
+4. language reference for version-accurate semantics
+5. stdlib reference for API details
+
+## Baseline Commands
+
+```bash
+zig init
+zig build run
+zig build test
+zig build --help
+zig fmt --check .
+```
+
+## Supplemental Source (Community)
+
+Use for intuition and examples, then verify with official docs:
+
+- https://www.openmymind.net/learning_zig/
+- https://www.openmymind.net/learning_zig/style_guide/
+- https://www.openmymind.net/learning_zig/heap_memory/

--- a/dot_agents/skills/local/zig-development-playbook/references/zig-c-interop-deep-template.md
+++ b/dot_agents/skills/local/zig-development-playbook/references/zig-c-interop-deep-template.md
@@ -1,0 +1,184 @@
+# Zig + C Interop Deep Template
+
+Use this file when C interop is more than a single `@cImport` and needs production structure.
+
+## 1. Suggested Repository Layout
+
+```text
+.
+├── build.zig
+├── build.zig.zon
+├── src/
+│   ├── main.zig
+│   ├── root.zig
+│   └── ffi/
+│       ├── c_api.zig
+│       └── adapter.zig
+├── vendor/
+│   └── mylib/
+│       ├── include/
+│       │   └── mylib.h
+│       └── src/
+│           └── mylib.c
+└── test/
+    └── ffi_integration_test.zig
+```
+
+## 2. `build.zig` Template (Vendored C Sources)
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const c_lib = b.addStaticLibrary(.{
+        .name = "mylib_c",
+        .target = target,
+        .optimize = optimize,
+    });
+    c_lib.linkLibC();
+    c_lib.addIncludePath(b.path("vendor/mylib/include"));
+    c_lib.addCSourceFiles(.{
+        .root = b.path("vendor/mylib/src"),
+        .files = &.{"mylib.c"},
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "app",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.linkLibrary(c_lib);
+    exe.linkLibC();
+
+    b.installArtifact(exe);
+
+    const run_exe = b.addRunArtifact(exe);
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_exe.step);
+}
+```
+
+## 3. `build.zig` Template (System C Library)
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "app",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    // Example: link system lib + headers
+    exe.linkSystemLibrary("m");
+    exe.linkLibC();
+
+    b.installArtifact(exe);
+}
+```
+
+If the project depends on `pkg-config`, document required packages and platform differences explicitly.
+
+## 4. Zig Wrapper Template (`src/ffi/c_api.zig`)
+
+```zig
+const c = @cImport({
+    @cInclude("mylib.h");
+});
+
+pub const ApiError = error{
+    InitFailed,
+    InvalidInput,
+    Unknown,
+};
+
+pub fn init() ApiError!void {
+    const rc = c.mylib_init();
+    if (rc == 0) return;
+    if (rc == -1) return ApiError.InitFailed;
+    return ApiError.Unknown;
+}
+
+pub fn process(input: []const u8, out: []u8) ApiError!usize {
+    if (input.len == 0) return ApiError.InvalidInput;
+    const n = c.mylib_process(input.ptr, input.len, out.ptr, out.len);
+    if (n < 0) return ApiError.Unknown;
+    return @intCast(n);
+}
+```
+
+## 5. Safe Adapter Template (`src/ffi/adapter.zig`)
+
+```zig
+const std = @import("std");
+const c_api = @import("c_api.zig");
+
+pub fn run(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    try c_api.init();
+
+    var buf = try allocator.alloc(u8, input.len * 2);
+    errdefer allocator.free(buf);
+
+    const n = try c_api.process(input, buf);
+    return buf[0..n];
+}
+```
+
+Rule: keep raw C pointers in one module, expose Zig-native types from adapter layer.
+
+## 6. Integration Test Template (`test/ffi_integration_test.zig`)
+
+```zig
+const std = @import("std");
+const adapter = @import("../src/ffi/adapter.zig");
+
+test "ffi adapter roundtrip" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const out = try adapter.run(allocator, "abc");
+    defer allocator.free(out);
+
+    try std.testing.expect(out.len > 0);
+}
+```
+
+## 7. ABI and Ownership Checklist
+
+1. State who owns each allocation boundary (C side vs Zig side).
+2. Convert C status codes to typed Zig errors immediately.
+3. Avoid passing temporary Zig slices to long-lived C storage.
+4. Keep one canonical place for `@cImport` declarations.
+5. Keep C compiler flags deterministic across platforms.
+
+## 8. Debugging Checklist
+
+```bash
+zig build --help
+zig build test
+zig build -Doptimize=ReleaseSafe
+zig build -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseSafe
+```
+
+If interop failures are target-specific, capture failing target triple and toolchain details in the report.
+
+## 9. Release Readiness Checklist
+
+- C headers and include paths are version-pinned.
+- C and Zig boundaries are covered by integration tests.
+- ReleaseSafe build is green on required targets.
+- Cross-target failures are explicit and reproducible.

--- a/dot_agents/skills/local/zig-development-playbook/references/zig-ecosystem-projects.md
+++ b/dot_agents/skills/local/zig-development-playbook/references/zig-ecosystem-projects.md
@@ -1,0 +1,48 @@
+# Zig Ecosystem Projects
+
+Survey date: 2026-02-19.
+
+## Representative Projects
+
+1. Ghostty
+
+- Repo: https://github.com/ghostty-org/ghostty
+- GitHub API reports primary language as Zig.
+- README states there is a large shared core written in Zig.
+
+2. Bun
+
+- Repo: https://github.com/oven-sh/bun
+- README explicitly states the Bun runtime is written in Zig.
+
+3. TigerBeetle
+
+- Repo: https://github.com/tigerbeetle/tigerbeetle
+- GitHub API reports primary language as Zig.
+
+4. river
+
+- Repo: https://github.com/riverwm/river
+- GitHub API reports primary language as Zig.
+
+5. ZLS (Zig Language Server)
+
+- Repo: https://github.com/zigtools/zls
+- GitHub API reports primary language as Zig.
+
+## Usage Guidance
+
+- Use `Ghostty` and `Bun` as high-visibility product examples.
+- Use `TigerBeetle` for database/systems performance discussions.
+- Use `river` for Linux/Wayland UI systems examples.
+- Use `zls` for tooling and editor ecosystem examples.
+
+## Refresh Command
+
+```bash
+for r in ghostty-org/ghostty oven-sh/bun tigerbeetle/tigerbeetle riverwm/river zigtools/zls; do
+  echo "== $r =="
+  curl -sSL "https://api.github.com/repos/$r" | rg '"full_name"|"description"|"language"|"html_url"'
+  echo
+done
+```

--- a/dot_agents/skills/local/zig-development-playbook/scripts/zig_quality_gate.sh
+++ b/dot_agents/skills/local/zig-development-playbook/scripts/zig_quality_gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  zig_quality_gate.sh [project_dir] [--release-mode <mode>] [--targets <csv>] [--skip-fmt]
+
+Options:
+  project_dir             Project root path. Default: current directory.
+  --release-mode <mode>   Debug | ReleaseSafe | ReleaseFast | ReleaseSmall (default: ReleaseSafe)
+  --targets <csv>         Optional cross-target list, comma separated.
+  --skip-fmt              Skip 'zig fmt --check .'.
+  -h, --help              Show this help.
+USAGE
+}
+
+project_dir="."
+release_mode="ReleaseSafe"
+targets_csv=""
+skip_fmt=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    --release-mode)
+        [[ $# -ge 2 ]] || {
+            echo "ERROR: --release-mode requires a value" >&2
+            exit 2
+        }
+        release_mode="$2"
+        shift 2
+        ;;
+    --targets)
+        [[ $# -ge 2 ]] || {
+            echo "ERROR: --targets requires a CSV value" >&2
+            exit 2
+        }
+        targets_csv="$2"
+        shift 2
+        ;;
+    --skip-fmt)
+        skip_fmt=1
+        shift
+        ;;
+    -*)
+        echo "ERROR: Unknown option: $1" >&2
+        usage
+        exit 2
+        ;;
+    *)
+        project_dir="$1"
+        shift
+        ;;
+    esac
+done
+
+case "$release_mode" in
+Debug | ReleaseSafe | ReleaseFast | ReleaseSmall) ;;
+*)
+    echo "ERROR: Invalid --release-mode '$release_mode'" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v zig >/dev/null 2>&1; then
+    echo "ERROR: 'zig' not found in PATH." >&2
+    echo "Install Zig first: https://ziglang.org/learn/getting-started/" >&2
+    exit 127
+fi
+
+[[ -d "$project_dir" ]] || {
+    echo "ERROR: project directory not found: $project_dir" >&2
+    exit 2
+}
+cd "$project_dir"
+[[ -f "build.zig" ]] || {
+    echo "ERROR: build.zig not found in: $(pwd)" >&2
+    exit 2
+}
+
+run_step() {
+    local label="$1"
+    shift
+    echo "==> $label"
+    "$@"
+}
+
+if [[ "$skip_fmt" -eq 0 ]]; then
+    run_step "Formatting check" zig fmt --check .
+fi
+
+run_step "Test suite" zig build test
+run_step "Primary build" zig build -Doptimize="$release_mode"
+
+if [[ -n "$targets_csv" ]]; then
+    IFS=',' read -r -a targets <<<"$targets_csv"
+    for raw in "${targets[@]}"; do
+        target="${raw//[[:space:]]/}"
+        [[ -n "$target" ]] || continue
+        run_step "Cross build ($target)" zig build -Dtarget="$target" -Doptimize="$release_mode"
+    done
+fi
+
+echo "==> Zig quality gate passed"


### PR DESCRIPTION
Add a local Zig skill playbook managed in dotfiles under `dot_agents/skills/local`.

This brings Zig work to the same practical standard as existing Go-oriented skills: clear triggers, reusable patterns, and strict verification gates.

The skill includes:
- end-to-end Zig workflow guidance in `SKILL.md`
- references for official docs, development standards, ecosystem examples (including Ghostty), and dotfiles integration constraints
- a reusable `zig_quality_gate.sh` script
- a deep `Zig + C interop` template reference

The placement under `local` intentionally avoids conflicts with externally managed skill namespaces that are synchronized with `exact = true`.

Validation was performed by running the skill validator and executing the quality gate on a fresh `zig init` project via `mise exec zig@0.15.2`.