### PR TITLE
chore(claude): remove superpowers and fix stale refs

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -11,8 +11,6 @@ versions:
   paperlib: 3.1.12
   claudeWshobsonAgentsRev: 03d0b4b9eb4d57bd961aa252a56025daa21543e6
   claudeWshobsonAgentsSha256: 1eedcac81f0bcbbf74600c2dd0bfafd2a1164b92d38592b2b701274c263515ac
-  claudeSuperpowersRev: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d
-  claudeSuperpowersSha256: c3afdd43c29e377632d54e617f804aa4596e157c8b82bbc4a355a8246e18164e
   claudeAnthropicsSkillsRev: ca1e7dc13c0ab5e2dfaa6de71991cd951b8f1cf2
   claudeAnthropicsSkillsSha256: 93d6fb77b8b9dc8e36df0ac65016de204f0248e5d1c4c0d5e13b3d0763c09d4a
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -56,31 +56,6 @@
 {{- end }}
 
 # ------------------------------------------------------------------------------
-# obra/superpowers (skills only)
-# - Curated skill list
-# - Hardcoded skill list
-# ------------------------------------------------------------------------------
-[".agents/skills/superpowers"]
-    type = "archive"
-    url = "https://github.com/obra/superpowers/archive/{{ $.versions.claudeSuperpowersRev }}.tar.gz"
-    checksum.sha256 = "{{ $.versions.claudeSuperpowersSha256 }}"
-    exact = true
-    stripComponents = 2
-    include = [
-      "superpowers-*/skills/brainstorming/**",
-      "superpowers-*/skills/writing-plans/**",
-      "superpowers-*/skills/executing-plans/**",
-      "superpowers-*/skills/test-driven-development/**",
-      "superpowers-*/skills/using-git-worktrees/**",
-      "superpowers-*/skills/finishing-a-development-branch/**",
-      "superpowers-*/skills/systematic-debugging/**",
-      "superpowers-*/skills/verification-before-completion/**",
-      "superpowers-*/skills/requesting-code-review/**",
-      "superpowers-*/skills/receiving-code-review/**"
-    ]
-    refreshPeriod = "168h"
-
-# ------------------------------------------------------------------------------
 # anthropics/skills (source-available, NOT open source)
 # License: https://github.com/anthropics/skills - see LICENSE.txt in each skill
 # Skills go to .agents/skills/anthropics/{skill}/ (Shared)

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -36,8 +36,6 @@ jobs:
 
           claude_wshobson_agents_rev=$(gh api repos/wshobson/agents/commits/main -q '.sha')
           claude_wshobson_agents_sha256=$(curl_sha256 "https://github.com/wshobson/agents/archive/${claude_wshobson_agents_rev}.tar.gz")
-          claude_superpowers_rev=$(gh api repos/obra/superpowers/commits/main -q '.sha')
-          claude_superpowers_sha256=$(curl_sha256 "https://github.com/obra/superpowers/archive/${claude_superpowers_rev}.tar.gz")
           claude_anthropics_skills_rev=$(gh api repos/anthropics/skills/commits/main -q '.sha')
           claude_anthropics_skills_sha256=$(curl_sha256 "https://github.com/anthropics/skills/archive/${claude_anthropics_skills_rev}.tar.gz")
           ui_ux_pro_max_skill_rev=$(gh api repos/nextlevelbuilder/ui-ux-pro-max-skill/commits/main -q '.sha')
@@ -70,8 +68,6 @@ jobs:
             echo "paperlib=$paperlib"
             echo "claude_wshobson_agents_rev=$claude_wshobson_agents_rev"
             echo "claude_wshobson_agents_sha256=$claude_wshobson_agents_sha256"
-            echo "claude_superpowers_rev=$claude_superpowers_rev"
-            echo "claude_superpowers_sha256=$claude_superpowers_sha256"
             echo "claude_anthropics_skills_rev=$claude_anthropics_skills_rev"
             echo "claude_anthropics_skills_sha256=$claude_anthropics_skills_sha256"
             echo "ui_ux_pro_max_skill_rev=$ui_ux_pro_max_skill_rev"
@@ -105,8 +101,6 @@ jobs:
           sed -i 's/paperlib: .*/paperlib: ${{ steps.versions.outputs.paperlib }}/' .chezmoidata/versions.yaml
           sed -i 's/claudeWshobsonAgentsRev: .*/claudeWshobsonAgentsRev: ${{ steps.versions.outputs.claude_wshobson_agents_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/claudeWshobsonAgentsSha256: .*/claudeWshobsonAgentsSha256: ${{ steps.versions.outputs.claude_wshobson_agents_sha256 }}/' .chezmoidata/versions.yaml
