### PR TITLE
chore(ai): remove naapi and harui providers

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -73,18 +73,6 @@ claude:
       disable_nonessential_traffic: true
       models:
         - ark-code-latest
-    naapi:
-      base_url: https://na.wanxiaot.com
-      timeout_ms: 300000
-      disable_nonessential_traffic: true
-      models:
-        - claude-opus-4-6
-        - claude-opus-4-6-thinking
-        - claude-sonnet-4-5-20250929
-        - claude-sonnet-4-5-20250929-thinking
-        - claude-haiku-4-5-20251001
-        - gpt-5.2-codex
-        - gpt-5.3-codex
   # ===== Account Configurations =====
   # Format: provider or provider@account
   # Fields: model, small_model, haiku_model, sonnet_model, opus_model, timeout_ms
@@ -114,13 +102,6 @@ claude:
       haiku_model: kimi-k2.5
       sonnet_model: kimi-k2.5
       opus_model: kimi-k2.5
-    naapi@private:
-      provider: naapi
-      model: claude-opus-4-6
-      small_model: claude-opus-4-6
-      haiku_model: claude-opus-4-6
-      sonnet_model: claude-opus-4-6
-      opus_model: claude-opus-4-6
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)
   # All skills are hardcoded in .chezmoiexternal.toml.tmpl

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -29,7 +29,6 @@ homebrew:
       - keka
       - keyboardcleantool
       - ghostty
-      # - "mactex"
       - mockoon
       - notion
       - nikitabobko/tap/aerospace
@@ -42,6 +41,7 @@ homebrew:
       - slidepilot
       - stats
       - tailscale-app
+      - typeless
       - google-chrome
     work:
       - dbeaver-community

--- a/README.ja.md
+++ b/README.ja.md
@@ -317,7 +317,7 @@ OpenCode 設定は次のテンプレートで宣言的に管理します。
 - `~/.config/opencode/opencode.jsonc`
 - `~/.config/opencode/oh-my-opencode.jsonc`
 
-OpenCode の key レンダリングは `provider@private` 命名（例: `harui@private`）を使い、gopass から provider key を解決します。
+OpenCode の key レンダリングは `provider@private` 命名（例: `kimi@private`）を使い、gopass から provider key を解決します。
 
 ### OpenCode ネイティブモード
 
@@ -390,7 +390,7 @@ codex-manage switch openai
 codex-with deepseek@private "explain this file"
 
 # OpenCode（ネイティブ CLI + provider key レンダリング）
-opencode run -m harui@private/gpt-5.3-codex "say ok"
+opencode run -m kimi@private/kimi-k2.5 "say ok"
 ```
 
 ### Token Helpers
@@ -398,7 +398,7 @@ opencode run -m harui@private/gpt-5.3-codex "say ok"
 ```bash
 claude-token --check kimi@private
 codex-token --check deepseek@private
-gopass show -o opencode/harui/private/api_key >/dev/null
+gopass show -o opencode/kimi/private/api_key >/dev/null
 ```
 
 ### MCP 連携

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Rendered targets:
 - `~/.config/opencode/opencode.jsonc`
 - `~/.config/opencode/oh-my-opencode.jsonc`
 
-OpenCode key rendering uses `provider@private` naming (for example `harui@private`) and resolves provider keys from gopass.
+OpenCode key rendering uses `provider@private` naming (for example `kimi@private`) and resolves provider keys from gopass.
 
 ### OpenCode Native Mode
 
@@ -390,7 +390,7 @@ codex-manage switch openai
 codex-with deepseek@private "explain this file"
 
 # OpenCode (native CLI + provider-based key rendering)
-opencode run -m harui@private/gpt-5.3-codex "say ok"
+opencode run -m kimi@private/kimi-k2.5 "say ok"
 ```
 
 ### Token Helpers
@@ -398,7 +398,7 @@ opencode run -m harui@private/gpt-5.3-codex "say ok"
 ```bash
 claude-token --check kimi@private
 codex-token --check deepseek@private
-gopass show -o opencode/harui/private/api_key >/dev/null
+gopass show -o opencode/kimi/private/api_key >/dev/null
 ```
 
 ### MCP Integration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -315,7 +315,7 @@ OpenCode 配置由以下模板声明式管理：
 - `~/.config/opencode/opencode.jsonc`
 - `~/.config/opencode/oh-my-opencode.jsonc`
 
