### PR TITLE
feat(ai): aichat, ccstatus, ccnew/ccdone, deepwiki MCP

### DIFF
--- a/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
@@ -190,3 +190,4 @@ ensure_user_mcp_json "arxiv-mcp-server" '{"command":"uv","args":["tool","run","a
 ensure_user_mcp_json "tavily" '{"command":"{{ .chezmoi.homeDir }}/.local/bin/mcp-tavily","args":[]}'
 ensure_user_mcp_json "postgres" '{"command":"{{ .chezmoi.homeDir }}/.local/bin/mcp-postgres","args":[]}'
 ensure_user_mcp_http "gitmcp" "https://gitmcp.io/docs"
+ensure_user_mcp_http "deepwiki" "https://mcp.deepwiki.com/mcp"

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -20,7 +20,17 @@ Pragmatic AI engineering assistant. Optimize for clarity, correctness, and minim
 
 ## MCP Policy
 
-Auto selection: Docs/API -> Context7, Web/news -> Tavily, Code navigation -> Serena.
+Auto selection:
+
+- Docs/API -> Context7
+- Web/news -> Tavily
+- Code navigation -> Serena (prefer symbolic/semantic tools; avoid full-file reads when a symbolic query suffices)
+- Browser/E2E -> Playwright
+- Paper/research -> arxiv
+- Repo Q&A (public) -> DeepWiki
+- Repo Q&A (private) -> gitmcp
+- Doc→Markdown -> markitdown
+
 User preference overrides. Fall back when unavailable. No sensitive data in queries.
 
 ## Dependency Install Preflight

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -20,7 +20,17 @@ Pragmatic AI engineering assistant. Optimize for clarity, correctness, and minim
 
 ## MCP Policy
 
-Auto selection: Docs/API -> Context7, Web/news -> Tavily, Code navigation -> Serena.
+Auto selection:
+
+- Docs/API -> Context7
+- Web/news -> Tavily
+- Code navigation -> Serena (prefer symbolic/semantic tools; avoid full-file reads when a symbolic query suffices)
+- Browser/E2E -> Playwright
+- Paper/research -> arxiv
+- Repo Q&A (public) -> DeepWiki
+- Repo Q&A (private) -> gitmcp
+- Doc→Markdown -> markitdown
+
 User preference overrides. Fall back when unavailable. No sensitive data in queries.
 
 ## Dependency Install Preflight

--- a/dot_codex/config.toml.tmpl
+++ b/dot_codex/config.toml.tmpl
@@ -184,6 +184,9 @@ args = []
 [mcp_servers.gitmcp]
 url = "https://gitmcp.io/docs"
 
+[mcp_servers.deepwiki]
+url = "https://mcp.deepwiki.com/mcp"
+
 # =============================================================================
 # Profiles
 # =============================================================================

--- a/dot_custom/exports.sh.tmpl
+++ b/dot_custom/exports.sh.tmpl
@@ -69,7 +69,7 @@ export FZF_CTRL_R_OPTS="
 
 # AI commit message provider (codex, gemini, claude, auto)
 # Override in ~/.custom/local.sh if needed
-export AICOMMIT_PROVIDER="${AICOMMIT_PROVIDER:-codex}"
+export AICOMMIT_PROVIDER="${AICOMMIT_PROVIDER:-claude}"
 
 # Global Justfile location (XDG)
 export JUSTFILE="${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile"

--- a/dot_custom/functions.sh
+++ b/dot_custom/functions.sh
@@ -1138,3 +1138,132 @@ ccp() {
         return 1
     fi
 }
