### PR TITLE
chore(aqua): update pinned packages (2026-05-19)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -15,8 +15,8 @@ packages:
     update:
       enabled: false
   - name: anthropics/claude-code@v2.1.143
-  - name: openai/codex@rust-v0.130.0
-  - name: anomalyco/opencode@v1.15.4
+  - name: openai/codex@rust-v0.131.0
+  - name: anomalyco/opencode@v1.15.5
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.5.11
   - name: muesli/duf@v0.9.1
@@ -69,7 +69,7 @@ packages:
   - name: astral-sh/ruff@0.15.13
   - name: astral-sh/ty@0.0.37
   - name: j178/prek@v0.4.0
-  - name: golang.org/x/tools/gopls@v0.21.1
+  - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.15.4
   - name: orhun/git-cliff@v2.13.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.