### PR TITLE
fix(claude,codex): make chezmoi apply idempotent

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -19,7 +19,65 @@
 
 {
   "apiKeyHelper": "{{- if and $provider (hasKey $provider "base_url") -}}~/.local/bin/claude-token{{- end -}}",
+  "env": {
+{{- /* Third-party providers: use provider base_url + account-configured model settings */ -}}
+{{- if and $provider (hasKey $provider "base_url") }}
+    "ANTHROPIC_BASE_URL": "{{ $provider.base_url }}",
+{{- end }}
+{{- if and $account (hasKey $account "model") }}
+    "ANTHROPIC_MODEL": "{{ $account.model }}",
+{{- end }}
+{{- if and $account (hasKey $account "small_model") }}
+    "ANTHROPIC_SMALL_FAST_MODEL": "{{ $account.small_model }}",
+{{- end }}
+{{- if and $account (hasKey $account "haiku_model") }}
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "{{ $account.haiku_model }}",
+{{- end }}
+{{- if and $account (hasKey $account "sonnet_model") }}
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "{{ $account.sonnet_model }}",
+{{- end }}
+{{- if and $account (hasKey $account "opus_model") }}
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "{{ $account.opus_model }}",
+{{- end }}
+{{- /* disable_nonessential_traffic: account -> provider -> defaults */ -}}
+{{- $disableTraffic := false -}}
+{{- if and $account (hasKey $account "disable_nonessential_traffic") -}}
+{{-   $disableTraffic = $account.disable_nonessential_traffic -}}
+{{- else if and $provider (hasKey $provider "disable_nonessential_traffic") -}}
+{{-   $disableTraffic = $provider.disable_nonessential_traffic -}}
+{{- else if hasKey $defaults "disable_nonessential_traffic" -}}
+{{-   $disableTraffic = $defaults.disable_nonessential_traffic -}}
+{{- end -}}
+{{- if $disableTraffic }}
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+{{- end }}
+{{- /* timeout_ms: account -> provider -> defaults */ -}}
+{{- $timeout := "" -}}
+{{- if and $account (hasKey $account "timeout_ms") -}}
+{{-   $timeout = $account.timeout_ms -}}
+{{- else if and $provider (hasKey $provider "timeout_ms") -}}
+{{-   $timeout = $provider.timeout_ms -}}
+{{- else if hasKey $defaults "timeout_ms" -}}
+{{-   $timeout = $defaults.timeout_ms -}}
+{{- end -}}
+{{- if $timeout }}
+    "API_TIMEOUT_MS": "{{ $timeout }}"
+{{- end }}
+  },
   "permissions": {
+    "allow": [
+      "Bash(uv:*)",
+      "Bash(uvx:*)",
+      "Bash(ruff:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(just:*)",
+      "Bash(mise:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(nix:*)",
+      "Bash(chezmoi:*)"
+    ],
     "deny": [
       "Bash(sudo rm -rf:*)",
       "Bash(rm -rf /*)",
@@ -52,19 +110,6 @@
       "Write(**/*.key)",
       "Write(**/credentials*)",
       "Write(**/secrets/**)"
-    ],
-    "allow": [
-      "Bash(uv:*)",
-      "Bash(uvx:*)",
-      "Bash(ruff:*)",
-      "Bash(git:*)",
-      "Bash(gh:*)",
-      "Bash(just:*)",
-      "Bash(mise:*)",
-      "Bash(npm:*)",
-      "Bash(npx:*)",
-      "Bash(nix:*)",
-      "Bash(chezmoi:*)"
     ]
   },
   "hooks": {
@@ -119,49 +164,5 @@
       }
     ]
   },