-OpenCode 的 key 渲染使用 `provider@private` 命名（如 `harui@private`），并从 gopass 解析 provider key。
+OpenCode 的 key 渲染使用 `provider@private` 命名（如 `kimi@private`），并从 gopass 解析 provider key。
 
 ### OpenCode 原生模式
 
@@ -388,7 +388,7 @@ codex-manage switch openai
 codex-with deepseek@private "explain this file"
 
 # OpenCode（原生 CLI + provider key 渲染）
-opencode run -m harui@private/gpt-5.3-codex "say ok"
+opencode run -m kimi@private/kimi-k2.5 "say ok"
 ```
 
 ### Token Helpers
@@ -396,7 +396,7 @@ opencode run -m harui@private/gpt-5.3-codex "say ok"
 ```bash
 claude-token --check kimi@private
 codex-token --check deepseek@private
-gopass show -o opencode/harui/private/api_key >/dev/null
+gopass show -o opencode/kimi/private/api_key >/dev/null
 ```
 
 ### MCP 集成

--- a/docs/opencode-provider.md
+++ b/docs/opencode-provider.md
@@ -6,7 +6,7 @@ OpenCode in this repository is managed in native mode.
 
 - `opencode-manage`, `opencode-with`, and `opencode-token` are removed.
 - Use the native `opencode` CLI directly.
-- Key rendering uses `provider@private` naming (for example `harui@private`) and resolves provider keys accordingly.
+- Key rendering uses `provider@private` naming (for example `kimi@private`) and resolves provider keys accordingly.
 
 ## Managed Files
 
@@ -23,7 +23,7 @@ Provider keys are stored in gopass under:
 Examples:
 
 ```bash
-gopass show -o opencode/harui/private/api_key
+gopass show -o opencode/kimi/private/api_key
 gopass show -o opencode/kimi/private/api_key
 ```
 
@@ -31,7 +31,7 @@ gopass show -o opencode/kimi/private/api_key
 
 ```bash
 # Native OpenCode invocation
-opencode run -m harui@private/gpt-5.3-codex "say ok"
+opencode run -m kimi@private/kimi-k2.5 "say ok"
 
 # Verify config rendering after template changes
 bash tests/test_opencode_config_rendering.sh

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -132,11 +132,6 @@ base_url = "https://ark.cn-beijing.volces.com/api/v3"
 name = "Glm"
 base_url = "https://open.bigmodel.cn/api/paas/v4"
 
-[model_providers.harui]
-name = "Harui"
-base_url = "https://codex.harui.edu.kg"
-wire_api = "responses"
-
 [model_providers.kimi]
 name = "Kimi"
 base_url = "https://api.moonshot.ai/v1"
@@ -144,10 +139,6 @@ base_url = "https://api.moonshot.ai/v1"
 [model_providers.minimax]
 name = "Minimax"
 base_url = "https://api.minimax.io/v1"
-
-[model_providers.naapi]
-name = "Naapi"
-base_url = "https://na.wanxiaot.com/v1"
 
 [model_providers.qwen]
 name = "Qwen"

--- a/dot_local/bin/lib/ai/core.tmpl
+++ b/dot_local/bin/lib/ai/core.tmpl
@@ -350,8 +350,6 @@ codex_default_model_for_provider() {
         qwen) echo "qwen3-coder-plus" ;;
         minimax) echo "MiniMax-M2.1" ;;
         doubao) echo "doubao-seed-1-6-thinking-250715" ;;
-        naapi) echo "gpt-5.2" ;;
-        harui) echo "gpt-5.2" ;;
         *) echo "gpt-5.4" ;;
     esac
 }

--- a/private_dot_config/opencode/opencode.jsonc.tmpl
+++ b/private_dot_config/opencode/opencode.jsonc.tmpl
@@ -1,7 +1,7 @@
-{{- $resolvedProvider := "harui@private" -}}
-{{- $model := "gpt-5.3-codex" -}}
+{{- $resolvedProvider := "kimi@private" -}}
+{{- $model := "kimi-k2.5" -}}
 {{- $modelRef := printf "%s/%s" $resolvedProvider $model -}}
