### PR TITLE
chore(aqua): update pinned packages (2026-05-18)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -16,9 +16,9 @@ packages:
       enabled: false
   - name: anthropics/claude-code@v2.1.143
   - name: openai/codex@rust-v0.130.0
-  - name: anomalyco/opencode@v1.15.3
+  - name: anomalyco/opencode@v1.15.4
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.10
+  - name: jdx/mise@v2026.5.11
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.