### PR TITLE
chore(versions): update pinned versions (2026-05-19)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -15,9 +15,9 @@ versions:
   claudeAnthropicsSkillsSha256: 402c3d3fa88f96c1b1d5ea2800c7be8ee46a942186d9ac326be8126e0df136ba
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
-  openaiSkillsRev: c25113bf4c64c8dba6bfe61acf06051d79aa43f6
+  openaiSkillsRev: 590b49edc158611a2b2ed715ae73f27eb70d251a
   huggingfaceSkillsRev: d640d38d200d4586658d9925415c3812369734e8
-  getsentrySkillsRev: 58c611d2b05403f8e53c0b340bc9a574f8cdd4f0
+  getsentrySkillsRev: c41ee49b37ae72da503f10c5aa91e2906b946e4c
   trailofbitsSkillsRev: a56045e9ae00b3506cacefea0f672aab0a1a6e3c
   cloudflareSkillsRev: 60147cbb773649eadca89cee92b4e0caf02234b4
   vercelLabsAgentSkillsRev: b9c8ee0643d87d3c5a953d1e22382ff2ead39229
@@ -25,7 +25,7 @@ versions:
   supabaseAgentSkillsRev: daaed4afe2c78cbdbf92a98f43540cb0293b512d
   expoSkillsRev: 47f0ef64821f10e42a600758b5087bfe89c09474
   microsoftSkillsRev: 8c173dbe3c4051ae35ee4cb78b8bf80c88f36cc8
-  sickn33AntigravitySkillsRev: 7c55ad5908444255b5b58674972bf09333bc0424
+  sickn33AntigravitySkillsRev: 9e5d4ddefa24be7b50cc83f56a2450401cdf3317
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.20.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.0` |
| nix-index-database | `2026-05-17-060925` |
| paperlib | `3.1.12` |
| openai/skills | `590b49edc158611a2b2ed715ae73f27eb70d251a` |
| huggingface/skills | `d640d38d200d4586658d9925415c3812369734e8` |
| getsentry/skills | `c41ee49b37ae72da503f10c5aa91e2906b946e4c` |
| trailofbits/skills | `a56045e9ae00b3506cacefea0f672aab0a1a6e3c` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `b9c8ee0643d87d3c5a953d1e22382ff2ead39229` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `daaed4afe2c78cbdbf92a98f43540cb0293b512d` |
| expo/skills | `47f0ef64821f10e42a600758b5087bfe89c09474` |
| microsoft/skills | `8c173dbe3c4051ae35ee4cb78b8bf80c88f36cc8` |
| sickn33/antigravity-awesome-skills | `9e5d4ddefa24be7b50cc83f56a2450401cdf3317` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |