### PR TITLE
chore(versions): update pinned versions (2026-05-24)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -24,8 +24,8 @@ versions:
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
   supabaseAgentSkillsRev: 4e69c80e213f315c02c9ebef9c28dd6e43a4707e
   expoSkillsRev: 10b526b7097f9ec56f9357649699b8d32bc524a4
-  microsoftSkillsRev: c57cd4fc5a19b0a540b6d6184617afe8aab1fcdc
-  sickn33AntigravitySkillsRev: 85b3a55bc5219b63447012b9ca015c271fda919b
+  microsoftSkillsRev: 325091fc44bafebc11330a442af58039248c9f29
+  sickn33AntigravitySkillsRev: 837a882f84bb1281a0fa3f19ef03a2216b3ec38a
   zigDevelopmentPlaybookSkillRev: 72cab69050cc84793603ea7a9d82de367cdd104c
   rustDevelopmentPlaybookSkillRev: eea186a4c35edecd47058c62b44cf8643fc7cc07
   humanizerEnRev: 8b3a17889fbf12bedae20974a3c9f9de746ed754


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.0` |
| nix-index-database | `2026-05-17-060925` |
| paperlib | `3.1.12` |
| openai/skills | `b0401f07213a66414d84a65cb50c1d226f99485a` |
| huggingface/skills | `6592035ef09a74249f2d60083c6a178960d267c6` |
| getsentry/skills | `b10e2db21d3165de1904bdf3fa64285016765fe5` |
| trailofbits/skills | `a56045e9ae00b3506cacefea0f672aab0a1a6e3c` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `18a24346600009dc3fcb99e4b2cd83b301601775` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `4e69c80e213f315c02c9ebef9c28dd6e43a4707e` |
| expo/skills | `10b526b7097f9ec56f9357649699b8d32bc524a4` |
| microsoft/skills | `325091fc44bafebc11330a442af58039248c9f29` |
| sickn33/antigravity-awesome-skills | `837a882f84bb1281a0fa3f19ef03a2216b3ec38a` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `8b3a17889fbf12bedae20974a3c9f9de746ed754` |
| stop-slop-en | `8da1f030185bdfe8471220585162991eaeb970e9` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |