### PR TITLE
chore(aqua): update pinned packages (2026-05-09)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.133
-  - name: openai/codex@rust-v0.129.0
+  - name: anthropics/claude-code@v2.1.137
+  - name: openai/codex@rust-v0.130.0
   - name: anomalyco/opencode@v1.14.41
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.2
+  - name: jdx/mise@v2026.5.3
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.69.0
@@ -39,7 +39,7 @@ packages:
   - name: neovim/neovim@v0.12.2
   - name: LuaLS/lua-language-server@3.18.2
   - name: tree-sitter/tree-sitter@v0.26.8
-  - name: rclone/rclone@v1.74.0
+  - name: rclone/rclone@v1.74.1
   - name: o2sh/onefetch@2.27.1
   - name: ip7z/7zip@26.01
   - name: Nukesor/pueue/pueue@v4.0.4


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.