### PR TITLE
chore(claude): switch default model to Opus 4.8

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -20,6 +20,7 @@ claude:
     # Native Anthropic (OAuth, no API key needed)
     anthropic:
       models:
+        - claude-opus-4-8
         - claude-opus-4-7
         - claude-opus-4-7[1m]
         - claude-opus-4-6
@@ -79,10 +80,10 @@ claude:
   accounts:
     # Native Anthropic accounts (use OAuth)
     anthropic:
-      model: claude-opus-4-7[1m]
+      model: claude-opus-4-8
     opus:
       provider: anthropic
-      model: claude-opus-4-7[1m]
+      model: claude-opus-4-8
       small_model: claude-haiku-4-5-20251001
     haiku:
       provider: anthropic

--- a/docs/claude-provider.md
+++ b/docs/claude-provider.md
@@ -88,12 +88,7 @@ claude:
   # Provider definitions (base_url + available models)
   providers:
     anthropic:
-      models:
-        [
-          claude-opus-4-5-20251101,
-          claude-sonnet-4-5-20250929,
-          claude-haiku-4-5-20251001,
-        ]
+      models: [claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001]
     deepseek:
       base_url: https://api.deepseek.com/anthropic
       models: [deepseek-chat, deepseek-reasoner]
@@ -105,12 +100,11 @@ claude:
   accounts:
     # Native Anthropic (OAuth)
     anthropic:
-      model: claude-sonnet-4-5-20250929
-      small_model: claude-sonnet-4-5-20250929
+      model: claude-opus-4-8
     opus:
       provider: anthropic # Use anthropic provider
-      model: claude-opus-4-5-20251101
-      small_model: claude-sonnet-4-5-20250929
+      model: claude-opus-4-8
+      small_model: claude-haiku-4-5-20251001
 
     # Third-party accounts (format: provider@label)
     kimi@private:

--- a/dot_claude/templates/github-action-code-review.yml
+++ b/dot_claude/templates/github-action-code-review.yml
@@ -86,4 +86,4 @@ jobs:
 
             Reference the repository's CLAUDE.md for style and conventions.
             Use `gh pr comment` to leave your review on the PR.
-          claude_args: '--model claude-opus-4-6 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/dot_claude/templates/github-action-security-review.yml
+++ b/dot_claude/templates/github-action-security-review.yml
@@ -30,7 +30,7 @@ jobs:
           # Authentication
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Model selection
-          claude-model: claude-opus-4-6
+          claude-model: claude-opus-4-8
           # Custom instructions specific to your codebase
           # Examples:
           # - "Our API uses JWT tokens stored in httpOnly cookies"


### PR DESCRIPTION
## Summary
Switch every Opus 4.7 / Opus 4.6 model reference in this repo to Opus 4.8.

**Active config** (`.chezmoidata/claude.yaml`):
- `anthropic` and `opus` accounts now default to `claude-opus-4-8`
- `claude-opus-4-8` added to the anthropic provider's model list; 4.7 entries kept for legacy pins
- 1M context is enabled by default on Opus 4.8 — no `[1m]` suffix needed
- Pricing is unchanged from Opus 4.7 (\$5 input / \$25 output per MTok)

**Ancillary references** (squashed-in from former #528):
- `dot_claude/templates/github-action-security-review.yml`: `claude-opus-4-6` → `claude-opus-4-8`
- `dot_claude/templates/github-action-code-review.yml`: `claude-opus-4-6` → `claude-opus-4-8`
- `docs/claude-provider.md`: refresh the stale example config from 4.5-era pins to the current recommended pairing (Opus 4.8 + Sonnet 4.6 + Haiku 4.5) so the doc stops drifting from the actual `.chezmoidata/claude.yaml`

## Context
Anthropic shipped Opus 4.8 on 2026-05-28 with gains in agentic coding and honesty. See [Introducing Claude Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8) and the [Models overview](https://platform.claude.com/docs/en/about-claude/models/overview).

## Test plan
- [x] `grep -rE "claude-opus-4-[67]" .` only matches the intentional legacy entries in `.chezmoidata/claude.yaml`
- [ ] `chezmoi diff ~/.claude/settings.json` shows only the `ANTHROPIC_MODEL` line changing
- [ ] `chezmoi apply` renders the new settings.json successfully
- [ ] Start a fresh `claude` session and confirm the model banner reports Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)