### PR TITLE
chore(versions): update pinned versions (2026-05-11)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -7,7 +7,7 @@ versions:
   aquaInstaller: v4.0.4
   aquaInstallerSha256: acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28
   aquaVersion: v2.58.1
-  nixIndexDb: 2026-05-08-112113
+  nixIndexDb: 2026-05-10-055239
   paperlib: 3.1.12
   claudeWshobsonAgentsRev: 9f9ba3237022cd88d8660060fc58e0492002f978
   claudeWshobsonAgentsSha256: baf84fae43c513b004d009294cda659ccc77ce1c83610236380735c508b9764a
@@ -25,7 +25,7 @@ versions:
   supabaseAgentSkillsRev: fa9911ac26eb15184d0e0f21ac195c6224e6c0b4
   expoSkillsRev: 47f0ef64821f10e42a600758b5087bfe89c09474
   microsoftSkillsRev: eceed4a9fd0809d9460a9e86750cbf4c658d6b97
-  sickn33AntigravitySkillsRev: d237aa53065ef4012378554d826fabb428e3cee8
+  sickn33AntigravitySkillsRev: e5713b879bc546ce5ddd728f86b8875314faa139
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.20.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.58.1` |
| nix-index-database | `2026-05-10-055239` |
| paperlib | `3.1.12` |
| openai/skills | `4c4058ebf44f6734e62c70ab4a81246d4d093fc8` |
| huggingface/skills | `7c71cfb2b12920002c3177474c779feeec4e9ad1` |
| getsentry/skills | `c81373583417504de2d3be1ae3d81977b11b2981` |
| trailofbits/skills | `a56045e9ae00b3506cacefea0f672aab0a1a6e3c` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `b9c8ee0643d87d3c5a953d1e22382ff2ead39229` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `fa9911ac26eb15184d0e0f21ac195c6224e6c0b4` |
| expo/skills | `47f0ef64821f10e42a600758b5087bfe89c09474` |
| microsoft/skills | `eceed4a9fd0809d9460a9e86750cbf4c658d6b97` |
| sickn33/antigravity-awesome-skills | `e5713b879bc546ce5ddd728f86b8875314faa139` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |