### PR TITLE
chore(aqua): update pinned packages (2026-05-11)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -16,9 +16,9 @@ packages:
       enabled: false
   - name: anthropics/claude-code@v2.1.138
   - name: openai/codex@rust-v0.130.0
-  - name: anomalyco/opencode@v1.14.45
+  - name: anomalyco/opencode@v1.14.47
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.4
+  - name: jdx/mise@v2026.5.5
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.69.0
@@ -34,7 +34,7 @@ packages:
   - name: charmbracelet/glow@v2.1.2
   - name: jqlang/jq@jq-1.8.1
   - name: ynqa/jnv@v0.7.1
-  - name: casey/just@1.50.0
+  - name: casey/just@1.51.0
   - name: jesseduffield/lazygit@v0.61.1
   - name: neovim/neovim@v0.12.2
   - name: LuaLS/lua-language-server@3.18.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.