### PR TITLE
chore(aqua): update pinned packages (2026-05-20)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.143
+  - name: anthropics/claude-code@v2.1.145
   - name: openai/codex@rust-v0.131.0
   - name: anomalyco/opencode@v1.15.5
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.11
+  - name: jdx/mise@v2026.5.12
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
@@ -37,13 +37,13 @@ packages:
   - name: jqlang/jq@jq-1.8.1
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.0
-  - name: ast-grep/ast-grep@0.42.2
+  - name: ast-grep/ast-grep@0.42.3
   - name: casey/just@1.51.0
   - name: jesseduffield/lazygit@v0.61.1
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.2
   - name: LuaLS/lua-language-server@3.18.2
-  - name: tree-sitter/tree-sitter@v0.26.8
+  - name: tree-sitter/tree-sitter@v0.26.9
   - name: jj-vcs/jj@v0.41.0
   - name: rclone/rclone@v1.74.1
   - name: o2sh/onefetch@2.27.1
@@ -67,7 +67,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.15.13
-  - name: astral-sh/ty@0.0.37
+  - name: astral-sh/ty@0.0.38
   - name: j178/prek@v0.4.0
   - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.