-          sed -i 's/claudeSuperpowersRev: .*/claudeSuperpowersRev: ${{ steps.versions.outputs.claude_superpowers_rev }}/' .chezmoidata/versions.yaml
-          sed -i 's/claudeSuperpowersSha256: .*/claudeSuperpowersSha256: ${{ steps.versions.outputs.claude_superpowers_sha256 }}/' .chezmoidata/versions.yaml
           sed -i 's/claudeAnthropicsSkillsRev: .*/claudeAnthropicsSkillsRev: ${{ steps.versions.outputs.claude_anthropics_skills_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/claudeAnthropicsSkillsSha256: .*/claudeAnthropicsSkillsSha256: ${{ steps.versions.outputs.claude_anthropics_skills_sha256 }}/' .chezmoidata/versions.yaml
           sed -i 's/uiUxProMaxSkillRev: .*/uiUxProMaxSkillRev: ${{ steps.versions.outputs.ui_ux_pro_max_skill_rev }}/' .chezmoidata/versions.yaml

--- a/README.ja.md
+++ b/README.ja.md
@@ -278,7 +278,6 @@ Skills は `.chezmoiexternal.toml.tmpl` 経由で次のソースから同期さ�
 
 - [wshobson/agents](https://github.com/wshobson/agents)
 - [anthropics/skills](https://github.com/anthropics/skills)
-- [obra/superpowers](https://github.com/obra/superpowers)
 - 多言語 Humanizer コミュニティパック（`humanizer-en`、`stop-slop-en`、`humanizer-zh`、`humanizer-ja`）
 
 同期先は `~/.agents/skills` で、Claude/Codex/OpenCode のすべてで利用します。
@@ -371,7 +370,6 @@ OpenCode の key レンダリングは `provider@private` 命名（例: `harui@p
 
 - `wshobson/agents`
 - `anthropics/skills`
-- `obra/superpowers`
 - 多言語 Humanizer コミュニティソース（`humanizer-en`、`stop-slop-en`、`humanizer-zh`、`humanizer-ja`）
 
 同期先は `~/.agents/skills` で、Claude/Codex/OpenCode のすべてで利用します。
@@ -569,7 +567,6 @@ chezmoi init --apply --promptBool headless=true signalridge
 - [flakey-profile](https://github.com/lf-/flakey-profile) - クロスプラットフォーム Nix プロファイル管理
 - [wshobson/agents](https://github.com/wshobson/agents) - Claude Code 向けプラグイン集
 - [anthropics/skills](https://github.com/anthropics/skills) - 公式 Claude Code スキル集
-- [obra/superpowers](https://github.com/obra/superpowers) - 高度なワークフローパターン
 - [Dracula Theme](https://draculatheme.com/) - ターミナル / fzf テーマのベース
 
 ---

--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ Skills are synced via `.chezmoiexternal.toml.tmpl` from:
 
 - [wshobson/agents](https://github.com/wshobson/agents)
 - [anthropics/skills](https://github.com/anthropics/skills)
-- [obra/superpowers](https://github.com/obra/superpowers)
 - community multilingual Humanizer pack (`humanizer-en`, `stop-slop-en`, `humanizer-zh`, `humanizer-ja`)
 
 They are normalized into `~/.agents/skills` and shared by Claude/Codex/OpenCode.
@@ -371,7 +370,6 @@ See: `docs/opencode-provider.md`.
 
 - `wshobson/agents`
 - `anthropics/skills`
-- `obra/superpowers`
 - multilingual Humanizer community sources (`humanizer-en`, `stop-slop-en`, `humanizer-zh`, `humanizer-ja`)
 
 They are normalized into `~/.agents/skills` and shared by Claude/Codex/OpenCode.
@@ -569,7 +567,6 @@ See:
 - [flakey-profile](https://github.com/lf-/flakey-profile) - Cross-platform Nix profile management
 - [wshobson/agents](https://github.com/wshobson/agents) - Claude Code plugins marketplace
 - [anthropics/skills](https://github.com/anthropics/skills) - Official Claude Code skills
-- [obra/superpowers](https://github.com/obra/superpowers) - Advanced workflow patterns
 - [Dracula Theme](https://draculatheme.com/) - Theme palette for terminal and fzf styling
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -276,7 +276,6 @@ skills 由 `.chezmoiexternal.toml.tmpl` 从以下来源同步：
 
 - [wshobson/agents](https://github.com/wshobson/agents)
 - [anthropics/skills](https://github.com/anthropics/skills)
-- [obra/superpowers](https://github.com/obra/superpowers)
 - 社区多语言 Humanizer 套件（`humanizer-en`、`stop-slop-en`、`humanizer-zh`、`humanizer-ja`）
 
 同步后统一落到 `~/.agents/skills`，可被 Claude/Codex/OpenCode 共用。
@@ -369,7 +368,6 @@ OpenCode 的 key 渲染使用 `provider@private` 命名（如 `harui@private`）
 
 - `wshobson/agents`
 - `anthropics/skills`
-- `obra/superpowers`
 - 多语言 Humanizer 社区来源（`humanizer-en`、`stop-slop-en`、`humanizer-zh`、`humanizer-ja`）
 
 最终统一到 `~/.agents/skills`，由 Claude、Codex、OpenCode 共同使用。
@@ -567,7 +565,6 @@ chezmoi init --apply --promptBool headless=true signalridge
 - [flakey-profile](https://github.com/lf-/flakey-profile) - 跨平台 Nix profile 管理
 - [wshobson/agents](https://github.com/wshobson/agents) - Claude Code 插件 marketplace
 - [anthropics/skills](https://github.com/anthropics/skills) - 官方 Claude Code skills
-- [obra/superpowers](https://github.com/obra/superpowers) - 高级工作流模式
 - [Dracula Theme](https://draculatheme.com/) - 终端与 fzf 主题灵感来源
 
 ---

--- a/dot_agents/commands/core/plan.md
+++ b/dot_agents/commands/core/plan.md
@@ -5,7 +5,6 @@ Plan a feature or task with clear structure before coding.
 ## When to Use
 
 - Direct changes where you want a lightweight implementation plan.
-- Direct changes where you want a more structured planning workflow via Superpowers `writing-plans`.
 - Any time the scope is still fuzzy and you want to clarify goal/DoD.
 
 ## Framework: Goal → Constraints → Definition of Done
@@ -64,14 +63,6 @@ Pick the next command to run:
 - `/context` when you need entrypoints, dependencies, or conventions
 - `/review` when the change touches auth/permissions/tokens/secrets
 - `/test` when doing TDD or validating an assumption
-- `superpowers:writing-plans` when you need a structured, detailed execution plan
-- `superpowers:brainstorming` when you need option exploration before committing to one plan
-
-## Related Skills
-
-- `superpowers:brainstorming`
-- `superpowers:writing-plans`
-- `superpowers:executing-plans`
 
 ## Output Format
 

--- a/dot_claude/context/guardrails.md
+++ b/dot_claude/context/guardrails.md
@@ -79,7 +79,5 @@ delete, drop, truncate, migrate
 
 This document is the Single Source of Truth (SSOT) for guardrails. Referenced by:
 
-- `CLAUDE.md` - Collaboration Model section
-- `coding-philosophy.md` - ALWAYS rules
-- `security-scanning` plugin - security review skills
+- `CLAUDE.md` - Guardrails & Boundaries section
 - `settings.json` - deny permissions

--- a/dot_claude/templates/github-action-code-review.yml
+++ b/dot_claude/templates/github-action-code-review.yml
@@ -86,4 +86,4 @@ jobs:
 
             Reference the repository's CLAUDE.md for style and conventions.
             Use `gh pr comment` to leave your review on the PR.
-          claude_args: '--model claude-opus-4-1-20250805 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-6 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/dot_claude/templates/github-action-security-review.yml
+++ b/dot_claude/templates/github-action-security-review.yml
@@ -30,7 +30,7 @@ jobs:
           # Authentication
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Model selection
-          claude-model: claude-opus-4-1-20250805
+          claude-model: claude-opus-4-6
           # Custom instructions specific to your codebase
           # Examples:
           # - "Our API uses JWT tokens stored in httpOnly cookies"


### PR DESCRIPTION
## Summary

- Remove all `obra/superpowers` configuration (external archive, version pins, CI workflow, skill references in plan.md, README mentions across 3 languages)
- Fix stale cross-references in `guardrails.md` (removed non-existent "Collaboration Model", "ALWAYS rules", and "security-scanning plugin" refs)
- Update GitHub Action templates model ID from `claude-opus-4-1-20250805` to `claude-opus-4-6`

## Motivation

Replacing superpowers with a custom framework. Stale refs discovered during cleanup audit.

## Test plan

- [x] Pre-commit hooks all pass (treefmt, shellcheck, template validation)
- [ ] `chezmoi apply --dry-run` on target machine
- [ ] Verify no remaining `superpowers` references: `grep -ri superpowers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)