-  "env": {
-{{- /* Third-party providers: use provider base_url + account-configured model settings */ -}}
-{{- if and $provider (hasKey $provider "base_url") }}
-    "ANTHROPIC_BASE_URL": "{{ $provider.base_url }}",
-{{- end }}
-{{- if and $account (hasKey $account "model") }}
-    "ANTHROPIC_MODEL": "{{ $account.model }}",
-{{- end }}
-{{- if and $account (hasKey $account "small_model") }}
-    "ANTHROPIC_SMALL_FAST_MODEL": "{{ $account.small_model }}",
-{{- end }}
-{{- if and $account (hasKey $account "haiku_model") }}
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "{{ $account.haiku_model }}",
-{{- end }}
-{{- if and $account (hasKey $account "sonnet_model") }}
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "{{ $account.sonnet_model }}",
-{{- end }}
-{{- if and $account (hasKey $account "opus_model") }}
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "{{ $account.opus_model }}",
-{{- end }}
-{{- /* disable_nonessential_traffic: account -> provider -> defaults */ -}}
-{{- $disableTraffic := false -}}
-{{- if and $account (hasKey $account "disable_nonessential_traffic") -}}
-{{-   $disableTraffic = $account.disable_nonessential_traffic -}}
-{{- else if and $provider (hasKey $provider "disable_nonessential_traffic") -}}
-{{-   $disableTraffic = $provider.disable_nonessential_traffic -}}
-{{- else if hasKey $defaults "disable_nonessential_traffic" -}}
-{{-   $disableTraffic = $defaults.disable_nonessential_traffic -}}
-{{- end -}}
-{{- if $disableTraffic }}
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-{{- end }}
-{{- /* timeout_ms: account -> provider -> defaults */ -}}
-{{- $timeout := "" -}}
-{{- if and $account (hasKey $account "timeout_ms") -}}
-{{-   $timeout = $account.timeout_ms -}}
-{{- else if and $provider (hasKey $provider "timeout_ms") -}}
-{{-   $timeout = $provider.timeout_ms -}}
-{{- else if hasKey $defaults "timeout_ms" -}}
-{{-   $timeout = $defaults.timeout_ms -}}
-{{- end -}}
-{{- if $timeout }}
-    "API_TIMEOUT_MS": "{{ $timeout }}"
-{{- end }}
-  }
+  "skipDangerousModePermissionPrompt": true
 }

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -1,6 +1,14 @@
+#!/usr/bin/env bash
+# chezmoi modify_ script: render Codex config, preserving any [projects.*] sections
+# that Codex CLI writes when the user trusts a project directory.
+set -euo pipefail
+
+EXISTING=$(cat)
+
+cat <<'CHEZMOI_TEMPLATE_EOF'
 #:schema https://developers.openai.com/codex/config-schema.json
 # Codex CLI Configuration
-# Managed by chezmoi - do not edit directly
+# Managed by chezmoi - do not edit directly (except [projects.*] sections, which are preserved)
 # Run: chezmoi edit ~/.codex/config.toml
 
 {{- /* codexProviderAccount can be openai or provider@label */ -}}
@@ -15,7 +23,7 @@
 # =============================================================================
 
 # Default model
-model = "gpt-5.4"
+model = "gpt-5.5"
 
 # Model provider (only for third-party providers)
 {{- if ne $providerName "openai" }}
@@ -216,3 +224,16 @@ experimental_use_profile = true
 [sandbox_workspace_write]
 network_access = true
 exclude_slash_tmp = false
+CHEZMOI_TEMPLATE_EOF
+
+# Preserve [projects.*] sections (Codex CLI writes these when trusting a directory).
+# Capture from the first [projects.*] header until a different top-level table appears.
+projects=$(printf '%s\n' "$EXISTING" | awk '
+  /^\[projects\./             { in_projects = 1; print; next }
+  in_projects && /^\[/        { in_projects = 0 }
+  in_projects                 { print }
+')
+
+if [ -n "$projects" ]; then
+  printf '\n%s\n' "$projects"
+fi


### PR DESCRIPTION
## Summary
- `dot_claude/settings.json.tmpl`: reorder top-level keys to match the order Claude Code itself writes (`apiKeyHelper` → `env` → `permissions[allow,deny]` → `hooks` → `skipDangerousModePermissionPrompt`) and add the new `skipDangerousModePermissionPrompt: true` field. Previously every `chezmoi apply` produced a diff because the CLI rewrites the file in a different key order.
- `dot_codex/config.toml.tmpl` → `dot_codex/modify_config.toml.tmpl`: convert to a chezmoi `modify_` script. The script re-emits the managed config and appends any existing `[projects.*]` sections from the target file. Codex writes `[projects."/abs/path"] trust_level = "trusted"` when the user trusts a directory; previously each apply erased these, causing a diff every time. Also bumps default model to `gpt-5.5`.

## Why
`chezmoi status` was permanently dirty on `.claude/settings.json` and `.codex/config.toml` because both target files are rewritten by their owning tools after apply. This makes `chezmoi status` noisy and risks losing user-side state (e.g. Codex project trust) on every apply.

## Test plan
- [ ] `chezmoi apply` once to sync the renamed comment / new key order to home
- [ ] `chezmoi status` no longer lists `.claude/settings.json` or `.codex/config.toml`
- [ ] Trust a new dir via Codex (`codex` in a new project → answer "trust"), re-run `chezmoi apply`, confirm the new `[projects."..."]` section survives and `chezmoi status` stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)