### PR TITLE
chore(aqua): update pinned packages (2026-05-03)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -16,7 +16,7 @@ packages:
       enabled: false
   - name: anthropics/claude-code@v2.1.126
   - name: openai/codex@rust-v0.128.0
-  - name: anomalyco/opencode@v1.14.31
+  - name: anomalyco/opencode@v1.14.33
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.4.28
   - name: muesli/duf@v0.9.1
@@ -47,7 +47,7 @@ packages:
   - name: phiresky/ripgrep-all@v0.10.10
   - name: chmln/sd@v1.1.0
   - name: joshmedeski/sesh@v2.26.1
-  - name: skim-rs/skim@v4.6.1
+  - name: skim-rs/skim@v4.6.2
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.4.1
   - name: Kampfkarren/selene@0.30.1
@@ -55,7 +55,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: golang.org/x/tools/gopls@v0.21.1
-  - name: golangci/golangci-lint@v2.12.0
+  - name: golangci/golangci-lint@v2.12.1
   - name: goreleaser/goreleaser@v2.15.4
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.