-{{- $providerKeys := list "openai@private" "deepseek@private" "doubao@private" "glm@private" "harui@private" "kimi@private" "minimax@private" "naapi@private" "qwen@private" -}}
+{{- $providerKeys := list "openai@private" "deepseek@private" "doubao@private" "glm@private" "kimi@private" "minimax@private" "qwen@private" -}}
 {{- $providerApiKeys := dict -}}
 {{- range $providerKey := $providerKeys -}}
 {{-   $providerApiPath := printf "opencode/%s/api_key" (replace "@" "/" $providerKey) -}}
@@ -213,41 +213,6 @@
         }
       }
     },
-    "harui@private": {
-      "npm": "@ai-sdk/openai",
-      "name": "harui@private",
-      "env": ["HARUI_API_KEY"],
-      "options": {
-        "baseURL": "https://codex.harui.edu.kg/v1"{{- if ne (get $providerApiKeys "harui@private") "" }},
-        "apiKey": {{ get $providerApiKeys "harui@private" | quote }}{{- end }}
-      },
-      "models": {
-        "gpt-5.3-codex": {
-          "name": "GPT-5.3 Codex",
-          "options": {
-            "store": false
-          },
-          "variants": {
-            "low": {},
-            "medium": {},
-            "high": {},
-            "xhigh": {}
-          }
-        },
-        "gpt-5.2-codex": {
-          "name": "GPT-5.2 Codex",
-          "options": {
-            "store": false
-          },
-          "variants": {
-            "low": {},
-            "medium": {},
-            "high": {},
-            "xhigh": {}
-          }
-        }
-      }
-    },
     "kimi@private": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "kimi@private",
