### PR TITLE
fix(nix): add upgrade fallback when determinate-nixd is unavailable

### DIFF
--- a/.chezmoiscripts/run_onchange_before_00_install-nix.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00_install-nix.sh.tmpl
@@ -153,10 +153,15 @@ main() {
         current_version=$(nix --version 2>/dev/null | awk '{print $NF}')
         info "current: $current_version, pinned: $NIX_VERSION"
 
-        # Check for updates
-        if command -v determinate-nixd >/dev/null 2>&1; then
-            info "checking for updates..."
-            sudo determinate-nixd upgrade || warn "upgrade failed"
+        # Upgrade if version mismatch
+        if [ "$current_version" != "${NIX_VERSION#v}" ]; then
+            if command -v determinate-nixd >/dev/null 2>&1; then
+                info "upgrading via determinate-nixd..."
+                sudo determinate-nixd upgrade || warn "upgrade failed"
+            else
+                info "upgrading via nix upgrade-nix..."
+                sudo nix upgrade-nix || warn "upgrade failed"
+            fi
         fi
         return 0
     fi


### PR DESCRIPTION
## Summary
- Nix upgrade was silently skipped when `determinate-nixd` is not on PATH (free-tier Determinate Nix installations)
- Add version mismatch check — only attempt upgrade when `current != pinned`
- Fall back to `nix upgrade-nix` when `determinate-nixd` is unavailable

## Test plan
- [ ] Run `dot apply` with Nix version behind pinned — verify upgrade is attempted via `nix upgrade-nix`
- [ ] Run `dot apply` with Nix version matching pinned — verify no upgrade is attempted
- [ ] On a system with `determinate-nixd` — verify it still uses that path

🤖 Generated with [Claude Code](https://claude.com/claude-code)