### PR TITLE
chore(versions): update pinned versions (2026-05-14)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -22,10 +22,10 @@ versions:
   cloudflareSkillsRev: 60147cbb773649eadca89cee92b4e0caf02234b4
   vercelLabsAgentSkillsRev: b9c8ee0643d87d3c5a953d1e22382ff2ead39229
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
-  supabaseAgentSkillsRev: 3e7771598f3a03d29533208dd7b5a50bdfc8860f
+  supabaseAgentSkillsRev: daaed4afe2c78cbdbf92a98f43540cb0293b512d
   expoSkillsRev: 47f0ef64821f10e42a600758b5087bfe89c09474
   microsoftSkillsRev: b71de35cb5a1acc458e1f518cbb9acc830f6d7c6
-  sickn33AntigravitySkillsRev: 72e7132ecbcda49eb16464038095fd8789e54e0b
+  sickn33AntigravitySkillsRev: d68b997a88272e1bf048b40c0dd6ac091fcfeb07
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.20.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.58.1` |
| nix-index-database | `2026-05-10-055239` |
| paperlib | `3.1.12` |
| openai/skills | `c25113bf4c64c8dba6bfe61acf06051d79aa43f6` |
| huggingface/skills | `35810a6dbe518a0f7bd99b1e6550cb57b266ff0b` |
| getsentry/skills | `c81373583417504de2d3be1ae3d81977b11b2981` |
| trailofbits/skills | `a56045e9ae00b3506cacefea0f672aab0a1a6e3c` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `b9c8ee0643d87d3c5a953d1e22382ff2ead39229` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `daaed4afe2c78cbdbf92a98f43540cb0293b512d` |
| expo/skills | `47f0ef64821f10e42a600758b5087bfe89c09474` |
| microsoft/skills | `b71de35cb5a1acc458e1f518cbb9acc830f6d7c6` |
| sickn33/antigravity-awesome-skills | `d68b997a88272e1bf048b40c0dd6ac091fcfeb07` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |