### PR TITLE
chore(aqua): update pinned packages (2026-05-07)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,7 +14,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.128
+  - name: anthropics/claude-code@v2.1.132
   - name: openai/codex@rust-v0.128.0
   - name: anomalyco/opencode@v1.14.39
   - name: direnv/direnv@v2.37.1
@@ -55,7 +55,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: golang.org/x/tools/gopls@v0.21.1
-  - name: golangci/golangci-lint@v2.12.1
+  - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.15.4
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.