### PR TITLE
chore(aqua): update pinned packages (2026-05-24)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,11 +14,11 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.149
+  - name: anthropics/claude-code@v2.1.150
   - name: openai/codex@rust-v0.133.0
-  - name: anomalyco/opencode@v1.15.9
+  - name: anomalyco/opencode@v1.15.10
   - name: direnv/direnv@v2.37.1
-  - name: jdx/mise@v2026.5.14
+  - name: jdx/mise@v2026.5.15
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
@@ -26,7 +26,7 @@ packages:
   - name: eza-community/eza@v0.23.4
   - name: fastfetch-cli/fastfetch@2.63.1
   - name: sharkdp/fd@v10.4.2
-  - name: junegunn/fzf@v0.72.0
+  - name: junegunn/fzf@v0.73.0
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.92.0
   - name: dlvhdr/gh-dash@v4.24.1
@@ -45,7 +45,7 @@ packages:
   - name: LuaLS/lua-language-server@3.18.2
   - name: tree-sitter/tree-sitter@v0.26.9
   - name: jj-vcs/jj@v0.41.0
-  - name: rclone/rclone@v1.74.1
+  - name: rclone/rclone@v1.74.2
   - name: o2sh/onefetch@2.27.1
   - name: ip7z/7zip@26.01
   - name: ouch-org/ouch@0.7.1
@@ -59,7 +59,7 @@ packages:
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.46.2
+  - name: crate-ci/typos@v1.46.3
   - name: zizmorcore/zizmor@v1.25.2
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.