### PR TITLE
chore(aqua): update pinned packages (2026-04-29)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -6,7 +6,7 @@ packages:
   - name: nektos/act@v0.2.87
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.0
-  - name: atuinsh/atuin@v18.15.2
+  - name: atuinsh/atuin@v18.16.0
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
   - name: eth-p/bat-extras@v2024.08.24
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.120
+  - name: anthropics/claude-code@v2.1.122
   - name: openai/codex@rust-v0.125.0
-  - name: anomalyco/opencode@v1.14.28
+  - name: anomalyco/opencode@v1.14.29
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.24
+  - name: jdx/mise@v2026.4.25
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.68.0
@@ -27,7 +27,7 @@ packages:
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.72.0
   - name: gopasspw/gopass@v1.16.1
-  - name: cli/cli@v2.91.0
+  - name: cli/cli@v2.92.0
   - name: dlvhdr/gh-dash@v4.23.2
   - name: x-motemen/ghq@v1.10.1
   - name: git-lfs/git-lfs@v3.7.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.