### PR TITLE
chore(nix): update flake.lock for darwin (2026-04-24)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776898871,
-        "narHash": "sha256-NiXj1krhMyswtDdVCZXlDKGzq7kA22b2JfrEUaJQyps=",
+        "lastModified": 1776985488,
+        "narHash": "sha256-v14iugqepvi2CeObRmIt2Z9dulXUqat21gLPUi4g604=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "f58027dcd7d00fcc3179d1533a915512dbe0825b",
+        "rev": "ff13cc389ff72fbd8f03d508276137e9f7593898",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776901786,
-        "narHash": "sha256-F4Ceq9doAwv8x8Ei3fzT3tDHi+98OX895bLFAvmZE1s=",
+        "lastModified": 1776989860,
+        "narHash": "sha256-MiKs+1TwDF02PA1PpsSSlaJ7Sbqleptx9tWqWcgJF+c=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "1470474c338aaad6141c87fb6877c1d2e420b01f",
+        "rev": "92fc1b908dd50cdea63419b64073203af2a0a8ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.