### PR TITLE
feat(bootstrap): support cold-start without pre-existing SSH key

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -5,10 +5,17 @@
 # ==============================================================================
 # TPM (Tmux Plugin Manager)
 # After chezmoi apply, run `prefix + I` in tmux to install plugins
+#
+# Uses `type = "archive"` (anonymous HTTPS tarball download) instead of
+# `type = "git-repo"` to keep cold-start independent of git/SSH/insteadOf
+# rewrites. tpm itself almost never changes, so losing `git pull` ergonomics
+# is a non-issue.
 # ==============================================================================
 [".config/tmux/plugins/tpm"]
-    type = "git-repo"
-    url = "https://github.com/tmux-plugins/tpm.git"
+    type = "archive"
+    url = "https://github.com/tmux-plugins/tpm/archive/refs/heads/master.tar.gz"
+    exact = true
+    stripComponents = 1
     refreshPeriod = "168h"
 
 # ==============================================================================

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -13,8 +13,17 @@
 #   - git, openssl
 #   - jq or python3 (metadata parsing)
 #   - nix (optional, to install missing tools)
+#
+# Cold-start auth bootstrap (when no SSH key exists yet to access keys-backup):
+#   - GH_TOKEN/GITHUB_TOKEN env: one-shot HTTPS clone, token stripped from origin.
+#   - Interactive TTY: install gh via nix and run device-code OAuth (works on
+#     truly headless hosts — no local browser required, just open the printed
+#     URL on any other device).
+#   - Neither: fail fast with remediation hint.
+#
 # Optional env:
 #   - KEYS_BACKUP_PASSWORD (skip prompt)
+#   - GH_TOKEN / GITHUB_TOKEN (unattended cold-start auth)
 set -euo pipefail
 umask 077
 
@@ -387,22 +396,97 @@ if [[ -z "$KEYS_REPO_URL" ]]; then
 fi
 info "Using keys repository: $KEYS_REPO_URL"
 
+# ─────────────────────────────────────────────────────────────
+# Cold-start auth bootstrap.
+# Probe whether the configured URL is reachable as-is. If not, set up an
+# HTTPS+token path so we can clone without a pre-existing SSH key.
+# ─────────────────────────────────────────────────────────────
+KEYS_REPO_CLONE_URL="" # if set, used for clone but stripped from origin afterwards
+needs_bootstrap=false
+case "$KEYS_REPO_URL" in
+git@github.com:* | ssh://git@github.com/*)
+    if ! GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=5' \
+        git -c "url.https://github.com/.insteadOf=" \
+        ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+        needs_bootstrap=true
+    fi
+    ;;
+https://github.com/*)
+    if ! git -c "url.https://github.com/.insteadOf=" \
+        ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+        needs_bootstrap=true
+    fi
+    ;;
+esac
+
+if [[ "$needs_bootstrap" == true ]]; then
+    case "$KEYS_REPO_URL" in
+    git@github.com:*)
+        KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#git@github.com:}"
+        info "Cold start: rewriting keys repo to HTTPS: $KEYS_REPO_URL"
+        ;;
+    ssh://git@github.com/*)
+        KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#ssh://git@github.com/}"
+        info "Cold start: rewriting keys repo to HTTPS: $KEYS_REPO_URL"
+        ;;
+    esac
+
+    if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
+        # Unattended: embed PAT in the clone URL for this single operation.
+        # We rewrite origin afterwards so the token never persists in .git/config.
+        info "Cold start: using GH_TOKEN/GITHUB_TOKEN for one-shot HTTPS clone"
+        bootstrap_token="${GH_TOKEN:-$GITHUB_TOKEN}"
+        KEYS_REPO_CLONE_URL="${KEYS_REPO_URL/https:\/\//https://oauth:${bootstrap_token}@}"
+        unset bootstrap_token
+    elif [[ -t 0 || -t 1 ]] || [[ -e /dev/tty ]]; then
+        # Interactive: install gh temporarily (aqua installs the permanent one
+        # in step 05) and run device-code OAuth. Works on headless SSH sessions.
+        if ! command -v gh >/dev/null 2>&1; then
+            info "Cold start: installing gh temporarily via nix..."
+            maybe_install_with_nix gh || {
+                err "Failed to install gh via nix; ensure script 00 ran successfully"
+                exit 1
+            }
+        fi
+        if ! gh auth status -h github.com >/dev/null 2>&1; then
+            info "Cold start: running 'gh auth login' (device-code flow)"
+            # No -w: gh prints a one-time code + URL you can open on any device.
+            gh auth login -h github.com -p https || {
+                err "gh auth login failed"
+                exit 1
+            }
+        fi
+        # Configure git credential helper so the upcoming clone uses the gh token.
+        gh auth setup-git -h github.com >/dev/null 2>&1 || true
+    else
+        err "Cannot reach $KEYS_REPO_URL and no auth method is available."
+        err "Either:"
+        err "  - export GH_TOKEN=<PAT-with-repo-scope>  (unattended hosts)"
+        err "  - or run with an interactive TTY        (gh device-code OAuth)"
+        exit 1
+    fi
+fi
+
 mkdir -p "$(dirname "$REPO_DIR")"
 
 if [[ -d "$REPO_DIR/.git" ]]; then
     info "Updating existing keys repository: $REPO_DIR"
     (cd "$REPO_DIR" && git remote get-url origin >/dev/null 2>&1) || (cd "$REPO_DIR" && git remote add origin "$KEYS_REPO_URL")
