### PR TITLE
chore(claude): bump default model to opus-4-7[1m]

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -20,7 +20,10 @@ claude:
     # Native Anthropic (OAuth, no API key needed)
     anthropic:
       models:
+        - claude-opus-4-7
+        - claude-opus-4-7[1m]
         - claude-opus-4-6
+        - claude-sonnet-4-6
         - claude-sonnet-4-5-20250929
         - claude-haiku-4-5-20251001
     # DeepSeek: https://api-docs.deepseek.com/guides/anthropic_api
@@ -88,11 +91,11 @@ claude:
   accounts:
     # Native Anthropic accounts (use OAuth)
     anthropic:
-      model: claude-opus-4-6
+      model: claude-opus-4-7[1m]
     opus:
       provider: anthropic
-      model: claude-opus-4-6
-      small_model: claude-opus-4-6
+      model: claude-opus-4-7[1m]
+      small_model: claude-haiku-4-5-20251001
     haiku:
       provider: anthropic
       model: claude-haiku-4-5-20251001


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7` and `claude-opus-4-7[1m]` (1M context) to the native `anthropic` provider's model list; add `claude-sonnet-4-6` while at it
- Switch `accounts.anthropic.model` and `accounts.opus.model` to `claude-opus-4-7[1m]` (rendered into `ANTHROPIC_MODEL` env var via `dot_claude/settings.json.tmpl`)
- Drop `accounts.opus.small_model` from opus → `claude-haiku-4-5-20251001` (using opus as its own small model was wasteful)

## Type of Change

- [x] `chore` - Maintenance, dependencies, CI/CD

## Testing

- [x] `chezmoi diff` shows only the intended `ANTHROPIC_MODEL` change (`claude-opus-4-6` → `claude-opus-4-7[1m]`)
- [x] Pre-commit hooks pass locally

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or sensitive data included
- [x] Templates render correctly (verified via `chezmoi diff ~/.claude/settings.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)