### PR TITLE
chore(versions): update pinned versions (2026-04-12)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -16,7 +16,7 @@ versions:
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
   openaiSkillsRev: 0ed2046f287a92b5f4bcace213dcb3cc5f094cb9
-  huggingfaceSkillsRev: 0e9820357fa0ed7711f346fb0d76df4e071c8364
+  huggingfaceSkillsRev: f89b940362495d2a65dbd88af9755dd5001f2acd
   getsentrySkillsRev: 53901e61b144bd60387b9b011ca4cb929c632d37
   trailofbitsSkillsRev: d7f76b532d1e4c6e7757e04d25c99ab60dd5e32c
   cloudflareSkillsRev: 5ec03da67e230df52b698255c8e5979dc9b124b6
@@ -25,7 +25,7 @@ versions:
   supabaseAgentSkillsRev: 05a8f1a3a9f0977e192c44a85627532e0e69fe8f
   expoSkillsRev: 8f26555fe105f72cf43051cf671771ad227a2f8f
   microsoftSkillsRev: f246ec163617b1bd47b02f7c34ae644c36e6576b
-  sickn33AntigravitySkillsRev: 43280f981edc950bc8d2e75bc00c1173da253d6e
+  sickn33AntigravitySkillsRev: f2d80cea0b5a0f84500cbd0f0969dabf5d3f6bff
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.17.3` |
| nix | `v2.34.4` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.57.1` |
| nix-index-database | `2026-03-29-050203` |
| paperlib | `3.1.12` |
| openai/skills | `0ed2046f287a92b5f4bcace213dcb3cc5f094cb9` |
| huggingface/skills | `f89b940362495d2a65dbd88af9755dd5001f2acd` |
| getsentry/skills | `53901e61b144bd60387b9b011ca4cb929c632d37` |
| trailofbits/skills | `d7f76b532d1e4c6e7757e04d25c99ab60dd5e32c` |
| cloudflare/skills | `5ec03da67e230df52b698255c8e5979dc9b124b6` |
| vercel-labs/agent-skills | `73140fc5b3a214ad3222bcf557b397b3c02d11c1` |
| vercel-labs/next-skills | `038954e07bfc313e97fa5f6ff7caf87226e4a782` |
| supabase/agent-skills | `05a8f1a3a9f0977e192c44a85627532e0e69fe8f` |
| expo/skills | `8f26555fe105f72cf43051cf671771ad227a2f8f` |
| microsoft/skills | `f246ec163617b1bd47b02f7c34ae644c36e6576b` |
| sickn33/antigravity-awesome-skills | `f2d80cea0b5a0f84500cbd0f0969dabf5d3f6bff` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |