### PR TITLE
chore(aqua): update pinned packages (2026-05-01)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,14 +14,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.122
-  - name: openai/codex@rust-v0.125.0
-  - name: anomalyco/opencode@v1.14.29
+  - name: anthropics/claude-code@v2.1.123
+  - name: openai/codex@rust-v0.128.0
+  - name: anomalyco/opencode@v1.14.30
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.4.25
+  - name: jdx/mise@v2026.4.28
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
-  - name: Wilfred/difftastic@0.68.0
+  - name: Wilfred/difftastic@0.69.0
   - name: eza-community/eza@v0.23.4
   - name: fastfetch-cli/fastfetch@2.62.1
   - name: sharkdp/fd@v10.4.2
@@ -48,7 +48,7 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: joshmedeski/sesh@v2.26.1
   - name: skim-rs/skim@v4.6.1
-  - name: starship/starship@v1.25.0
+  - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.4.1
   - name: Kampfkarren/selene@0.30.1
   - name: koalaman/shellcheck@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.