@@ -294,41 +259,6 @@
       "models": {
         "MiniMax-M2.1": {
           "name": "MiniMax M2.1",
-          "options": {
-            "store": false
-          },
-          "variants": {
-            "low": {},
-            "medium": {},
-            "high": {},
-            "xhigh": {}
-          }
-        }
-      }
-    },
-    "naapi@private": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "naapi@private",
-      "env": ["NAAPI_API_KEY"],
-      "options": {
-        "baseURL": "https://na.wanxiaot.com/v1"{{- if ne (get $providerApiKeys "naapi@private") "" }},
-        "apiKey": {{ get $providerApiKeys "naapi@private" | quote }}{{- end }}
-      },
-      "models": {
-        "gpt-5.3-codex": {
-          "name": "GPT-5.3 Codex",
-          "options": {
-            "store": false
-          },
-          "variants": {
-            "low": {},
-            "medium": {},
-            "high": {},
-            "xhigh": {}
-          }
-        },
-        "gpt-5.2-codex": {
-          "name": "GPT-5.2 Codex",
           "options": {
             "store": false
           },

--- a/tests/test_manage_list_logic.sh
+++ b/tests/test_manage_list_logic.sh
@@ -291,7 +291,6 @@ assert_not_contains "$claude_list" "qwen@private"
 assert_not_contains "$claude_list" "kimi"
 assert_not_contains "$claude_list" "deepseek"
 assert_not_contains "$claude_list" "doubao@private"
-assert_not_contains "$claude_list" "naapi@private"
 assert_not_contains "$claude_list" "(no key)"
 
 # list-visible runtime accounts must be operable for switch.

--- a/tests/test_opencode_config_rendering.sh
+++ b/tests/test_opencode_config_rendering.sh
@@ -113,7 +113,7 @@ case "$cmd" in
     list)
         target="${1:-}"
         [[ "$target" == "-f" ]] && target="${2:-}"
-        if [[ "$target" == "opencode/harui/private/api_key" || "$target" == "opencode/deepseek/private/api_key" || "$target" == "opencode/openai/private/api_key" ]]; then
+        if [[ "$target" == "opencode/kimi/private/api_key" || "$target" == "opencode/deepseek/private/api_key" || "$target" == "opencode/openai/private/api_key" ]]; then
             exit 0
         fi
         exit 1
@@ -123,7 +123,7 @@ case "$cmd" in
         if [[ "$target" == "--password" || "$target" == "-o" ]]; then
             target="${2:-}"
         fi
-        if [[ "$target" == "opencode/harui/private/api_key" ]]; then
+        if [[ "$target" == "opencode/kimi/private/api_key" ]]; then
             printf '%s' "stub-account-key"
             exit 0
         fi
@@ -183,10 +183,9 @@ assert_jq "$OPENCODE_DEFAULT" '(.provider | has("openai_private")) == false'
 assert_jq "$OPENCODE_DEFAULT" '.provider["deepseek@private"].env == ["DEEPSEEK_API_KEY"]'
 assert_jq "$OPENCODE_DEFAULT" '.provider["deepseek@private"].models["deepseek-chat"].options.store == false'
 assert_jq "$OPENCODE_DEFAULT" '(.provider["deepseek@private"].models["deepseek-chat"].variants | has("xhigh")) == true'
-assert_jq "$OPENCODE_DEFAULT" '.provider["harui@private"].env == ["HARUI_API_KEY"]'
-assert_jq "$OPENCODE_DEFAULT" '.provider["harui@private"].npm == "@ai-sdk/openai"'
-assert_jq "$OPENCODE_DEFAULT" '.provider["harui@private"].options.baseURL == "https://codex.harui.edu.kg/v1"'
-assert_jq "$OPENCODE_DEFAULT" '.provider["harui@private"].models["gpt-5.3-codex"].options.store == false'
+assert_jq "$OPENCODE_DEFAULT" '.provider["kimi@private"].env == ["MOONSHOT_API_KEY"]'
+assert_jq "$OPENCODE_DEFAULT" '.provider["kimi@private"].npm == "@ai-sdk/openai-compatible"'
+assert_jq "$OPENCODE_DEFAULT" '.provider["kimi@private"].models["kimi-k2.5"].options.store == false'
 assert_jq "$OPENCODE_DEFAULT" '.provider["qwen@private"].env == ["DASHSCOPE_API_KEY"]'
 assert_jq "$OPENCODE_DEFAULT" '(.provider["qwen@private"].models["qwen3-max"].variants | has("medium")) == true'
 assert_jq "$OPENCODE_DEFAULT" '.provider["kimi@private"].options.baseURL == "https://api.moonshot.ai/v1"'
@@ -210,7 +209,7 @@ assert_jq "$OPENCODE_DEFAULT" '.mcp.gitmcp.type == "remote"'
 assert_jq "$OPENCODE_DEFAULT" '.mcp.gitmcp.url == "https://gitmcp.io/docs"'
 assert_jq "$OPENCODE_DEFAULT" '.mcp.gitmcp.oauth == false'
 assert_jq "$OPENCODE_DEFAULT" '.mcp.gitmcp.enabled == true'
-assert_jq "$OPENCODE_WITH_GOPASS" '.provider["harui@private"].options.apiKey == "stub-account-key"'
+assert_jq "$OPENCODE_WITH_GOPASS" '.provider["kimi@private"].options.apiKey == "stub-account-key"'
 assert_jq "$OPENCODE_WITH_GOPASS" '.provider["deepseek@private"].options.apiKey == "stub-deepseek-key"'
 assert_jq "$OPENCODE_WITH_GOPASS" '.provider["openai@private"].options.apiKey == "stub-openai-key"'
 


### PR DESCRIPTION
## Summary

Removes the **naapi** (`na.wanxiaot.com`) and **harui** (`codex.harui.edu.kg`) third-party AI providers across all chezmoi config templates, tests, and docs.

- opencode default provider/model: `harui@private/gpt-5.3-codex` → `kimi@private/kimi-k2.5`
- codex default unaffected (defaults to `openai`); `[model_providers.naapi]` / `[model_providers.harui]` blocks removed
- Removed obsolete `naapi@private` account from `claude.yaml`
- Removed `naapi)` / `harui)` cases from `codex_default_model_for_provider` in `core.tmpl`
- Retargeted opencode rendering test assertions/gopass stub from harui to `kimi@private`
- Updated README (en/ja/zh) and `docs/opencode-provider.md` examples to kimi

**Unrelated (dotfiles housekeeping):** `homebrew.yaml` drops the commented-out `mactex` cask and adds `typeless`.

## Verification

- No `naapi`/`harui`/`wanxiaot` references remain in the repo
- opencode template renders valid JSON with `model = kimi@private/kimi-k2.5`
- codex config renders without harui/naapi provider blocks
- `tests/test_manage_list_logic.sh`: OK
- `tests/test_opencode_config_rendering.sh`: kimi assertions pass
- pre-commit (incl. template render/check, shellcheck, gitleaks) passed

## Known pre-existing issue (not introduced here)

`tests/test_opencode_config_rendering.sh:341-347` asserts against `dot_codex/config.toml.tmpl`, which does not exist (actual file is `modify_config.toml.tmpl`). This fails identically on `main` before these changes — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)