### PR TITLE
chore(aqua): update pinned packages (2026-05-28)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,9 +14,9 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.150
+  - name: anthropics/claude-code@v2.1.152
   - name: openai/codex@rust-v0.134.0
-  - name: anomalyco/opencode@v1.15.10
+  - name: anomalyco/opencode@v1.15.11
   - name: direnv/direnv@v2.37.1
   - name: jdx/mise@v2026.5.15
   - name: muesli/duf@v0.9.1
@@ -28,7 +28,7 @@ packages:
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.73.1
   - name: gopasspw/gopass@v1.16.1
-  - name: cli/cli@v2.92.0
+  - name: cli/cli@v2.93.0
   - name: dlvhdr/gh-dash@v4.24.1
   - name: x-motemen/ghq@v1.10.1
   - name: git-lfs/git-lfs@v3.7.1
@@ -66,8 +66,8 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.15.14
-  - name: astral-sh/ty@0.0.39
-  - name: j178/prek@v0.4.2
+  - name: astral-sh/ty@0.0.40
+  - name: j178/prek@v0.4.3
   - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.16.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.