### PR TITLE
chore(aqua): update pinned packages (2026-04-22)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,9 +14,9 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.116
+  - name: anthropics/claude-code@v2.1.117
   - name: openai/codex@rust-v0.122.0
-  - name: anomalyco/opencode@v1.14.19
+  - name: anomalyco/opencode@v1.14.20
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.4.18
   - name: muesli/duf@v0.9.1
@@ -56,7 +56,7 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: golang.org/x/tools/gopls@v0.21.1
   - name: golangci/golangci-lint@v2.11.4
-  - name: goreleaser/goreleaser@v2.15.3
+  - name: goreleaser/goreleaser@v2.15.4
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0
   - name: dduan/tre@v0.4.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.