### PR TITLE
chore(aqua): update pinned packages (2026-05-14)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,21 +14,21 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.140
+  - name: anthropics/claude-code@v2.1.141
   - name: openai/codex@rust-v0.130.0
-  - name: anomalyco/opencode@v1.14.48
+  - name: anomalyco/opencode@v1.14.49
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.6
+  - name: jdx/mise@v2026.5.7
   - name: muesli/duf@v0.9.1
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.69.0
   - name: eza-community/eza@v0.23.4
-  - name: fastfetch-cli/fastfetch@2.62.1
+  - name: fastfetch-cli/fastfetch@2.63.1
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.72.0
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.92.0
-  - name: dlvhdr/gh-dash@v4.24.0
+  - name: dlvhdr/gh-dash@v4.24.1
   - name: x-motemen/ghq@v1.10.1
   - name: git-lfs/git-lfs@v3.7.1
   - name: charmbracelet/glow@v2.1.2
@@ -64,4 +64,4 @@ packages:
   - name: mikefarah/yq@v4.53.2
   - name: ajeetdsouza/zoxide@v0.9.9
   - name: derailed/k9s@v0.50.18
-  - name: terraform-linters/tflint@v0.62.0
+  - name: terraform-linters/tflint@v0.62.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.