-    (cd "$REPO_DIR" && git fetch origin --quiet)
+    (cd "$REPO_DIR" && git -c "url.https://github.com/.insteadOf=" fetch origin --quiet)
     (cd "$REPO_DIR" && git pull --ff-only --quiet) || {
         err "Failed to pull keys repository (ff-only)"
         exit 1
     }
 else
     info "Cloning keys repository..."
-    git clone "$KEYS_REPO_URL" "$REPO_DIR" || {
+    git -c "url.https://github.com/.insteadOf=" clone "${KEYS_REPO_CLONE_URL:-$KEYS_REPO_URL}" "$REPO_DIR" || {
         err "Failed to clone keys repository"
         exit 1
     }
+    if [[ -n "$KEYS_REPO_CLONE_URL" ]]; then
+        # Strip the embedded PAT from origin so it never lands in .git/config.
+        (cd "$REPO_DIR" && git remote set-url origin "$KEYS_REPO_URL")
+    fi
 fi
 
 [[ -d "$BACKUP_FILES_DIR" ]] || {


### PR DESCRIPTION
## Summary

Fixes the chicken-and-egg problem where `chezmoi apply` on a brand-new machine fails because:

- **Script 01** (`run_before_01_setup-encryption-key`) needs to clone the encrypted `keys-backup` repo to restore the SSH key, but the repo URL is `git@github.com:...` — no SSH key, no clone.
- **TPM external** uses `type = "git-repo"` over HTTPS, but `~/.config/git/config` rewrites `https://github.com/` → `ssh://git@github.com/` via `insteadOf`, so even HTTPS clones demand an SSH key once the gitconfig lands.

The user surfaced this when running `chezmoi apply` on a fresh mac:
```
Cloning into '/Users/.../.config/tmux/plugins/tpm'...
git@github.com: Permission denied (publickey).
chezmoi: .config/tmux/plugins/tpm: ... exit status 128
```

## Changes

### Script 01: cold-start auth bootstrap
Probes the configured keys repo URL. If unreachable, rewrites SSH → HTTPS and authenticates via one of three paths:

1. **`GH_TOKEN` / `GITHUB_TOKEN` env** — unattended/CI. Token embedded in the clone URL for one operation, then stripped from `origin` so it never persists in `.git/config`.
2. **Interactive TTY** — installs `gh` temporarily via the existing `maybe_install_with_nix` helper, then runs `gh auth login -h github.com -p https`. Critically **no `-w` flag**, so it uses the device-code flow that works on headless SSH sessions — the user opens the printed URL on any other device (phone, laptop) to complete OAuth.
3. **Neither available** — fail fast with a clear remediation hint.

Defense-in-depth: all git operations in this path use `-c "url.https://github.com/.insteadOf="` to neutralize any pre-existing rewrite rule from a previous partial apply.

### TPM external: `git-repo` → `archive`
Downloads as an anonymous HTTPS tarball via chezmoi's internal HTTP fetcher — completely decoupled from git, SSH, and `insteadOf` rewrites. TPM itself almost never changes; losing `git pull` ergonomics is a non-issue.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Warm machine (SSH key already present) | ✅ Works | ✅ Works (SSH probe short-circuits, zero overhead) |
| Cold mac with browser | ❌ Fails on tpm clone | ✅ Device-code OAuth, browser opens locally |
| Cold headless SSH server | ❌ Fails on tpm clone | ✅ Device-code OAuth, open URL on phone |
| Unattended CI host | ❌ Fails on tpm clone | ✅ `GH_TOKEN=ghp_xxx chezmoi apply` |

## Test plan

- [x] `bash -n` on the rendered template (syntax valid)
- [x] `shellcheck` on the rendered script (clean)
- [x] `pre-commit run` on both files (all hooks pass, including `check-templates` which renders + treefmt + shellcheck)
- [ ] Manual cold-start verification on a fresh VM / spare machine — primary acceptance criterion
- [ ] Verify warm-path is genuinely zero-overhead (SSH probe completes quickly when key is present)
- [ ] Verify `GH_TOKEN` path: token is stripped from `.git/config` after clone