### PR TITLE
chore(aqua): update pinned packages (2026-05-21)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -15,8 +15,8 @@ packages:
     update:
       enabled: false
   - name: anthropics/claude-code@v2.1.145
-  - name: openai/codex@rust-v0.131.0
-  - name: anomalyco/opencode@v1.15.5
+  - name: openai/codex@rust-v0.132.0
+  - name: anomalyco/opencode@v1.15.6
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.5.12
   - name: muesli/duf@v0.9.1
@@ -56,7 +56,7 @@ packages:
   - name: ducaale/xh@v0.25.3
   - name: watchexec/watchexec@v2.5.1
   - name: joshmedeski/sesh@v2.26.2
-  - name: skim-rs/skim@v4.6.2
+  - name: skim-rs/skim@v4.6.3
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.30.1
@@ -68,7 +68,7 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.15.13
   - name: astral-sh/ty@0.0.38
-  - name: j178/prek@v0.4.0
+  - name: j178/prek@v0.4.1
   - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.15.4
@@ -80,7 +80,7 @@ packages:
   - name: ClementTsang/bottom@0.12.3
   - name: dalance/procs@v0.14.11
   - name: sharkdp/hexyl@v0.17.0
-  - name: mr-karan/doggo@v1.1.5
+  - name: mr-karan/doggo@v1.1.6
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0
   - name: sxyazi/yazi@v26.5.6


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.