### PR TITLE
chore(apps): replace Zen browser with Google Chrome

### DIFF
--- a/.chezmoidata/hammerspoon.yaml
+++ b/.chezmoidata/hammerspoon.yaml
@@ -41,7 +41,7 @@ hammerspoon:
         ime: jp
       - app: Safari
         ime: jp
-      - app: Zen
+      - app: Google Chrome
         ime: jp
     private:
       # Browsers/Communication -> Chinese for private
@@ -51,7 +51,7 @@ hammerspoon:
         ime: zh
       - app: Safari
         ime: zh
-      - app: Zen
+      - app: Google Chrome
         ime: zh
       - app: WeChat
         ime: zh

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -42,7 +42,7 @@ homebrew:
       - slidepilot
       - stats
       - tailscale-app
-      - zen
+      - google-chrome
     work:
       - dbeaver-community
       - obsidian


### PR DESCRIPTION
## Summary
- Swap Zen browser for Google Chrome in Homebrew cask list
- Update Hammerspoon IME app-switch rules (jp + zh) to match Chrome instead of Zen

## Test plan
- [ ] `chezmoi diff` shows expected changes
- [ ] `chezmoi apply` installs google-chrome cask
- [ ] Hammerspoon IME switching works when focusing Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)