### PR TITLE
chore(aqua): update pinned packages (2026-04-15)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,9 +14,9 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.105
+  - name: anthropics/claude-code@v2.1.108
   - name: openai/codex@rust-v0.120.0
-  - name: anomalyco/opencode@v1.4.3
+  - name: anomalyco/opencode@v1.4.4
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.4.11
   - name: muesli/duf@v0.9.1
@@ -37,7 +37,7 @@ packages:
   - name: casey/just@1.49.0
   - name: jesseduffield/lazygit@v0.61.1
   - name: neovim/neovim@v0.12.1
-  - name: LuaLS/lua-language-server@3.18.1
+  - name: LuaLS/lua-language-server@3.18.2
   - name: tree-sitter/tree-sitter@v0.26.8
   - name: rclone/rclone@v1.73.4
   - name: o2sh/onefetch@2.27.1
@@ -47,7 +47,7 @@ packages:
   - name: phiresky/ripgrep-all@v0.10.10
   - name: chmln/sd@v1.1.0
   - name: joshmedeski/sesh@v2.25.0
-  - name: skim-rs/skim@v4.5.1
+  - name: skim-rs/skim@v4.6.0
   - name: starship/starship@v1.24.2
   - name: JohnnyMorganz/StyLua@v2.4.1
   - name: Kampfkarren/selene@0.30.1
@@ -56,7 +56,7 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: golang.org/x/tools/gopls@v0.21.1
   - name: golangci/golangci-lint@v2.11.4
-  - name: goreleaser/goreleaser@v2.15.2
+  - name: goreleaser/goreleaser@v2.15.3
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0
   - name: dduan/tre@v0.4.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.