### PR TITLE
chore(aqua): update pinned packages (2026-04-10)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -13,11 +13,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.97
+  - name: anthropics/claude-code@v2.1.98
   - name: openai/codex@rust-v0.118.0
-  - name: anomalyco/opencode@v1.4.0
+  - name: anomalyco/opencode@v1.4.2
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.6
+  - name: jdx/mise@v2026.4.7
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.68.0
@@ -28,9 +28,9 @@ packages:
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.89.0
   - name: dlvhdr/gh-dash@v4.23.2
-  - name: x-motemen/ghq@v1.9.4
+  - name: x-motemen/ghq@v1.10.0
   - name: git-lfs/git-lfs@v3.7.1
-  - name: charmbracelet/glow@v2.1.1
+  - name: charmbracelet/glow@v2.1.2
   - name: jqlang/jq@jq-1.8.1
   - name: casey/just@1.49.0
   - name: jesseduffield/lazygit@v0.61.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.