### PR TITLE
chore(aqua): update pinned packages (2026-04-28)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -16,16 +16,16 @@ packages:
       enabled: false
   - name: anthropics/claude-code@v2.1.120
   - name: openai/codex@rust-v0.125.0
-  - name: anomalyco/opencode@v1.14.25
+  - name: anomalyco/opencode@v1.14.28
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.22
+  - name: jdx/mise@v2026.4.24
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.68.0
   - name: eza-community/eza@v0.23.4
   - name: fastfetch-cli/fastfetch@2.62.1
   - name: sharkdp/fd@v10.4.2
-  - name: junegunn/fzf@v0.71.0
+  - name: junegunn/fzf@v0.72.0
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.91.0
   - name: dlvhdr/gh-dash@v4.23.2
@@ -41,13 +41,13 @@ packages:
   - name: tree-sitter/tree-sitter@v0.26.8
   - name: rclone/rclone@v1.73.5
   - name: o2sh/onefetch@2.27.1
-  - name: ip7z/7zip@26.00
+  - name: ip7z/7zip@26.01
   - name: Nukesor/pueue/pueue@v4.0.4
   - name: BurntSushi/ripgrep@15.1.0
   - name: phiresky/ripgrep-all@v0.10.10
   - name: chmln/sd@v1.1.0
-  - name: joshmedeski/sesh@v2.26.0
-  - name: skim-rs/skim@v4.6.0
+  - name: joshmedeski/sesh@v2.26.1
+  - name: skim-rs/skim@v4.6.1
   - name: starship/starship@v1.25.0
   - name: JohnnyMorganz/StyLua@v2.4.1
   - name: Kampfkarren/selene@0.30.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.