### PR TITLE
chore(nix): update flake.lock for darwin (2026-04-19)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776469040,
-        "narHash": "sha256-IX5UflSmiXkJnRUCNjzBl4/HMw0NMLQqsfdwA4l0kyU=",
+        "lastModified": 1776556484,
+        "narHash": "sha256-Mwo16k4pE9WkC+qzQw3/95VbUgl2KC0MShcnEo9HdLM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "906ff3d493d3e9f50ceb5041fcc14bcfe3d63ff1",
+        "rev": "60c66583f9ee24ba34b71a11ec16cd72a5732daf",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776461416,
-        "narHash": "sha256-AqxPJs6cy7ZwsS2ovNuLxUJM+2kgnEi4ECXitf6nb18=",
+        "lastModified": 1776557902,
+        "narHash": "sha256-HLclghm1xDsN2WTbDuZM1dHHwfPDzpBK1TnQN7frz8c=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "2aab2c98676928d65d72ce7fc2abd5c7f3634319",
+        "rev": "f03045bafb2976b9406a6acbeb2bc0cea8626ed8",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.