### PR TITLE
feat(homebrew): add OpenAI Codex desktop app (codex-app cask)

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -22,6 +22,7 @@ homebrew:
   casks:
     shared:
       - cmux
+      - codex-app # OpenAI Codex desktop app for managing coding agents
       - dockdoor
       - visual-studio-code
       - hammerspoon


### PR DESCRIPTION
# Pull Request

## Summary

Adds the [`codex-app`](https://formulae.brew.sh/cask/codex-app) Homebrew cask — OpenAI's Codex **desktop GUI app** for managing coding agents — to the `shared` profile. This complements the existing `codex` CLI (installed via aqua: `openai/codex@rust-v0.133.0`) and the `dot_codex/` configuration, both of which are already shared across all machines.

## Type of Change

- [x] `feat` - New feature or functionality

## Changes

- Add `codex-app` to `homebrew.casks.shared` in `.chezmoidata/homebrew.yaml`. nix-darwin's `homebrew` module (`nix-config/modules/apps.nix.tmpl`) renders this into `brew install --cask` for all profiles.

## Testing

- [x] `chezmoi execute-template` renders `"codex-app"` into the apps.nix casks list
- [x] Pre-commit hooks pass locally (treefmt, check-yaml, typos, gitleaks, etc.)
- [x] `brew install --cask codex-app` succeeds (v26.519.41501); `Codex.app` installed to `/Applications`
- [x] Tested on: macOS (Apple Silicon)

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or sensitive data included
- [x] Templates render correctly
- [x] Nix flake checks pass (no nix-config changes; only `.chezmoidata`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)