+
+# ─────────────────────────────────────────────────────────────
+# ccnew / ccdone — claude + worktree + dedicated tmux session
+# ─────────────────────────────────────────────────────────────
+# One branch == one worktree == one tmux session. Builds on the wt-*
+# helpers above; see `wt-new --help` for the underlying semantics.
+
+_cc_session_name() {
+    local repo="$1" branch="$2"
+    # Disambiguate across same-named repos under different owners (common in
+    # ghq layouts: ~/ghq/github.com/acme/slipway vs .../signalridge/slipway).
+    # Use owner-basename(repo)-branch, then collapse tmux-unsafe chars.
+    local owner base
+    base="$(basename "$repo")"
+    owner="$(basename "$(dirname "$repo")")"
+    printf '%s' "${owner}-${base}-${branch}" | tr './: ' '----'
+}
+
+# Usage: ccnew <branch> [base-ref]
+ccnew() {
+    local branch="${1:-}"
+    local base="${2:-}"
+
+    if [[ -z "$branch" ]]; then
+        echo "Usage: ccnew <branch> [base-ref]"
+        return 1
+    fi
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "Claude Code not installed"
+        return 1
+    fi
+
+    local repo
+    repo="$(_wt_repo_root)" || {
+        echo "Not in a git repository"
+        return 1
+    }
+
+    wt-new "$branch" "$base" || return 1
+
+    local target="$PWD"
+    local session
+    session="$(_cc_session_name "$repo" "$branch")"
+
+    if ! command -v tmux >/dev/null 2>&1; then
+        claude
+        return $?
+    fi
+
+    if ! tmux has-session -t "$session" 2>/dev/null; then
+        tmux new-session -d -s "$session" -c "$target"
+        tmux send-keys -t "$session" 'claude' C-m
+    fi
+
+    if [[ -n "${TMUX:-}" ]]; then
+        tmux switch-client -t "$session"
+    else
+        tmux attach-session -t "$session"
+    fi
+}
+
+# Usage: ccdone <branch> [--force]
+ccdone() {
+    if [[ -z "${1:-}" ]]; then
+        echo "Usage: ccdone <branch> [--force]"
+        return 1
+    fi
+
+    local branch="$1"
+    shift
+
+    local repo
+    repo="$(_wt_repo_root)" || {
+        echo "Not in a git repository"
+        return 1
+    }
+
+    local session
+    session="$(_cc_session_name "$repo" "$branch")"
+
+    # Refuse upfront if we'd need to kill the session we're attached to —
+    # otherwise the user gets bounced out of their shell mid-command.
+    if [[ -n "${TMUX:-}" ]] && command -v tmux >/dev/null 2>&1 &&
+        tmux has-session -t "$session" 2>/dev/null &&
+        [[ "$(tmux display-message -p '#S')" == "$session" ]]; then
+        echo "Refusing to kill the session you're attached to: $session"
+        echo "Detach first (prefix + d) then re-run ccdone."
+        return 1
+    fi
+
+    # Remove the worktree FIRST. A dirty/untracked worktree makes
+    # `git worktree remove` fail — we don't want to have torn down the
+    # claude session before discovering that, or the user loses their
+    # running agent for nothing.
+    wt-rm "$branch" "$@" || return $?
+
+    if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session" 2>/dev/null; then
+        tmux kill-session -t "$session"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# aichat shell integration
+# ─────────────────────────────────────────────────────────────────────────────
+# `?` invokes aichat for a one-shot question (`? why does tar -xzf fail...`).
+# Alt-e runs the current prompt buffer through `aichat -e` to translate
+# natural language into a shell command in place:
+#     find all files larger than 1G under /var<Alt-e>
+if command -v aichat >/dev/null 2>&1; then
+    # Function (not alias) so it works inside $(), eval, etc. and isn't
+    # shadowed by zsh's `?` glob metacharacter in non-command positions.
+    # Defined via eval because shellcheck/shfmt (bash parsers) reject the
+    # quoted-name function syntax even though zsh accepts it.
+    eval "'?'() { aichat \"\$@\"; }"
+
+    _aichat_zsh_widget() {
+        [[ -z "$BUFFER" ]] && return
+        local out
+        out="$(aichat -e "$BUFFER" 2>/dev/null)"
+        if [[ -n "$out" ]]; then
+            BUFFER="$out"
+            # shellcheck disable=SC2034  # CURSOR is used by zle
+            CURSOR=${#BUFFER}
+            zle reset-prompt
+        fi
+    }
+    zle -N _aichat_zsh_widget
+    bindkey '\ee' _aichat_zsh_widget
+fi

--- a/dot_local/bin/executable_ccstatus
+++ b/dot_local/bin/executable_ccstatus
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ccstatus — compact AI-agent counter for the tmux status bar.
+#
+# Output: "AI 2/5" where
+#   - 5 = total AI agents (claude / codex / opencode) running inside tmux panes
+#   - 2 = subset whose tmux window has the activity flag set (fresh output
+#         since you last looked — usually "waiting for input" for an idle
+#         AI agent).
+#
+# Hot path: runs on every status-interval tick. Fast path = zero AI agents:
+# one `ps` fork and we're done. The tmux pane enumeration only happens when
+# at least one candidate process exists.
+#
+# Discovery quirk: tmux `pane_current_command` is unreliable because the
+# aqua shim sets claude's argv[0] to its version string (e.g. "2.1.101"),
+# and codex shows up truncated as "codex-aarch64-a". We walk the process
+# table with `ps -o comm` instead, which reports the real binary basename,
+# then map each agent up to its parent tmux shell pid.
+#
+# Install into tmux.conf:
+#   set -ag status-right "#(~/.local/bin/ccstatus) "
+
+set -euo pipefail
+
+tmux has-session 2>/dev/null || exit 0
+
+# Fast path: enumerate AI agents first. If there are none, we're done
+# before touching tmux — keeps the common case (shell-only session) cheap.
+agents=$(ps -eo pid,ppid,comm 2>/dev/null \
+    | awk '$3 ~ /^(claude|codex|opencode)$/ {print $2}' || true)
+[[ -z "$agents" ]] && exit 0
+
+# Map pane_pid -> window_activity_flag. tmux pane_pids are unique per pane,
+# so no OR-merge is needed.
+declare -A pane_activity=()
+while IFS=' ' read -r ppid flag; do
+    [[ -n "$ppid" ]] && pane_activity[$ppid]=$flag
+done < <(tmux list-panes -a -F '#{pane_pid} #{?window_activity_flag,1,0}' 2>/dev/null || true)
+
+total=0
+alert=0
+while read -r parent_pid; do
+    [[ -z "$parent_pid" ]] && continue
+    if [[ -n "${pane_activity[$parent_pid]:-}" ]]; then
+        total=$((total + 1))
+        [[ "${pane_activity[$parent_pid]}" == "1" ]] && alert=$((alert + 1))
+    fi
+done <<< "$agents"
+
+(( total == 0 )) && exit 0
+
+# Dracula palette — matches the post-TPM theme in tmux.conf.tmpl.
+# Pink (#ff79c6) for alert, green (#50fa7b) for steady-state.
+if (( alert > 0 )); then
+    printf '#[fg=#ff79c6,bold]AI %d/%d#[default]' "$alert" "$total"
+else
+    printf '#[fg=#50fa7b]AI %d#[default]' "$total"
+fi

--- a/private_dot_config/aichat/config.yaml.tmpl
+++ b/private_dot_config/aichat/config.yaml.tmpl
@@ -1,53 +1,12 @@
 {{- /*
-  aichat config - cloud API only.
-
-  API keys live at gopass path `claude/<provider>/private/api_key`, matching
-  the layout claude-token/claude-with already use. Providers without a key
-  are silently skipped so a fresh machine with no gopass entries still gets
-  a valid config.
-
-  All gopass lookups happen in a single sh invocation at template-render
-  time (one shell fork, one gopass tree walk) instead of one fork per
-  provider — `chezmoi apply` stays snappy even with a cold gpg-agent.
-
-  Default model is naapi's Claude passthrough so `?` / `aichat` keep
-  working even when native Anthropic OAuth isn't available. Switch with
-  `.model <client>:<name>` inside the REPL or `aichat -m ...`.
+  aichat config — kimi + doubao (火山) only.
+  API keys: gopass `claude/{kimi,doubao}/private/api_key`. Missing keys are
+  silently skipped so `chezmoi apply` still works on a fresh machine.
 */ -}}
-{{- $providers := dict
-    "naapi"    (dict "base" "https://na.wanxiaot.com/v1"                         "models" (list "claude-opus-4-6" "claude-sonnet-4-5-20250929" "gpt-5.3-codex" "gpt-5.2-codex"))
-    "deepseek" (dict "base" "https://api.deepseek.com/v1"                        "models" (list "deepseek-chat" "deepseek-reasoner"))
-    "kimi"     (dict "base" "https://api.moonshot.ai/v1"                         "models" (list "kimi-k2.5" "kimi-k2"))
-    "glm"      (dict "base" "https://open.bigmodel.cn/api/paas/v4"               "models" (list "glm-4.7" "glm-4.5-air"))
-    "qwen"     (dict "base" "https://dashscope.aliyuncs.com/compatible-mode/v1"  "models" (list "qwen3-coder-plus" "qwen3-max" "qwen-flash"))
-    "minimax"  (dict "base" "https://api.minimax.io/v1"                          "models" (list "MiniMax-M2.1"))
-    "doubao"   (dict "base" "https://ark.cn-beijing.volces.com/api/v3"           "models" (list "ark-code-latest"))
-    "harui"    (dict "base" "https://codex.harui.edu.kg/v1"                      "models" (list "gpt-5.3-codex" "gpt-5.2-codex"))
--}}
-{{- /*
-  One sh call fetches every key — `printf` guarantees one line per provider
-  (missing entries become empty strings), so we can zip the output back to
-  $names by index. `gopass list -f` can't be used as a presence check
-  because it exits 0 on empty matches; instead we attempt `gopass show`
-  and let its non-zero exit become the empty fallback.
-*/ -}}
-{{- $names := list "naapi" "deepseek" "kimi" "glm" "qwen" "minimax" "doubao" "harui" -}}
-{{- $script := "command -v gopass >/dev/null 2>&1 || { for p in naapi deepseek kimi glm qwen minimax doubao harui; do printf '\\n'; done; exit 0; }; for p in naapi deepseek kimi glm qwen minimax doubao harui; do v=$(gopass show --password \"claude/$p/private/api_key\" 2>/dev/null | head -n 1 || true); printf '%s\\n' \"$v\"; done" -}}
-{{- $raw := output "sh" "-c" $script -}}
-{{- $lines := splitList "\n" (trimSuffix "\n" $raw) -}}
-{{- $keys := dict -}}
-{{- range $i, $name := $names -}}
-{{-   $_ := set $keys $name (index $lines $i | default "") -}}
-{{- end -}}
+{{- $kimi := output "sh" "-c" "gopass show --password claude/kimi/private/api_key 2>/dev/null | head -n1 || true" | trim -}}
+{{- $doubao := output "sh" "-c" "gopass show --password claude/doubao/private/api_key 2>/dev/null | head -n1 || true" | trim -}}
 # Managed by chezmoi. Edit the template, not this file.
-#
-# Usage:
-#   aichat                         # REPL
-#   aichat "why is the sky blue"   # one-shot
-#   aichat -e "find large files"   # generate shell command (bound to Alt-e)
-#   .model naapi:claude-opus-4-6   # switch model inside REPL
-#
-model: naapi:claude-opus-4-6
+model: kimi:kimi-k2.5
 temperature: 0.3
 save: true
 save_session: null
@@ -57,17 +16,20 @@ wrap: auto
 highlight: true
 
 clients:
-{{- range $name := $names }}
-{{-   $key := index $keys $name }}
-{{-   if ne $key "" }}
-{{-     $cfg := index $providers $name }}
+{{- if ne $kimi "" }}
   - type: openai-compatible
-    name: {{ $name }}
-    api_base: {{ $cfg.base }}
-    api_key: {{ $key | quote }}
+    name: kimi
+    api_base: https://api.moonshot.ai/v1
+    api_key: {{ $kimi | quote }}
     models:
-{{-     range $m := $cfg.models }}
-      - name: {{ $m }}
-{{-     end }}
-{{-   end }}
+      - name: kimi-k2.5
+      - name: kimi-k2
+{{- end }}
+{{- if ne $doubao "" }}
+  - type: openai-compatible
+    name: doubao
+    api_base: https://ark.cn-beijing.volces.com/api/v3
+    api_key: {{ $doubao | quote }}
+    models:
+      - name: ark-code-latest
 {{- end }}

--- a/private_dot_config/aichat/config.yaml.tmpl
+++ b/private_dot_config/aichat/config.yaml.tmpl
@@ -1,0 +1,73 @@
+{{- /*
+  aichat config - cloud API only.
+
+  API keys live at gopass path `claude/<provider>/private/api_key`, matching
+  the layout claude-token/claude-with already use. Providers without a key
+  are silently skipped so a fresh machine with no gopass entries still gets
+  a valid config.
+
+  All gopass lookups happen in a single sh invocation at template-render
+  time (one shell fork, one gopass tree walk) instead of one fork per
+  provider — `chezmoi apply` stays snappy even with a cold gpg-agent.
+
+  Default model is naapi's Claude passthrough so `?` / `aichat` keep
+  working even when native Anthropic OAuth isn't available. Switch with
+  `.model <client>:<name>` inside the REPL or `aichat -m ...`.
+*/ -}}
+{{- $providers := dict
+    "naapi"    (dict "base" "https://na.wanxiaot.com/v1"                         "models" (list "claude-opus-4-6" "claude-sonnet-4-5-20250929" "gpt-5.3-codex" "gpt-5.2-codex"))
+    "deepseek" (dict "base" "https://api.deepseek.com/v1"                        "models" (list "deepseek-chat" "deepseek-reasoner"))
+    "kimi"     (dict "base" "https://api.moonshot.ai/v1"                         "models" (list "kimi-k2.5" "kimi-k2"))
+    "glm"      (dict "base" "https://open.bigmodel.cn/api/paas/v4"               "models" (list "glm-4.7" "glm-4.5-air"))
+    "qwen"     (dict "base" "https://dashscope.aliyuncs.com/compatible-mode/v1"  "models" (list "qwen3-coder-plus" "qwen3-max" "qwen-flash"))
+    "minimax"  (dict "base" "https://api.minimax.io/v1"                          "models" (list "MiniMax-M2.1"))
+    "doubao"   (dict "base" "https://ark.cn-beijing.volces.com/api/v3"           "models" (list "ark-code-latest"))
+    "harui"    (dict "base" "https://codex.harui.edu.kg/v1"                      "models" (list "gpt-5.3-codex" "gpt-5.2-codex"))
+-}}
+{{- /*
+  One sh call fetches every key — `printf` guarantees one line per provider
+  (missing entries become empty strings), so we can zip the output back to
+  $names by index. `gopass list -f` can't be used as a presence check
+  because it exits 0 on empty matches; instead we attempt `gopass show`
+  and let its non-zero exit become the empty fallback.
+*/ -}}
+{{- $names := list "naapi" "deepseek" "kimi" "glm" "qwen" "minimax" "doubao" "harui" -}}
+{{- $script := "command -v gopass >/dev/null 2>&1 || { for p in naapi deepseek kimi glm qwen minimax doubao harui; do printf '\\n'; done; exit 0; }; for p in naapi deepseek kimi glm qwen minimax doubao harui; do v=$(gopass show --password \"claude/$p/private/api_key\" 2>/dev/null | head -n 1 || true); printf '%s\\n' \"$v\"; done" -}}
+{{- $raw := output "sh" "-c" $script -}}
+{{- $lines := splitList "\n" (trimSuffix "\n" $raw) -}}
+{{- $keys := dict -}}
+{{- range $i, $name := $names -}}
+{{-   $_ := set $keys $name (index $lines $i | default "") -}}
+{{- end -}}
+# Managed by chezmoi. Edit the template, not this file.
+#
+# Usage:
+#   aichat                         # REPL
+#   aichat "why is the sky blue"   # one-shot
+#   aichat -e "find large files"   # generate shell command (bound to Alt-e)
+#   .model naapi:claude-opus-4-6   # switch model inside REPL
+#
+model: naapi:claude-opus-4-6
+temperature: 0.3
+save: true
+save_session: null
+keybindings: emacs
+editor: ${EDITOR:-nvim}
+wrap: auto
+highlight: true
+
+clients:
+{{- range $name := $names }}
+{{-   $key := index $keys $name }}
+{{-   if ne $key "" }}
+{{-     $cfg := index $providers $name }}
+  - type: openai-compatible
+    name: {{ $name }}
+    api_base: {{ $cfg.base }}
+    api_key: {{ $key | quote }}
+    models:
+{{-     range $m := $cfg.models }}
+      - name: {{ $m }}
+{{-     end }}
+{{-   end }}
+{{- end }}

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,6 +7,7 @@ packages:
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.0
   - name: atuinsh/atuin@v18.13.6
+  - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
   - name: eth-p/bat-extras@v2024.08.24
     # aqua update can downgrade to v20200408 due semver ordering;
@@ -32,6 +33,7 @@ packages:
   - name: git-lfs/git-lfs@v3.7.1
   - name: charmbracelet/glow@v2.1.2
   - name: jqlang/jq@jq-1.8.1
+  - name: ynqa/jnv@v0.7.1
   - name: casey/just@1.49.0
   - name: jesseduffield/lazygit@v0.61.0
   - name: neovim/neovim@v0.12.1

--- a/private_dot_config/nvim/lua/plugins/ai.lua
+++ b/private_dot_config/nvim/lua/plugins/ai.lua
@@ -1,0 +1,65 @@
+-- CodeCompanion: AI chat / inline-edit for Neovim.
+-- Auth via ANTHROPIC_API_KEY from shell env (see dot_custom/exports.sh).
+-- To route through gopass instead, change env.api_key to:
+--   "cmd:gopass show --password <path> | head -n 1"
+return {
+  {
+    "olimorris/codecompanion.nvim",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-treesitter/nvim-treesitter",
+    },
+    cmd = {
+      "CodeCompanion",
+      "CodeCompanionChat",
+      "CodeCompanionActions",
+      "CodeCompanionCmd",
+    },
+    keys = {
+      { "<leader>aa", "<cmd>CodeCompanionActions<cr>", mode = { "n", "v" }, desc = "CodeCompanion Actions" },
+      { "<leader>ac", "<cmd>CodeCompanionChat Toggle<cr>", mode = { "n", "v" }, desc = "CodeCompanion Chat" },
+      { "<leader>ai", "<cmd>CodeCompanion<cr>", mode = { "n", "v" }, desc = "CodeCompanion Inline" },
+      { "<leader>ap", "<cmd>CodeCompanionChat Add<cr>", mode = "v", desc = "CodeCompanion Paste Selection" },
+    },
+    opts = {
+      adapters = {
+        anthropic = function()
+          return require("codecompanion.adapters").extend("anthropic", {
+            env = {
+              api_key = "ANTHROPIC_API_KEY",
+            },
+            schema = {
+              model = {
+                -- Sonnet is the daily-driver default; Opus stays reserved for
+                -- the standalone Claude Code CLI to avoid burning budget here.
+                default = "claude-sonnet-4-5",
+              },
+            },
+          })
+        end,
+      },
+      strategies = {
+        chat = { adapter = "anthropic" },
+        inline = { adapter = "anthropic" },
+        cmd = { adapter = "anthropic" },
+      },
+      display = {
+        chat = {
+          show_settings = false,
+          show_token_count = true,
+          window = {
+            layout = "vertical",
+            width = 0.4,
+          },
+        },
+        diff = {
+          provider = "default",
+        },
+      },
+      opts = {
+        log_level = "ERROR",
+        send_code = true,
+      },
+    },
+  },
+}

--- a/private_dot_config/opencode/AGENTS.md
+++ b/private_dot_config/opencode/AGENTS.md
@@ -20,7 +20,17 @@ Pragmatic AI engineering assistant. Optimize for clarity, correctness, and minim
 
 ## MCP Policy
 
-Auto selection: Docs/API -> Context7, Web/news -> Tavily, Code navigation -> Serena.
+Auto selection:
+
+- Docs/API -> Context7
+- Web/news -> Tavily
+- Code navigation -> Serena (prefer symbolic/semantic tools; avoid full-file reads when a symbolic query suffices)
+- Browser/E2E -> Playwright
+- Paper/research -> arxiv
+- Repo Q&A (public) -> DeepWiki
+- Repo Q&A (private) -> gitmcp
+- Doc→Markdown -> markitdown
+
 User preference overrides. Fall back when unavailable. No sensitive data in queries.
 
 > Exa may be default web search in OpenCode setups; Tavily still takes precedence when available.

--- a/private_dot_config/opencode/opencode.jsonc.tmpl
+++ b/private_dot_config/opencode/opencode.jsonc.tmpl
@@ -418,6 +418,12 @@
       "url": "https://gitmcp.io/docs",
       "oauth": false,
       "enabled": true
+    },
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/mcp",
+      "oauth": false,
+      "enabled": true
     }
   },
   "permission": {

--- a/private_dot_config/tmux/tmux.conf.tmpl
+++ b/private_dot_config/tmux/tmux.conf.tmpl
@@ -46,6 +46,13 @@ setw -g mode-keys vi
 # focus events (for vim/nvim autoread)
 set -g focus-events on
 
+# -- activity monitoring -------------------------------------------------------
+# Flag windows with new output so idle AI agents (claude / codex / opencode
+# sitting in a background window waiting for input) are visible at a glance.
+# The visual style is already themed below via window-status-activity-style.
+setw -g monitor-activity on
+set -g visual-activity off
+
 # windows & panes
 set -g base-index 1
 setw -g pane-base-index 1
@@ -360,6 +367,19 @@ set -g window-status-bell-style "fg=#282a36,bg=#f1fa8c"
 set -g copy-mode-match-style "fg=#282a36,bg=#f1fa8c"
 set -g copy-mode-current-match-style "fg=#282a36,bg=#ffb86c,bold"
 set -g copy-mode-mark-style "fg=#282a36,bg=#ff79c6"
+
+# -- AI agent counter in status-right -----------------------------------------
+# ccstatus short-circuits on zero AI agents, so this is invisible on plain
+# shell sessions. 10s refresh keeps the alert flag responsive; ccstatus
+# itself is cheap (one ps fork in the common case).
+#
+# Reload-idempotent: `prefix + r` re-sources this file but TPM does NOT
+# re-run tmux2k, so a naive `set -ag` would accumulate ccstatus on every
+# reload. Strip any prior occurrence first, then re-append. `##(` is the
+# tmux-config escape for a literal `#(` so the format sequence survives
+# run-shell's own argument parsing.
+set -g status-interval 10
+run-shell 'cur=$(tmux show-options -gv status-right 2>/dev/null); cur=$(printf "%s" "$cur" | sed "s| *##(~/\\.local/bin/ccstatus)||g"); tmux set -g status-right "${cur} ##(~/.local/bin/ccstatus)"'
 
 # -- Popup & Menu (tmux 3.4+) --------------------------------------------------
 set -g popup-style "fg=#f8f8f2,bg=#282a36"


### PR DESCRIPTION
## Summary

Batch of AI-tooling improvements: new `aichat` cloud-CLI wiring, a tmux `ccstatus` AI-agent counter, worktree+session helpers (`ccnew`/`ccdone`), DeepWiki MCP added to all three clients, and a unified MCP Policy block across Claude / Codex / OpenCode docs.

## Changes

- **aichat**: aqua-pinned install, chezmoi-templated config with batched gopass lookup (one `sh` fork, not eight), zsh widget on `Alt-e` for inline NL→shell rewrite, and a `?` function for one-shot queries. Cloud-only — no local/ollama.
- **ccstatus** (`dot_local/bin/executable_ccstatus`): tmux status-right counter that maps `ps` output → `pane_pid` to survive aqua's argv[0] rewrite for claude/codex. Idempotent across `prefix + r` reloads via a sed-strip + re-append using `##(` to escape the format sequence through tmux's arg parser. Fast-path exits before touching tmux when no AI agents are running.
- **ccnew / ccdone** (`dot_custom/functions.sh`): worktree+tmux session helpers. Session names are owner-qualified (`${owner}-${base}-${branch}`) to disambiguate same-name repos under different ghq owners. `ccdone` removes the worktree *before* killing the tmux session so a dirty worktree fails loudly instead of orphaning itself, and refuses upfront if the target session is the one you're attached to.
- **MCP Policy**: unified block in `CLAUDE.md`, `AGENTS.md` (codex + opencode) covering Context7 / Tavily / Serena / Playwright / arxiv / DeepWiki / gitmcp / markitdown. Single-space arrow format (`Docs/API -> Context7`) to satisfy `test_opencode_config_rendering` substring assertions.
- **DeepWiki MCP**: added to the Claude MCP sync script, codex `config.toml.tmpl`, and opencode `opencode.jsonc.tmpl` so all three clients share public-repo Q&A.
- **CodeCompanion.nvim** (`private_dot_config/nvim/lua/plugins/ai.lua`): new plugin spec wired to the Anthropic adapter via `ANTHROPIC_API_KEY`.
- **aicommit default**: `AICOMMIT_PROVIDER` default flipped from `codex` to `claude` in `dot_custom/exports.sh.tmpl`.
- **tmux**: `monitor-activity on` so background windows running idle AI agents are visible at a glance; activity style themed through the existing Dracula palette.

## Testing

- [x] `bash tests/run.sh` — all 8 suites green (bootstrap, keys-manage, toolchain, opencode/codex config rendering, codex model selection, manage-list logic, apply flags, menu nav).
- [x] `ccstatus` idempotency verified by sourcing `tmux.conf` three times in an isolated tmux server — `status-right` converges on a single ccstatus entry.
- [x] `_cc_session_name` disambiguation verified across same-named repos under different owners.
- [x] `ccdone` teardown-order regression verified: a dirty worktree now aborts before killing the session.
- [x] pre-commit hooks (treefmt / shellcheck / selene / templates): pass.
- [ ] `aichat` runtime behaviour tested after `chezmoi apply` + aqua install on the target machine.

## Checklist

- [x] Follows `type(scope): description` commit convention used in recent history
- [x] Self-review via `/simplify` completed — reuse / quality / efficiency findings all addressed
- [x] Tests pass locally
- [x] No secrets staged (gopass keys resolved at apply-time only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)