### PR TITLE
chore(versions): update pinned versions (2026-04-26)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -6,7 +6,7 @@ versions:
   nixVersion: v2.34.6
   aquaInstaller: v4.0.4
   aquaInstallerSha256: acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28
-  aquaVersion: v2.57.1
+  aquaVersion: v2.57.2
   nixIndexDb: 2026-03-29-050203
   paperlib: 3.1.12
   claudeWshobsonAgentsRev: 27a7ed95755a5c3a2948694343a8e2cd7a7ef6fb
@@ -25,7 +25,7 @@ versions:
   supabaseAgentSkillsRev: f15a5a40779072a530c9e53c3f14ec4131118ea6
   expoSkillsRev: 93751dadf0494110893a9f7a2091ca14833d8212
   microsoftSkillsRev: 7d736cbd13e586462eac0c22d6eada4f7a0e435a
-  sickn33AntigravitySkillsRev: 846ac1c763877775967f0584ea06818e47aa0c2a
+  sickn33AntigravitySkillsRev: 9bad53f2426e310c33ef5bacf9f845855197be6a
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.18.1` |
| nix | `v2.34.6` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.57.2` |
| nix-index-database | `2026-03-29-050203` |
| paperlib | `3.1.12` |
| openai/skills | `724cd511c96593f642bddf13187217aa155d2554` |
| huggingface/skills | `ddcf68038c45b78adda240b924a427f1e069f4b2` |
| getsentry/skills | `a2366b16ba49c0c845bdbbd27e0eae283b3a493f` |
| trailofbits/skills | `e8cc5baf9329ccb491bfa200e82eacbac83b1ead` |
| cloudflare/skills | `0438a075b419f737eb091d1c91800b7387e3a75f` |
| vercel-labs/agent-skills | `ce3e64e468f8fa09a2d075d102771838061fdac0` |
| vercel-labs/next-skills | `038954e07bfc313e97fa5f6ff7caf87226e4a782` |
| supabase/agent-skills | `f15a5a40779072a530c9e53c3f14ec4131118ea6` |
| expo/skills | `93751dadf0494110893a9f7a2091ca14833d8212` |
| microsoft/skills | `7d736cbd13e586462eac0c22d6eada4f7a0e435a` |
| sickn33/antigravity-awesome-skills | `9bad53f2426e310c33ef5bacf9f845855197be6a` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |