### PR TITLE
chore(nix): update flake.lock for darwin (2026-04-21)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776640060,
-        "narHash": "sha256-ulrO28QArb84CJAeQObnd3BVNfIxjA7R6aJmvrNU4mc=",
+        "lastModified": 1776730364,
+        "narHash": "sha256-OvHkafGowBbDKfRkbS5GHvMKSftfzQhB8KZSGItf7qE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "ee338433b1c31702c1ac958ff1fc30a995374558",
+        "rev": "54d94435444db6285b45a3253238c52c75ce2c74",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776643182,
-        "narHash": "sha256-culo1wj8fU1z8hjgz8MeHRAgG5rUudHOMsi+6XYtohY=",
+        "lastModified": 1776723856,
+        "narHash": "sha256-oaICnroy1Tb7Tj1RiIMiZicBZnb1LD5B+7sjAkVDuB0=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "fb75171393ca6234c13d4b6371427f20543cee71",
+        "rev": "87edf9093f644fef6e4e04e23670a58036ec759f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.