### PR TITLE
chore(aqua): update pinned packages (2026-04-12)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -15,10 +15,10 @@ packages:
     update:
       enabled: false
   - name: anthropics/claude-code@v2.1.101
-  - name: openai/codex@rust-v0.119.0
+  - name: openai/codex@rust-v0.120.0
   - name: anomalyco/opencode@v1.4.3
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.8
+  - name: jdx/mise@v2026.4.9
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.68.0
@@ -29,7 +29,7 @@ packages:
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.89.0
   - name: dlvhdr/gh-dash@v4.23.2
-  - name: x-motemen/ghq@v1.10.0
+  - name: x-motemen/ghq@v1.10.1
   - name: git-lfs/git-lfs@v3.7.1
   - name: charmbracelet/glow@v2.1.2
   - name: jqlang/jq@jq-1.8.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.