### PR TITLE
chore(claude): bump remaining model references to Opus 4.8

### DIFF
--- a/docs/claude-provider.md
+++ b/docs/claude-provider.md
@@ -88,12 +88,7 @@ claude:
   # Provider definitions (base_url + available models)
   providers:
     anthropic:
-      models:
-        [
-          claude-opus-4-5-20251101,
-          claude-sonnet-4-5-20250929,
-          claude-haiku-4-5-20251001,
-        ]
+      models: [claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001]
     deepseek:
       base_url: https://api.deepseek.com/anthropic
       models: [deepseek-chat, deepseek-reasoner]
@@ -105,12 +100,11 @@ claude:
   accounts:
     # Native Anthropic (OAuth)
     anthropic:
-      model: claude-sonnet-4-5-20250929
-      small_model: claude-sonnet-4-5-20250929
+      model: claude-opus-4-8
     opus:
       provider: anthropic # Use anthropic provider
-      model: claude-opus-4-5-20251101
-      small_model: claude-sonnet-4-5-20250929
+      model: claude-opus-4-8
+      small_model: claude-haiku-4-5-20251001
 
     # Third-party accounts (format: provider@label)
     kimi@private:

--- a/dot_claude/templates/github-action-code-review.yml
+++ b/dot_claude/templates/github-action-code-review.yml
@@ -86,4 +86,4 @@ jobs:
 
             Reference the repository's CLAUDE.md for style and conventions.
             Use `gh pr comment` to leave your review on the PR.
-          claude_args: '--model claude-opus-4-6 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/dot_claude/templates/github-action-security-review.yml
+++ b/dot_claude/templates/github-action-security-review.yml
@@ -30,7 +30,7 @@ jobs:
           # Authentication
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Model selection
-          claude-model: claude-opus-4-6
+          claude-model: claude-opus-4-8
           # Custom instructions specific to your codebase
           # Examples:
           # - "Our API uses JWT tokens stored in httpOnly cookies"


### PR DESCRIPTION
## Summary
Follow-up to #526 — catches the model strings outside `.chezmoidata/claude.yaml` that the original PR didn't touch:

- `dot_claude/templates/github-action-security-review.yml`: `claude-opus-4-6` → `claude-opus-4-8`
- `dot_claude/templates/github-action-code-review.yml`: `claude-opus-4-6` → `claude-opus-4-8`
- `docs/claude-provider.md`: refresh the stale example config from 4.5-era pins to the current recommended pairing (Opus 4.8 + Sonnet 4.6 + Haiku 4.5)

## Why a separate PR
- #526 is scoped to the active account model; this PR is scoped to ancillary references and documentation. Keeping them apart makes each easier to review and revert independently.
- The docs example was drifting well before Opus 4.8 (still pointed at 4.5-era pins), so this PR isn't strictly tied to the 4.8 release — but it's a clean moment to resync.

## Test plan
- [x] `grep -rE "claude-opus-4-[67]" .` returns no hits after the change
- [ ] Reviewer eyeballs the docs example to confirm it matches the intended `.chezmoidata/claude.yaml` shape (once #526 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)