### PR TITLE
feat: document & diagram rendering toolchain (quarto, typst, tex, mermaid)

### DIFF
--- a/.chezmoidata/nix.yaml
+++ b/.chezmoidata/nix.yaml
@@ -2,8 +2,17 @@ nix:
   sysPkgs: []
   homepkgs:
     shared:
-      # texliveFull: temporarily disabled (90+ fmt derivations rebuild on every flake.lock update)
-      # - "(texliveFull.withPackages (ps: with ps; [ ]))"
+      # texlive: minimal set for Japanese lualatex (ltjsarticle, lang: ja) used by quarto.
+      # NOTE: the nix store is read-only, so quarto/tlmgr CANNOT auto-install missing
+      # packages at render time — everything the document needs must be listed here.
+      # If a render reports a missing .sty/.cls, add the TeX Live package name below.
+      # ~2.6 GiB on disk (vs scheme-full ~4.8 GiB) once latexextra/mathscience are included —
+      # quarto's default PDF template genuinely needs that breadth. The combine derivations
+      # build locally and rebuild on flake.lock bumps. Avoid texliveFull.withPackages (uncached).
+      # collection-mathscience: unicode-math etc.; lualatex-math: separate pkg quarto needs under lualatex.
+      # collection-latexextra: framed/fancyvrb/bookmark/footnotehyper/... quarto's default PDF template pulls these.
+      # selnolig: standalone pkg quarto loads unconditionally under LuaTeX (not in the collections above).
+      - "(texlive.withPackages (ps: with ps; [ scheme-basic latexmk collection-latexrecommended collection-latexextra collection-fontsrecommended collection-mathscience lualatex-math selnolig collection-langjapanese ]))"
       - aria2
       - git
       - certbot

--- a/.chezmoidata/nix.yaml
+++ b/.chezmoidata/nix.yaml
@@ -12,7 +12,20 @@ nix:
       # collection-mathscience: unicode-math etc.; lualatex-math: separate pkg quarto needs under lualatex.
       # collection-latexextra: framed/fancyvrb/bookmark/footnotehyper/... quarto's default PDF template pulls these.
       # selnolig: standalone pkg quarto loads unconditionally under LuaTeX (not in the collections above).
-      - "(texlive.withPackages (ps: with ps; [ scheme-basic latexmk collection-latexrecommended collection-latexextra collection-fontsrecommended collection-mathscience lualatex-math selnolig collection-langjapanese ]))"
+      - |-
+        (texlive.withPackages (
+              ps: with ps; [
+                scheme-basic
+                latexmk
+                collection-latexrecommended
+                collection-latexextra
+                collection-fontsrecommended
+                collection-mathscience
+                lualatex-math
+                selnolig
+                collection-langjapanese
+              ]
+            ))
       - aria2
       - git
       - certbot

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -56,3 +56,8 @@ fi
 # XDG config paths for tools whose macOS defaults live under Library/Application Support.
 export TLRC_CONFIG="${TLRC_CONFIG:-${XDG_CONFIG_HOME}/tlrc/config.toml}"
 export SLUMBER_CONFIG_PATH="${SLUMBER_CONFIG_PATH:-${XDG_CONFIG_HOME}/slumber/config.yml}"
+
+# Mermaid CLI (mmdc): the nix mermaid-cli ships no Chromium on macOS, so puppeteer
+# can't launch a browser. Point it at the installed Google Chrome (no-op elsewhere).
+[[ -z "${PUPPETEER_EXECUTABLE_PATH:-}" && -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]] \
+    && export PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -56,7 +56,6 @@ packages:
   - name: ducaale/xh@v0.25.3
   - name: watchexec/watchexec@v2.5.1
   - name: joshmedeski/sesh@v2.26.2
-  - name: skim-rs/skim@v4.7.0
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
@@ -100,3 +99,5 @@ packages:
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0
   - name: terraform-linters/tflint@v0.62.1
+  - name: quarto-dev/quarto-cli@v1.9.37
+  - name: typst/typst@v0.14.2


### PR DESCRIPTION
## What

Sets up a document/diagram rendering toolchain and trims an unused tool.

| Change | File | Why |
|---|---|---|
| Add `quarto-dev/quarto-cli@v1.9.37` + `typst/typst@v0.14.2` | `aqua.yaml` | Scientific publishing + standalone typst (matches quarto's bundled typst 0.14.2); both single binaries, fit aqua |
| Add minimal `texlive.withPackages` to flakey-profile | `.chezmoidata/nix.yaml` | Quarto's `lualatex` PDF path (ltjsarticle, `lang: ja`) needs a TeX install |
| Point puppeteer at Google Chrome | `dot_zshenv` | nix `mermaid-cli` ships no Chromium on macOS, so `mmdc` couldn't launch a browser |
| Drop `skim-rs/skim` | `aqua.yaml` | Carried over from old nix home-manager config, wired to nothing; redundant with fzf / ripgrep / ripgrep-all / ugrep |

## TeX set notes

The nix store is read-only, so `tlmgr` cannot auto-install at render time — the package set must list everything quarto's default PDF template needs. Built up empirically until a clean render: `scheme-basic latexmk collection-latexrecommended collection-latexextra collection-fontsrecommended collection-mathscience lualatex-math selnolig collection-langjapanese`. ~2.6 GiB on disk (vs `scheme-full` ~4.8 GiB). Avoids `texliveFull.withPackages` (uncached, rebuilds on every `flake.lock` bump).

## Verification

- `quarto render I470F_report.qmd --to pdf` → PDF produced (Japanese ltjsarticle, lualatex) ✅
- `typst compile` → Japanese PDF ✅
- `mmdc` renders SVG in a fresh shell sourcing `~/.zshenv` ✅
- `sk` removed from PATH; `aqua install` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)