### PR TITLE
chore(nix): update flake.lock for darwin (2026-04-25)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776985488,
-        "narHash": "sha256-v14iugqepvi2CeObRmIt2Z9dulXUqat21gLPUi4g604=",
+        "lastModified": 1777073829,
+        "narHash": "sha256-32KKHx2kM7djj8Os/SVhfeiYWVYKlbe7yUwT1nMFos0=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "ff13cc389ff72fbd8f03d508276137e9f7593898",
+        "rev": "1f28de6ec532535a96ab99b83fb56a19f06b1dfe",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776989860,
-        "narHash": "sha256-MiKs+1TwDF02PA1PpsSSlaJ7Sbqleptx9tWqWcgJF+c=",
+        "lastModified": 1777076488,
+        "narHash": "sha256-jfDVxZaFkfiKfaGjVhqbQPoE8xKw+VgdDf/BR4LNFSw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "92fc1b908dd50cdea63419b64073203af2a0a8ab",
+        "rev": "1397f8902515b2936d23ff5b4097cce0aa5f6e73",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.