### PR TITLE
chore(aqua): update pinned packages (2026-05-23)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.147
+  - name: anthropics/claude-code@v2.1.149
   - name: openai/codex@rust-v0.133.0
-  - name: anomalyco/opencode@v1.15.7
+  - name: anomalyco/opencode@v1.15.9
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.13
+  - name: jdx/mise@v2026.5.14
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
@@ -36,7 +36,7 @@ packages:
   - name: carapace-sh/carapace-bin@v1.6.6
   - name: jqlang/jq@jq-1.8.1
   - name: ynqa/jnv@v0.7.1
-  - name: tldr-pages/tlrc@v1.13.0
+  - name: tldr-pages/tlrc@v1.13.1
   - name: ast-grep/ast-grep@0.42.3
   - name: casey/just@1.51.0
   - name: jesseduffield/lazygit@v0.61.1
@@ -67,7 +67,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.15.14
-  - name: astral-sh/ty@0.0.38
+  - name: astral-sh/ty@0.0.39
   - name: j178/prek@v0.4.1
   - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.