### PR TITLE
feat(aqua): install slipway via third-party local registry

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -53,6 +53,15 @@ if [[ -f "$AQUA_CONFIG_PATH" ]]; then
     esac
 fi
 
+# aqua policy: allow-list for non-standard registries (must be allow-listed once via `aqua policy allow`)
+AQUA_POLICY_PATH="${XDG_CONFIG_HOME}/aquaproj-aqua/aqua-policy.yaml"
+if [[ -f "$AQUA_POLICY_PATH" ]]; then
+    case ":${AQUA_POLICY_CONFIG:-}:" in
+    *":${AQUA_POLICY_PATH}:"*) ;;
+    *) export AQUA_POLICY_CONFIG="${AQUA_POLICY_PATH}${AQUA_POLICY_CONFIG:+:${AQUA_POLICY_CONFIG}}" ;;
+    esac
+fi
+
 # XDG config paths for tools whose macOS defaults live under Library/Application Support.
 export TLRC_CONFIG="${TLRC_CONFIG:-${XDG_CONFIG_HOME}/tlrc/config.toml}"
 export SLUMBER_CONFIG_PATH="${SLUMBER_CONFIG_PATH:-${XDG_CONFIG_HOME}/slumber/config.yml}"

--- a/private_dot_config/aquaproj-aqua/aqua-policy.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua-policy.yaml
@@ -1,0 +1,15 @@
+---
+# Aqua policy file: allow-list for non-standard registries.
+# After chezmoi apply, activate once with:
+#   aqua policy allow ~/.config/aquaproj-aqua/aqua-policy.yaml
+# AQUA_POLICY_CONFIG (set in ~/.zshenv) points aqua at this file.
+
+registries:
+  - type: standard
+    ref: semver(">= 4.0.0")
+  - name: third-party
+    type: local
+    path: registry.yaml
+packages:
+  - registry: standard
+  - registry: third-party

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -2,7 +2,14 @@
 registries:
   - type: standard
     ref: v4.470.0
+  - name: third-party
+    type: local
+    path: registry.yaml
 packages:
+  # ----- third-party registry (see registry.yaml) -----
+  - name: signalridge/slipway@v0.1.0
+    registry: third-party
+  # ----- standard registry -----
   - name: nektos/act@v0.2.88
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.0

--- a/private_dot_config/aquaproj-aqua/registry.yaml
+++ b/private_dot_config/aquaproj-aqua/registry.yaml
@@ -1,0 +1,22 @@
+---
+# Local registry file for third-party aqua packages not yet in the standard registry.
+# Referenced from aqua.yaml as `name: third-party, type: local, path: registry.yaml`.
+# Each addition must also be allow-listed in aqua-policy.yaml.
+
+packages:
+  - type: github_release
+    repo_owner: signalridge
+    repo_name: slipway
+    description: Spec-driven development with full lifecycle accountability for Claude, Codex, Cursor & Gemini
+    asset: "slipway_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    format: tar.gz
+    files:
+      - name: slipway
+    overrides:
+      - goos: windows
+        asset: "slipway_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip"
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - windows


### PR DESCRIPTION
## Summary
- Wire [signalridge/slipway](https://github.com/signalridge/slipway) (v0.1.0) into aqua even though it's not in the standard registry yet
- New local registry file `registry.yaml` defines the GoReleaser-style asset (`slipway_<ver>_<os>_<arch>.tar.gz`, Windows → `.zip`)
- `aqua.yaml` registers the local registry as `third-party` and pins `signalridge/slipway@v0.1.0`
- New `aqua-policy.yaml` allow-lists `standard` + `third-party`; aqua refuses non-standard registries without an explicit policy
- `dot_zshenv` exports `AQUA_POLICY_CONFIG` so aqua finds the policy file

## Activation
After `chezmoi apply`, allow-list the policy once (aqua intentionally requires interactive consent):
```bash
aqua policy allow ~/.config/aquaproj-aqua/aqua-policy.yaml
```
Then `aqua install` (already wired into `run_onchange_after_05_aqua-install-tools.sh.tmpl`) will fetch the binary on next chezmoi apply.

## Test plan
- [x] `aqua list -a` shows `third-party,signalridge/slipway`
- [x] `aqua which slipway` resolves to the expected `pkgs/...` path
- [x] `aqua install` creates `~/.local/share/aquaproj-aqua/bin/slipway` symlink
- [x] `slipway --version` reports `slipway 0.1.0 commit: 44d6529`
- [ ] Fresh `chezmoi apply` on a clean machine completes without policy errors after one-time `aqua policy allow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)