### PR TITLE
chore(aqua): update pinned packages (2026-04-19)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.113
+  - name: anthropics/claude-code@v2.1.114
   - name: openai/codex@rust-v0.121.0
-  - name: anomalyco/opencode@v1.4.10
+  - name: anomalyco/opencode@v1.4.11
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.16
+  - name: jdx/mise@v2026.4.17
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.68.0
@@ -48,7 +48,7 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: joshmedeski/sesh@v2.25.0
   - name: skim-rs/skim@v4.6.0
-  - name: starship/starship@v1.24.2
+  - name: starship/starship@v1.25.0
   - name: JohnnyMorganz/StyLua@v2.4.1
   - name: Kampfkarren/selene@0.30.1
   - name: koalaman/shellcheck@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.