### PR TITLE
refactor(git): drop insteadOf, use gh credential helper for HTTPS auth

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -82,16 +82,16 @@ encryption = "age"
 {{-   $opencodeProviderAccount = .opencodeProvider -}}{{/* backward compatibility */}}
 {{- end -}}
 
-{{/* gopass password store repository */}}
-{{- $gopassRepository := printf "git@github.com:%s/passwords.git" $gitUsername -}}
+{{/* gopass password store repository (HTTPS; auth via gh credential helper) */}}
+{{- $gopassRepository := printf "https://github.com/%s/passwords.git" $gitUsername -}}
 {{- if hasKey . "gopassRepository" -}}
 {{-   $gopassRepository = .gopassRepository -}}
 {{- else if and (stdinIsATTY) $useEncryption -}}
 {{-   $gopassRepository = promptStringOnce . "gopassRepository" "gopass repository URL" $gopassRepository -}}
 {{- end -}}
 
-{{/* keys-manage backup repository */}}
-{{- $keysRepository := printf "git@github.com:%s/keypairs.git" $gitUsername -}}
+{{/* keys-manage backup repository (HTTPS; auth via gh credential helper) */}}
+{{- $keysRepository := printf "https://github.com/%s/keypairs.git" $gitUsername -}}
 {{- if hasKey . "keysRepository" -}}
 {{-   $keysRepository = .keysRepository -}}
 {{- else if and (stdinIsATTY) $useEncryption -}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -29,15 +29,50 @@ encryption = "age"
 {{- end -}}
 {{- "" -}}
 
+{{/* Identity prompts. In non-TTY mode `promptStringOnce` silently returns its
+     default (which is the prompt label!) — that pollutes downstream config with
+     literal "GitHub username" strings and breaks URL interpolation. Force an
+     explicit fail when no TTY and no data is available, so non-interactive
+     installs (curl | sh) can't accidentally write a half-formed config. */}}
+{{- $nonInteractiveHelp := "Either pre-populate the value in chezmoi data, or download init.sh and run it interactively instead of piping curl into sh:\n  curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh" -}}
+
 {{- $hostname := .chezmoi.hostname -}}
 {{- if not $work -}}
-{{- $hostname = promptStringOnce . "hostname" "Hostname" -}}{{/* set the hostname */}}
+{{-   if hasKey . "hostname" -}}
+{{-     $hostname = .hostname -}}
+{{-   else if stdinIsATTY -}}
+{{-     $hostname = promptStringOnce . "hostname" "Hostname" -}}
+{{-   else -}}
+{{-     fail (printf "hostname is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{-   end -}}
 {{- end -}}
 
-{{/* prompt for user specific configuration */}}
-{{- $useremail := promptStringOnce . "useremail" "Email address" -}}{{/* set the useremail address */}}
-{{- $gitUsername := promptStringOnce . "gitUsername" "GitHub username" -}}{{/* set the github username */}}
-{{- $gitEmail := promptStringOnce . "gitEmail" "GitHub useremail" -}}{{/* set the github useremail */}}
+{{- $useremail := "" -}}
+{{- if hasKey . "useremail" -}}
+{{-   $useremail = .useremail -}}
+{{- else if stdinIsATTY -}}
+{{-   $useremail = promptStringOnce . "useremail" "Email address" -}}
+{{- else -}}
+{{-   fail (printf "useremail is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{- end -}}
+
+{{- $gitUsername := "" -}}
+{{- if hasKey . "gitUsername" -}}
+{{-   $gitUsername = .gitUsername -}}
+{{- else if stdinIsATTY -}}
+{{-   $gitUsername = promptStringOnce . "gitUsername" "GitHub username" -}}
+{{- else -}}
+{{-   fail (printf "gitUsername is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{- end -}}
+
+{{- $gitEmail := "" -}}
+{{- if hasKey . "gitEmail" -}}
+{{-   $gitEmail = .gitEmail -}}
+{{- else if stdinIsATTY -}}
+{{-   $gitEmail = promptStringOnce . "gitEmail" "Git commit email" -}}
+{{- else -}}
+{{-   fail (printf "gitEmail is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{- end -}}
 
 {{- $osID := .chezmoi.os -}}
 {{- if (and (eq .chezmoi.os "linux") (hasKey .chezmoi.osRelease "id")) -}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -14,11 +14,18 @@ encryption = "age"
 {{- if hasKey . "useEncryption" -}}
 {{-   $useEncryption = .useEncryption -}}
 {{- else if env "DOTFILES_USE_ENCRYPTION" -}}
-{{-   $useEncryption = (eq (env "DOTFILES_USE_ENCRYPTION") "true") -}}
+{{-   $useEncryptionEnv := lower (env "DOTFILES_USE_ENCRYPTION") -}}
+{{-   if eq $useEncryptionEnv "true" -}}
+{{-     $useEncryption = true -}}
+{{-   else if eq $useEncryptionEnv "false" -}}
+{{-     $useEncryption = false -}}
+{{-   else -}}
+{{-     fail "DOTFILES_USE_ENCRYPTION must be either \"true\" or \"false\"" -}}
+{{-   end -}}
 {{- else if stdinIsATTY -}}
-{{-   $useEncryption = promptBoolOnce . "useEncryption" "Enable encryption & SSH config (requires ~/.ssh/main key)" -}}
+{{-   $useEncryption = promptBoolOnce . "useEncryption" "Enable encrypted key restore (requires keys backup repo)" -}}
 {{- else -}}
-{{-   fail "useEncryption is unset and there is no TTY to prompt.\nSet it explicitly:\n  - DOTFILES_USE_ENCRYPTION=true curl -fsSL <init-url> | sh\n  - Or download init.sh first and run interactively:\n      curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh" -}}
+{{-   fail "useEncryption is unset and there is no TTY to prompt.\nSet it explicitly:\n  - curl -fsSL <init-url> | DOTFILES_USE_ENCRYPTION=false sh\n  - Or, if restoring encrypted keys:\n      curl -fsSL <init-url> | DOTFILES_USE_ENCRYPTION=true sh\n  - Or download init.sh first and run interactively:\n      curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh" -}}
 {{- end -}}
 {{- "" -}}
 
@@ -98,6 +105,11 @@ encryption = "age"
 {{- else if and (stdinIsATTY) $useEncryption -}}
 {{-   $gopassRepository = promptStringOnce . "gopassRepository" "gopass repository URL" $gopassRepository -}}
 {{- end -}}
+{{- if hasPrefix "git@github.com:" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $gopassRepository) -}}
+{{- else if hasPrefix "ssh://git@github.com/" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $gopassRepository) -}}
+{{- end -}}
 
 {{/* keys-manage backup repository (HTTPS; auth via gh credential helper) */}}
 {{- $keysRepository := printf "https://github.com/%s/keypairs.git" $gitUsername -}}
@@ -105,6 +117,11 @@ encryption = "age"
 {{-   $keysRepository = .keysRepository -}}
 {{- else if and (stdinIsATTY) $useEncryption -}}
 {{-   $keysRepository = promptStringOnce . "keysRepository" "keys-manage backup repository URL" $keysRepository -}}
+{{- end -}}
+{{- if hasPrefix "git@github.com:" $keysRepository -}}
+{{-   $keysRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $keysRepository) -}}
+{{- else if hasPrefix "ssh://git@github.com/" $keysRepository -}}
+{{-   $keysRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $keysRepository) -}}
 {{- end -}}
 
 {{/* jj SSH commit signing key. Default to the managed SSH key only when encryption is enabled. */}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -11,9 +11,7 @@ encryption = "age"
      why the encrypted-keys bootstrap appears to skip itself with zero log
      output. Force an explicit signal instead. */}}
 {{- $useEncryption := false -}}
-{{- if hasKey . "useEncryption" -}}
-{{-   $useEncryption = .useEncryption -}}
-{{- else if env "DOTFILES_USE_ENCRYPTION" -}}
+{{- if env "DOTFILES_USE_ENCRYPTION" -}}
 {{-   $useEncryptionEnv := lower (env "DOTFILES_USE_ENCRYPTION") -}}
 {{-   if eq $useEncryptionEnv "true" -}}
 {{-     $useEncryption = true -}}
@@ -22,10 +20,12 @@ encryption = "age"
 {{-   else -}}
 {{-     fail "DOTFILES_USE_ENCRYPTION must be either \"true\" or \"false\"" -}}
 {{-   end -}}
+{{- else if hasKey . "useEncryption" -}}
+{{-   $useEncryption = .useEncryption -}}
 {{- else if stdinIsATTY -}}
 {{-   $useEncryption = promptBoolOnce . "useEncryption" "Enable encrypted key restore (requires keys backup repo)" -}}
 {{- else -}}
-{{-   fail "useEncryption is unset and there is no TTY to prompt.\nSet it explicitly:\n  - curl -fsSL <init-url> | DOTFILES_USE_ENCRYPTION=false sh\n  - Or, if restoring encrypted keys:\n      curl -fsSL <init-url> | DOTFILES_USE_ENCRYPTION=true sh\n  - Or download init.sh first and run interactively:\n      curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh" -}}
+{{-   fail "useEncryption is unset and there is no TTY to prompt.\nDownload init.sh and run it interactively so chezmoi prompts can read from your terminal:\n  curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh\nIf this is a re-apply with identity data already configured, set DOTFILES_USE_ENCRYPTION=true or false." -}}
 {{- end -}}
 {{- "" -}}
 

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -4,12 +4,21 @@ encryption = "age"
 {{- $work := promptBoolOnce . "work" "Is this a work machine" -}}{{/* true if this machine is a work machine */}}
 {{- $private := not $work -}}{{/* true if this machine should have private configuration  */}}
 {{- $headless := false -}}{{/* true if this machine does not have a screen and keyboard */}}
-{{- $useEncryption := false -}}{{/* default false for users without encryption key */}}
+{{/* useEncryption must be set explicitly. The historical silent default to
+     false was a cold-start footgun: when running `curl ... | sh`, chezmoi has
+     no TTY, the bool prompt silently returns its zero value (false), and
+     .chezmoiignore then hides script 01 entirely — leaving users wondering
+     why the encrypted-keys bootstrap appears to skip itself with zero log
+     output. Force an explicit signal instead. */}}
+{{- $useEncryption := false -}}
 {{- if hasKey . "useEncryption" -}}
 {{-   $useEncryption = .useEncryption -}}
-{{- end -}}
-{{- if stdinIsATTY -}}
-{{-   $useEncryption = promptBoolOnce . "useEncryption" "Enable encryption & SSH config (requires ~/.ssh/main key, default: false)" -}}
+{{- else if env "DOTFILES_USE_ENCRYPTION" -}}
+{{-   $useEncryption = (eq (env "DOTFILES_USE_ENCRYPTION") "true") -}}
+{{- else if stdinIsATTY -}}
+{{-   $useEncryption = promptBoolOnce . "useEncryption" "Enable encryption & SSH config (requires ~/.ssh/main key)" -}}
+{{- else -}}
+{{-   fail "useEncryption is unset and there is no TTY to prompt.\nSet it explicitly:\n  - DOTFILES_USE_ENCRYPTION=true curl -fsSL <init-url> | sh\n  - Or download init.sh first and run interactively:\n      curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh" -}}
 {{- end -}}
 {{- "" -}}
 

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -406,14 +406,12 @@ needs_bootstrap=false
 case "$KEYS_REPO_URL" in
 git@github.com:* | ssh://git@github.com/*)
     if ! GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=5' \
-        git -c "url.https://github.com/.insteadOf=" \
-        ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+        git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
         needs_bootstrap=true
     fi
     ;;
 https://github.com/*)
-    if ! git -c "url.https://github.com/.insteadOf=" \
-        ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+    if ! git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
         needs_bootstrap=true
     fi
     ;;
@@ -472,14 +470,14 @@ mkdir -p "$(dirname "$REPO_DIR")"
 if [[ -d "$REPO_DIR/.git" ]]; then
     info "Updating existing keys repository: $REPO_DIR"
     (cd "$REPO_DIR" && git remote get-url origin >/dev/null 2>&1) || (cd "$REPO_DIR" && git remote add origin "$KEYS_REPO_URL")
-    (cd "$REPO_DIR" && git -c "url.https://github.com/.insteadOf=" fetch origin --quiet)
+    (cd "$REPO_DIR" && git fetch origin --quiet)
     (cd "$REPO_DIR" && git pull --ff-only --quiet) || {
         err "Failed to pull keys repository (ff-only)"
         exit 1
     }
 else
     info "Cloning keys repository..."
-    git -c "url.https://github.com/.insteadOf=" clone "${KEYS_REPO_CLONE_URL:-$KEYS_REPO_URL}" "$REPO_DIR" || {
+    git clone "${KEYS_REPO_CLONE_URL:-$KEYS_REPO_URL}" "$REPO_DIR" || {
         err "Failed to clone keys repository"
         exit 1
     }

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -62,6 +62,27 @@ control_file_is_probably_text() {
     return 0
 }
 
+# Upgrade a legacy GitHub SSH origin to HTTPS so the fast path (and any later
+# fetch/pull/push) goes through the gh credential helper. Idempotent.
+# Must run BEFORE the fast-path early-return below, otherwise machines that
+# were set up on prior SSH-era versions silently keep their SSH origin.
+if [[ -d "$REPO_DIR/.git" ]]; then
+    _origin="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
+    _new=""
+    case "$_origin" in
+    git@github.com:*)
+        _new="https://github.com/${_origin#git@github.com:}"
+        ;;
+    ssh://git@github.com/*)
+        _new="https://github.com/${_origin#ssh://git@github.com/}"
+        ;;
+    esac
+    if [[ -n "$_new" ]]; then
+        git -C "$REPO_DIR" remote set-url origin "$_new" && info "Normalized SSH origin to HTTPS: $_new"
+    fi
+    unset _origin _new
+fi
+
 # Fast path: avoid network and prompting on every apply if everything is already present.
 if [[ -d "$REPO_DIR/.git" && -d "$BACKUP_FILES_DIR" && -f "$HOME/.ssh/main" ]]; then
     missing=false

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -78,7 +78,7 @@ if [[ -d "$REPO_DIR/.git" ]]; then
         ;;
     esac
     if [[ -n "$_new" ]]; then
-        git -C "$REPO_DIR" remote set-url origin "$_new" && info "Normalized SSH origin to HTTPS: $_new"
+        git -C "$REPO_DIR" remote set-url origin "$_new" && echo ":: Normalized SSH origin to HTTPS: $_new"
     fi
     unset _origin _new
 fi

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -14,7 +14,7 @@
 #   - jq or python3 (metadata parsing)
 #   - nix (optional, to install missing tools)
 #
-# Cold-start auth bootstrap (when no SSH key exists yet to access keys-backup):
+# Cold-start auth bootstrap (when HTTPS credentials are not configured yet):
 #   - GH_TOKEN/GITHUB_TOKEN env: one-shot HTTPS clone, token stripped from origin.
 #   - Interactive TTY: install gh via nix and run device-code OAuth (works on
 #     truly headless hosts — no local browser required, just open the printed
@@ -256,6 +256,19 @@ decrypt_openssl_pbkdf2_atomic() {
     return 1
 }
 
+decrypt_control_file_atomic() {
+    local enc="$1"
+    local plain="$2"
+    local password="$3"
+
+    decrypt_openssl_pbkdf2_atomic "$enc" "$plain" "$password" || return 1
+    if control_file_is_probably_text "$plain"; then
+        return 0
+    fi
+    rm -f "$plain" 2>/dev/null || true
+    return 1
+}
+
 get_backup_password() {
     # Same priority as keys-manage:
     #  1) KEYS_BACKUP_PASSWORD env var
@@ -316,7 +329,7 @@ decrypt_control_file() {
     # If the password is provided non-interactively, do not prompt/retry.
     if [[ -n "${KEYS_BACKUP_PASSWORD:-}" ]]; then
         password="$KEYS_BACKUP_PASSWORD"
-        decrypt_openssl_pbkdf2_atomic "$enc" "$plain" "$password" || return 1
+        decrypt_control_file_atomic "$enc" "$plain" "$password" || return 1
         return 0
     fi
 
@@ -326,7 +339,7 @@ decrypt_control_file() {
         attempts=$((attempts + 1))
 
         [[ -n "${password:-}" ]] || password="$(get_backup_password)" || return 1
-        if decrypt_openssl_pbkdf2_atomic "$enc" "$plain" "$password"; then
+        if decrypt_control_file_atomic "$enc" "$plain" "$password"; then
             return 0
         fi
 
@@ -416,16 +429,17 @@ ssh://git@github.com/*)
     ;;
 esac
 
-KEYS_REPO_CLONE_URL="" # if set, used for clone but stripped from origin afterwards
+KEYS_REPO_AUTH_URL="" # if set, temporarily used for fetch/clone then stripped from origin
+KEYS_REPO_CLONE_URL=""
 needs_bootstrap=false
-if ! git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+if ! GIT_TERMINAL_PROMPT=0 git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
     needs_bootstrap=true
 fi
 
 if [[ "$needs_bootstrap" == true ]]; then
     bootstrap_token=""
     if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
-        info "Cold start: using GH_TOKEN/GITHUB_TOKEN for HTTPS clone"
+        info "Cold start: using GH_TOKEN/GITHUB_TOKEN for HTTPS access"
         bootstrap_token="${GH_TOKEN:-$GITHUB_TOKEN}"
     elif [[ -t 0 || -t 1 ]] || [[ -e /dev/tty ]]; then
         # Interactive: install gh temporarily (aqua installs the permanent one
@@ -464,24 +478,50 @@ if [[ "$needs_bootstrap" == true ]]; then
     # `https://github.com/`, so the rewrite never triggers. (Relying on the gh
     # credential helper alone would not be enough — the helper is consulted
     # AFTER URL rewriting, by which point insteadOf has already sent us to SSH.)
-    # The token is stripped from `origin` immediately after clone completes.
-    KEYS_REPO_CLONE_URL="${KEYS_REPO_URL/https:\/\//https://oauth:${bootstrap_token}@}"
+    # The token is stripped from `origin` immediately after fetch/clone completes.
+    KEYS_REPO_AUTH_URL="${KEYS_REPO_URL/https:\/\//https://oauth:${bootstrap_token}@}"
+    KEYS_REPO_CLONE_URL="$KEYS_REPO_AUTH_URL"
     unset bootstrap_token
 fi
 
 mkdir -p "$(dirname "$REPO_DIR")"
 
+update_existing_keys_repo() {
+    local remote_url="${KEYS_REPO_AUTH_URL:-$KEYS_REPO_URL}"
+    local rc
+
+    (
+        cd "$REPO_DIR"
+        if git remote get-url origin >/dev/null 2>&1; then
+            git remote set-url origin "$remote_url"
+        else
+            git remote add origin "$remote_url"
+        fi
+    )
+
+    if (
+        cd "$REPO_DIR"
+        GIT_TERMINAL_PROMPT=0 git fetch origin --quiet
+        GIT_TERMINAL_PROMPT=0 git pull --ff-only --quiet
+    ); then
+        (cd "$REPO_DIR" && git remote set-url origin "$KEYS_REPO_URL")
+        return 0
+    else
+        rc=$?
+        (cd "$REPO_DIR" && git remote set-url origin "$KEYS_REPO_URL") || true
+        return "$rc"
+    fi
+}
+
 if [[ -d "$REPO_DIR/.git" ]]; then
     info "Updating existing keys repository: $REPO_DIR"
-    (cd "$REPO_DIR" && git remote get-url origin >/dev/null 2>&1) || (cd "$REPO_DIR" && git remote add origin "$KEYS_REPO_URL")
-    (cd "$REPO_DIR" && git fetch origin --quiet)
-    (cd "$REPO_DIR" && git pull --ff-only --quiet) || {
+    update_existing_keys_repo || {
         err "Failed to pull keys repository (ff-only)"
         exit 1
     }
 else
     info "Cloning keys repository..."
-    git clone "${KEYS_REPO_CLONE_URL:-$KEYS_REPO_URL}" "$REPO_DIR" || {
+    GIT_TERMINAL_PROMPT=0 git clone "${KEYS_REPO_CLONE_URL:-$KEYS_REPO_URL}" "$REPO_DIR" || {
         err "Failed to clone keys repository"
         exit 1
     }

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -397,38 +397,32 @@ fi
 info "Using keys repository: $KEYS_REPO_URL"
 
 # ─────────────────────────────────────────────────────────────
-# Cold-start auth bootstrap.
-# Probe whether the configured URL is reachable as-is. If not, set up an
-# HTTPS+token path so we can clone without a pre-existing SSH key.
+# HTTPS-only bootstrap.
+# Any SSH URL (legacy data from older configs) is normalized to HTTPS up
+# front; from here on everything is HTTPS. If the URL can be reached
+# directly (credential helper already configured or repo is public), we
+# clone it; otherwise we fall back to cold-start auth (PAT env or gh
+# device-code OAuth) and clone via an embedded-token URL that bypasses
+# any stale `insteadOf` rule still present in the global git config.
 # ─────────────────────────────────────────────────────────────
-KEYS_REPO_CLONE_URL="" # if set, used for clone but stripped from origin afterwards
-needs_bootstrap=false
 case "$KEYS_REPO_URL" in
-git@github.com:* | ssh://git@github.com/*)
-    if ! GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=5' \
-        git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
-        needs_bootstrap=true
-    fi
+git@github.com:*)
+    KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#git@github.com:}"
+    info "Normalizing SSH URL to HTTPS (SSH is deprecated): $KEYS_REPO_URL"
     ;;
-https://github.com/*)
-    if ! git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
-        needs_bootstrap=true
-    fi
+ssh://git@github.com/*)
+    KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#ssh://git@github.com/}"
+    info "Normalizing SSH URL to HTTPS (SSH is deprecated): $KEYS_REPO_URL"
     ;;
 esac
 
-if [[ "$needs_bootstrap" == true ]]; then
-    case "$KEYS_REPO_URL" in
-    git@github.com:*)
-        KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#git@github.com:}"
-        info "Cold start: rewriting keys repo to HTTPS: $KEYS_REPO_URL"
-        ;;
-    ssh://git@github.com/*)
-        KEYS_REPO_URL="https://github.com/${KEYS_REPO_URL#ssh://git@github.com/}"
-        info "Cold start: rewriting keys repo to HTTPS: $KEYS_REPO_URL"
-        ;;
-    esac
+KEYS_REPO_CLONE_URL="" # if set, used for clone but stripped from origin afterwards
+needs_bootstrap=false
+if ! git ls-remote "$KEYS_REPO_URL" HEAD >/dev/null 2>&1; then
+    needs_bootstrap=true
+fi
 
+if [[ "$needs_bootstrap" == true ]]; then
     bootstrap_token=""
     if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
         info "Cold start: using GH_TOKEN/GITHUB_TOKEN for HTTPS clone"

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -429,13 +429,10 @@ if [[ "$needs_bootstrap" == true ]]; then
         ;;
     esac
 
+    bootstrap_token=""
     if [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
-        # Unattended: embed PAT in the clone URL for this single operation.
-        # We rewrite origin afterwards so the token never persists in .git/config.
-        info "Cold start: using GH_TOKEN/GITHUB_TOKEN for one-shot HTTPS clone"
+        info "Cold start: using GH_TOKEN/GITHUB_TOKEN for HTTPS clone"
         bootstrap_token="${GH_TOKEN:-$GITHUB_TOKEN}"
-        KEYS_REPO_CLONE_URL="${KEYS_REPO_URL/https:\/\//https://oauth:${bootstrap_token}@}"
-        unset bootstrap_token
     elif [[ -t 0 || -t 1 ]] || [[ -e /dev/tty ]]; then
         # Interactive: install gh temporarily (aqua installs the permanent one
         # in step 05) and run device-code OAuth. Works on headless SSH sessions.
@@ -454,8 +451,11 @@ if [[ "$needs_bootstrap" == true ]]; then
                 exit 1
             }
         fi
-        # Configure git credential helper so the upcoming clone uses the gh token.
-        gh auth setup-git -h github.com >/dev/null 2>&1 || true
+        bootstrap_token="$(gh auth token -h github.com 2>/dev/null)" || true
+        if [[ -z "$bootstrap_token" ]]; then
+            err "Failed to obtain auth token from gh"
+            exit 1
+        fi
     else
         err "Cannot reach $KEYS_REPO_URL and no auth method is available."
         err "Either:"
@@ -463,6 +463,16 @@ if [[ "$needs_bootstrap" == true ]]; then
         err "  - or run with an interactive TTY        (gh device-code OAuth)"
         exit 1
     fi
+
+    # Embed token directly in the clone URL. This bypasses any pre-existing
+    # `[url ...] insteadOf` rule from a prior apply: insteadOf matches by URL
+    # prefix, and `https://oauth:TOKEN@github.com/...` does NOT start with
+    # `https://github.com/`, so the rewrite never triggers. (Relying on the gh
+    # credential helper alone would not be enough — the helper is consulted
+    # AFTER URL rewriting, by which point insteadOf has already sent us to SSH.)
+    # The token is stripped from `origin` immediately after clone completes.
+    KEYS_REPO_CLONE_URL="${KEYS_REPO_URL/https:\/\//https://oauth:${bootstrap_token}@}"
+    unset bootstrap_token
 fi
 
 mkdir -p "$(dirname "$REPO_DIR")"

--- a/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
@@ -37,4 +37,11 @@ else
     exit 0
 fi
 
+# Re-approve the policy file whenever its hash changes, otherwise aqua's
+# policy gate rejects non-standard registry packages with code 002.
+aqua_policy_path="${AQUA_POLICY_CONFIG:-$HOME/.config/aquaproj-aqua/aqua-policy.yaml}"
+if [[ -f "$aqua_policy_path" ]]; then
+    "$aqua_cmd" policy allow "$aqua_policy_path"
+fi
+
 "$aqua_cmd" install

--- a/.chezmoiscripts/run_onchange_after_06_setup-gopass.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_06_setup-gopass.sh.tmpl
@@ -2,6 +2,12 @@
 # Setup gopass on new device
 # Prerequisites: age encryption key already restored by 01_setup-encryption-key.sh
 set -euo pipefail
+{{- $gopassRepository := .gopassRepository -}}
+{{- if hasPrefix "git@github.com:" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $gopassRepository) -}}
+{{- else if hasPrefix "ssh://git@github.com/" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $gopassRepository) -}}
+{{- end }}
 
 # Ensure aqua-managed CLIs are discoverable for this non-interactive shell.
 aqua_bin_dir="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin"
@@ -37,7 +43,7 @@ echo "Clone gopass password store from Git"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "This will clone your password store from:"
-echo "  {{ .gopassRepository }}"
+echo "  {{ $gopassRepository }}"
 echo ""
 echo "Note: ~/.config/gopass/config is already configured by chezmoi"
 echo "      It points to ~/.ssh/main for age decryption"
@@ -52,7 +58,7 @@ fi
 if [[ "$confirm" != "yes" ]]; then
     echo ""
     echo "Skipped. You can clone later with:"
-    echo "  gopass clone {{ .gopassRepository | quote }}"
+    printf '  gopass clone %s\n' {{ $gopassRepository | quote }}
     echo ""
     exit 0
 fi
@@ -67,7 +73,7 @@ fi
 echo ""
 echo "Cloning password store..."
 # --check-keys=false: Don't generate new keys, use existing SSH key
-gopass clone --check-keys=false {{ .gopassRepository | quote }}
+gopass clone --check-keys=false {{ $gopassRepository | quote }}
 
 echo ""
 echo "✓ gopass password store cloned successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           gitEmail = "ci@test.com"
           useEncryption = false
           headless = true
-          gopassRepository = "git@github.com:test/pass.git"
-          keysRepository = "git@github.com:test/keys.git"
+          gopassRepository = "https://github.com/test/pass.git"
+          keysRepository = "https://github.com/test/keys.git"
           EOF
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   nix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,8 +115,8 @@ repos:
           gitEmail = "test@test.com"
           useEncryption = false
           headless = false
-          gopassRepository = "git@github.com:test/pass.git"
-          keysRepository = "git@github.com:test/keys.git"
+          gopassRepository = "https://github.com/test/pass.git"
+          keysRepository = "https://github.com/test/keys.git"
           codexProviderAccount = "openai"
           EOF
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -184,7 +184,7 @@
 ### 方法 1: `init.sh` を直接実行
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
 ```
 
 ### 方法 2: タグ/ブランチを固定して確認後に実行
@@ -211,7 +211,7 @@ git checkout <tag-or-commit>
 ./init.sh --repo signalridge/dotfiles
 ./init.sh --ref v1.2.3
 ./init.sh --depth 1
-./init.sh --ssh
+DOTFILES_USE_ENCRYPTION=false ./init.sh
 ```
 
 ---
@@ -226,7 +226,7 @@ git checkout <tag-or-commit>
 - `installMasApps`（MAS アプリを導入するか）
 - `claudeProviderAccount` / `codexProviderAccount`
 
-このリポジトリを初回利用する場合、keys-manage バックアップと鍵を自分で用意していない限り、`useEncryption = false` を推奨します。
+このリポジトリを初回利用する場合、keys-manage バックアップと鍵を自分で用意していない限り、`useEncryption = false` を推奨します。非対話で実行する場合は、`DOTFILES_USE_ENCRYPTION=false` または `DOTFILES_USE_ENCRYPTION=true` を明示してください。
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -181,11 +181,16 @@
 > このリポジトリはシェル、パッケージマネージャ、システム設定を変更します。
 > 本番利用前に Fork して内容を確認してください。
 
-### 方法 1: `init.sh` を直接実行
+### 方法 1: `init.sh` をダウンロードして対話実行
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh -o /tmp/init.sh
+sh /tmp/init.sh
 ```
+
+> なぜ `curl … | sh` ではないのか？
+> `chezmoi init` は hostname / GitHub ユーザー名 / メールなどを対話的に尋ねます。
+> パイプ実行だと stdin が curl に奪われ、prompt が TTY から読み取れずインストールが失敗します（または placeholder 値がそのまま書かれます）。先にダウンロードしてから `sh /tmp/init.sh` を実行すれば TTY が保たれます。
 
 ### 方法 2: タグ/ブランチを固定して確認後に実行
 
@@ -226,7 +231,9 @@ DOTFILES_USE_ENCRYPTION=false ./init.sh
 - `installMasApps`（MAS アプリを導入するか）
 - `claudeProviderAccount` / `codexProviderAccount`
 
-このリポジトリを初回利用する場合、keys-manage バックアップと鍵を自分で用意していない限り、`useEncryption = false` を推奨します。非対話で実行する場合は、`DOTFILES_USE_ENCRYPTION=false` または `DOTFILES_USE_ENCRYPTION=true` を明示してください。
+このリポジトリを初回利用する場合、keys-manage バックアップと鍵を自分で用意していない限り、`useEncryption = false` を推奨します。
+
+> 初回インストールは対話実行が前提です：身分関連の prompt（`hostname` / `gitUsername` / `useremail` / `gitEmail`）には安全な default がなく、TTY が無いと明示的に fail します。方式 1 の「ダウンロードしてから実行」を使ってください（`curl | sh` は NG）。`~/.config/chezmoi/chezmoi.toml` に既に値が書かれているマシンで再 apply する場合は prompt がスキップされ、その場面では `DOTFILES_USE_ENCRYPTION=true|false` で encryption フラグを環境変数から上書きできます。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The `chezmoi` script chain is staged and numbered:
 ### Option 1: Run `init.sh` directly
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
 ```
 
 ### Option 2: Pin to a tag/branch and review first
@@ -211,7 +211,7 @@ git checkout <tag-or-commit>
 ./init.sh --repo signalridge/dotfiles
 ./init.sh --ref v1.2.3
 ./init.sh --depth 1
-./init.sh --ssh
+DOTFILES_USE_ENCRYPTION=false ./init.sh
 ```
 
 ---
@@ -226,7 +226,7 @@ git checkout <tag-or-commit>
 - `installMasApps` (macOS App Store apps)
 - `claudeProviderAccount` / `codexProviderAccount`
 
-For most first-time users of this repo: keep `useEncryption = false` unless you have your own keys-manage backup repo and key material.
+For most first-time users of this repo: keep `useEncryption = false` unless you have your own keys-manage backup repo and key material. When running non-interactively, set `DOTFILES_USE_ENCRYPTION=false` or `DOTFILES_USE_ENCRYPTION=true` explicitly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -181,11 +181,16 @@ The `chezmoi` script chain is staged and numbered:
 > This repository modifies shell, package managers, and system settings.
 > Fork and review before running on a machine you care about.
 
-### Option 1: Run `init.sh` directly
+### Option 1: Download `init.sh` then run interactively
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh -o /tmp/init.sh
+sh /tmp/init.sh
 ```
+
+> Why not `curl … | sh`?
+> `chezmoi init` prompts for hostname, GitHub username, email, etc.
+> Piping into `sh` detaches stdin from your terminal, so those prompts have nothing to read from and the install bails out (or worse, would silently write placeholder values). Download first, then run — `sh /tmp/init.sh` keeps your TTY attached.
 
 ### Option 2: Pin to a tag/branch and review first
 
@@ -226,7 +231,9 @@ DOTFILES_USE_ENCRYPTION=false ./init.sh
 - `installMasApps` (macOS App Store apps)
 - `claudeProviderAccount` / `codexProviderAccount`
 
-For most first-time users of this repo: keep `useEncryption = false` unless you have your own keys-manage backup repo and key material. When running non-interactively, set `DOTFILES_USE_ENCRYPTION=false` or `DOTFILES_USE_ENCRYPTION=true` explicitly.
+For most first-time users of this repo: keep `useEncryption = false` unless you have your own keys-manage backup repo and key material.
+
+> First-run is interactive. Identity prompts (`hostname`, `gitUsername`, `useremail`, `gitEmail`) have no safe default and will hard-fail if there's no TTY — use Option 1's download-then-run pattern, not pipe-to-sh. On a re-apply where `~/.config/chezmoi/chezmoi.toml` already has these values, prompts are skipped; `DOTFILES_USE_ENCRYPTION=true|false` lets you override the encryption flag from the environment in that case.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,7 +182,7 @@
 ### 方式 1：直接运行 `init.sh`
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
 ```
 
 ### 方式 2：固定 tag/branch 并先审阅
@@ -209,7 +209,7 @@ git checkout <tag-or-commit>
 ./init.sh --repo signalridge/dotfiles
 ./init.sh --ref v1.2.3
 ./init.sh --depth 1
-./init.sh --ssh
+DOTFILES_USE_ENCRYPTION=false ./init.sh
 ```
 
 ---
@@ -224,7 +224,7 @@ git checkout <tag-or-commit>
 - `installMasApps`（是否安装 MAS 应用）
 - `claudeProviderAccount` / `codexProviderAccount`
 
-对大多数首次使用者：除非你已经有自己的 keys-manage 备份仓库与密钥材料，否则建议保持 `useEncryption = false`。
+对大多数首次使用者：除非你已经有自己的 keys-manage 备份仓库与密钥材料，否则建议保持 `useEncryption = false`。非交互运行时，请显式设置 `DOTFILES_USE_ENCRYPTION=false` 或 `DOTFILES_USE_ENCRYPTION=true`。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -179,11 +179,16 @@
 > 本仓库会修改 shell、包管理器和系统配置。
 > 建议先 Fork 并审阅，再用于生产机器。
 
-### 方式 1：直接运行 `init.sh`
+### 方式 1：先下载 `init.sh` 再交互运行
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh | DOTFILES_USE_ENCRYPTION=false sh
+curl -fsSL https://raw.githubusercontent.com/signalridge/dotfiles/main/init.sh -o /tmp/init.sh
+sh /tmp/init.sh
 ```
+
+> 为什么不用 `curl … | sh`？
+> `chezmoi init` 会交互式询问 hostname、GitHub 用户名、邮箱等。
+> 管道把 stdin 接到了 curl，prompt 没有 TTY 可读，安装会直接报错（或者更糟，悄悄写入占位值）。先下载再 `sh /tmp/init.sh`，终端就还在。
 
 ### 方式 2：固定 tag/branch 并先审阅
 
@@ -224,7 +229,9 @@ DOTFILES_USE_ENCRYPTION=false ./init.sh
 - `installMasApps`（是否安装 MAS 应用）
 - `claudeProviderAccount` / `codexProviderAccount`
 
-对大多数首次使用者：除非你已经有自己的 keys-manage 备份仓库与密钥材料，否则建议保持 `useEncryption = false`。非交互运行时，请显式设置 `DOTFILES_USE_ENCRYPTION=false` 或 `DOTFILES_USE_ENCRYPTION=true`。
+对大多数首次使用者：除非你已经有自己的 keys-manage 备份仓库与密钥材料，否则建议保持 `useEncryption = false`。
+
+> 首次安装必须交互执行：身份相关 prompt（`hostname` / `gitUsername` / `useremail` / `gitEmail`）没有安全默认值，无 TTY 时会直接 fail。请用方式 1 的"先下载再运行"模式，**不要** `curl | sh`。在 `~/.config/chezmoi/chezmoi.toml` 已经写入这些值的机器上 re-apply 时 prompt 会被跳过；此场景下可以用 `DOTFILES_USE_ENCRYPTION=true|false` 通过环境变量覆盖加密开关。
 
 ---
 

--- a/docs/gopass-new-device-setup.md
+++ b/docs/gopass-new-device-setup.md
@@ -38,7 +38,7 @@ Type `yes` to auto-clone.
 
 ```bash
 # Get repository URL from your dotfiles configuration
-REPO_URL=$(yq -r '.gopass.repository // "git@github.com:signalridge/password-store.git"' ~/.chezmoidata/gopass.yaml 2>/dev/null || echo "git@github.com:signalridge/password-store.git")
+REPO_URL=$(yq -r '.gopass.repository // "https://github.com/signalridge/password-store.git"' ~/.chezmoidata/gopass.yaml 2>/dev/null || echo "https://github.com/signalridge/password-store.git")
 
 gopass clone "$REPO_URL"
 ```
@@ -116,14 +116,14 @@ The `.age-recipients` file is already in the Git repository and will be automati
 
 ```yaml
 gopass:
-  repository: git@github.com:YOUR_USERNAME/password-store.git
+  repository: https://github.com/YOUR_USERNAME/password-store.git
 ```
 
 ### Method 2: Use in Scripts
 
 ```bash
 # In setup scripts or manual commands
-GOPASS_REPO=$(yq -r '.gopass.repository' ~/.chezmoidata/gopass.yaml 2>/dev/null || echo "git@github.com:signalridge/password-store.git")
+GOPASS_REPO=$(yq -r '.gopass.repository' ~/.chezmoidata/gopass.yaml 2>/dev/null || echo "https://github.com/signalridge/password-store.git")
 
 gopass clone "$GOPASS_REPO"
 ```
@@ -137,17 +137,23 @@ gopass clone "$GOPASS_REPO"
 If you want to avoid prompts:
 
 ```bash
-export KEYS_REPO=git@github.com:YOUR_USERNAME/keypairs.git
+export KEYS_REPO=https://github.com/YOUR_USERNAME/keypairs.git
 export KEYS_BACKUP_PASSWORD='...'
+# Headless/unattended: also export a PAT so gh's credential helper can supply
+# the token without an interactive `gh auth login`.
+export GH_TOKEN=<PAT-with-repo-scope>
 chezmoi apply
 ```
 
 ### Error: gopass clone fails
 
-**Solution:** Check SSH key is added to GitHub:
+**Solution:** HTTPS clone needs `gh` to be authenticated. Check status:
 
 ```bash
-ssh -T git@github.com
+gh auth status
+
+# If not logged in (device-code flow, works on headless SSH sessions):
+gh auth login -h github.com -p https
 ```
 
 ### Error: Cannot decrypt passwords

--- a/docs/keys-manage-guide.md
+++ b/docs/keys-manage-guide.md
@@ -424,15 +424,21 @@ Use yazi in FZF menu to add custom files under `$HOME`.
 Configure in `~/.local/share/chezmoi/.chezmoidata/keys.yaml`:
 
 ```yaml
-keysRepository: git@github.com:username/keys-backup.git
+keysRepository: https://github.com/username/keys-backup.git
 ```
 
 Or in `~/.config/chezmoi/chezmoi.toml`:
 
 ```toml
 [data]
-    keysRepository = "git@github.com:username/keys-backup.git"
+    keysRepository = "https://github.com/username/keys-backup.git"
 ```
+
+Authentication is handled by the `gh` credential helper declared in
+`~/.config/git/config` — `gh auth login` once on each machine and HTTPS
+private-repo access is automatic. SSH URLs (`git@github.com:...`) still
+work if you prefer them, but cold-start hosts without an SSH key will
+fall back to gh OAuth or `GH_TOKEN` automatically.
 
 ## Encryption Details
 
@@ -478,11 +484,14 @@ git push
 ### Authentication failed
 
 ```bash
-# Test SSH connection
-ssh -T git@github.com
+# Check gh auth status (default HTTPS path)
+gh auth status
 
-# Add SSH key
-ssh-add ~/.ssh/your_key
+# Re-authenticate if needed (device code works on headless)
+gh auth login -h github.com -p https
+
+# Or use a PAT for unattended hosts
+export GH_TOKEN=<PAT-with-repo-scope>
 
 # Verify repository URL
 git -C ~/.local/share/keys-backup remote get-url origin
@@ -621,7 +630,7 @@ Password saved to gopass (keys-manage/password)
 # Check status
 $ keys-manage status
 Repository: /home/user/.local/share/keys-backup
-  Remote: git@github.com:user/keys-backup.git
+  Remote: https://github.com/user/keys-backup.git
   Current: abc1234 - Backup: 3 files (2 hours ago)
   Total backups: 15
 

--- a/docs/keys-manage-guide.md
+++ b/docs/keys-manage-guide.md
@@ -436,9 +436,9 @@ Or in `~/.config/chezmoi/chezmoi.toml`:
 
 Authentication is handled by the `gh` credential helper declared in
 `~/.config/git/config` — `gh auth login` once on each machine and HTTPS
-private-repo access is automatic. SSH URLs (`git@github.com:...`) still
-work if you prefer them, but cold-start hosts without an SSH key will
-fall back to gh OAuth or `GH_TOKEN` automatically.
+private-repo access is automatic. SSH URLs are deprecated; any legacy
+`git@github.com:...` value in user data is auto-normalized to HTTPS at
+bootstrap time, but new setups should use HTTPS URLs exclusively.
 
 ## Encryption Details
 

--- a/dot_local/bin/executable_codex-manage
+++ b/dot_local/bin/executable_codex-manage
@@ -354,7 +354,7 @@ cmd_remove_account() {
         fi
     fi
 
-    log_warn "Account profile is template-managed; to fully remove, update dot_codex/config.toml.tmpl"
+    log_warn "Account profile is template-managed; to fully remove, update dot_codex/modify_config.toml.tmpl"
 }
 
 # Add API key

--- a/dot_local/bin/executable_keys-manage.tmpl
+++ b/dot_local/bin/executable_keys-manage.tmpl
@@ -12,7 +12,13 @@ source "$SCRIPT_DIR/lib/common"
 # ===== Constants =====
 
 # Paths from chezmoi data
-KEYS_REPO="{{ .keysRepository }}"
+{{- $keysRepository := .keysRepository -}}
+{{- if hasPrefix "git@github.com:" $keysRepository -}}
+{{-   $keysRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $keysRepository) -}}
+{{- else if hasPrefix "ssh://git@github.com/" $keysRepository -}}
+{{-   $keysRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $keysRepository) -}}
+{{- end }}
+KEYS_REPO="{{ $keysRepository }}"
 REPO_DIR="$HOME/.local/share/keys-backup"
 BACKUP_FILES_DIR="backup-files"  # Generic directory for all backed up files
 BACKUP_LIST="$REPO_DIR/backup-list.txt"

--- a/dot_local/bin/lib/keys-manage/backup.sh
+++ b/dot_local/bin/lib/keys-manage/backup.sh
@@ -69,7 +69,7 @@ cmd_init() {
         echo ""
         echo "Example (~/.config/chezmoi/chezmoi.toml):"
         echo "  [data]"
-        echo "  keysRepository = \"git@github.com:username/keypairs.git\""
+        echo "  keysRepository = \"https://github.com/username/keypairs.git\""
         return 1
     fi
 
@@ -106,18 +106,20 @@ cmd_init() {
             return 1
         elif echo "$error_content" | grep -q "not found\|does not exist"; then
             log_note "Repository does not exist yet (first time setup)"
-        elif echo "$error_content" | grep -q "Authentication\|Permission denied\|publickey"; then
+        elif echo "$error_content" | grep -q "Authentication\|Permission denied\|publickey\|could not read Username"; then
             log_error "Authentication failed"
             echo ""
-            echo "Possible causes:"
-            echo "  - SSH key not added to git server"
-            echo "  - Wrong repository URL"
-            echo "  - Insufficient permissions"
+            echo "Possible causes (HTTPS):"
+            echo "  - gh not authenticated on this machine"
+            echo "  - gh credential helper not configured"
+            echo "  - Wrong repository URL / insufficient permissions"
             echo ""
             echo "To fix:"
-            echo "  1. Add your SSH key: ssh-add ~/.ssh/your_key"
-            echo "  2. Test connection: ssh -T git@github.com (or your git server)"
-            echo "  3. Verify repository URL: $KEYS_REPO"
+            echo "  1. Authenticate gh:   gh auth login -h github.com -p https"
+            echo "                        (use device code on headless hosts; no -w)"
+            echo "  2. Verify:            gh auth status"
+            echo "  3. For unattended:    export GH_TOKEN=<PAT-with-repo-scope>"
+            echo "  4. Verify URL:        $KEYS_REPO"
             return 1
         fi
 

--- a/dot_local/bin/lib/keys-manage/backup.sh
+++ b/dot_local/bin/lib/keys-manage/backup.sh
@@ -18,6 +18,9 @@ cmd_init() {
             return 1
         }
 
+        # Upgrade legacy SSH origin to HTTPS (HTTPS-only auth via gh helper).
+        normalize_github_origin "$REPO_DIR"
+
         # Ensure the repo is on the new "encrypted control files" layout.
         ensure_repo_ignores_plain_control_files
 

--- a/dot_local/bin/lib/keys-manage/core.sh
+++ b/dot_local/bin/lib/keys-manage/core.sh
@@ -1076,6 +1076,25 @@ yazi_select_files() {
 
 # ===== Git Operations =====
 
+# Rewrite a legacy GitHub SSH origin URL to HTTPS so the gh credential helper
+# handles auth. Idempotent and silent when nothing needs changing.
+normalize_github_origin() {
+    local repo_dir="${1:-.}"
+    [[ -d "$repo_dir/.git" ]] || return 0
+    local cur new=""
+    cur=$(git -C "$repo_dir" remote get-url origin 2>/dev/null) || return 0
+    case "$cur" in
+    git@github.com:*)
+        new="https://github.com/${cur#git@github.com:}"
+        ;;
+    ssh://git@github.com/*)
+        new="https://github.com/${cur#ssh://git@github.com/}"
+        ;;
+    esac
+    [[ -n "$new" ]] || return 0
+    git -C "$repo_dir" remote set-url origin "$new" 2>/dev/null && log_info "Normalized SSH origin to HTTPS: $new"
+}
+
 # Check git sync status with remote
 # Returns: 0=in sync, 1=ahead, 2=behind, 3=diverged, 4=no remote, 5=offline
 check_git_sync_status() {
@@ -1086,7 +1105,10 @@ check_git_sync_status() {
         return 4
     fi
 
-    # Fetch remote without pulling
+    normalize_github_origin "$REPO_DIR"
+
+    # Fetch remote without pulling. After normalization origin should be HTTPS,
+    # but keep GIT_SSH_COMMAND as a safety net for non-GitHub SSH remotes.
     local fetch_timeout ssh_cmd
     fetch_timeout="${KEYS_GIT_FETCH_TIMEOUT_SEC:-12}"
     ssh_cmd="${GIT_SSH_COMMAND:-ssh -o BatchMode=yes -o ConnectTimeout=8}"

--- a/dot_local/bin/lib/keys-manage/core.sh
+++ b/dot_local/bin/lib/keys-manage/core.sh
@@ -1274,13 +1274,14 @@ safe_git_push() {
         echo "  2. Resolve any conflicts"
         echo "  3. Run backup again"
         return 1
-    elif echo "$error_content" | grep -q "Authentication\|Permission denied"; then
+    elif echo "$error_content" | grep -q "Authentication\|Permission denied\|could not read Username"; then
         log_error "Authentication failed"
         echo ""
         echo "  Cannot push to remote (permission denied)"
         echo ""
-        echo "  To fix:"
-        echo "  - Check SSH key: ssh -T git@github.com"
+        echo "  To fix (HTTPS via gh credential helper):"
+        echo "  - Check auth status: gh auth status"
+        echo "  - Re-authenticate:   gh auth login -h github.com -p https"
         echo "  - Verify repository access rights"
         return 1
     else

--- a/init.sh
+++ b/init.sh
@@ -14,26 +14,30 @@ Usage: init.sh [options] [-- <chezmoi init flags>]
 
 Options:
   --repo <repo>     Repo to init from (default: signalridge)
-                   Examples: signalridge, signalridge/dotfiles, git@github.com:signalridge/dotfiles.git
+                   Examples: signalridge, signalridge/dotfiles, https://github.com/signalridge/dotfiles.git
   --ref <ref>       Branch or tag to checkout (maps to: chezmoi init --branch)
   --depth <n>       Shallow clone depth (maps to: chezmoi init --depth)
-  --ssh             Use SSH when guessing repo URL (maps to: chezmoi init --ssh)
   -h, --help        Show this help
 
 Environment:
-  DOTFILES_REPO / DOTFILES_REF / DOTFILES_DEPTH / DOTFILES_SSH
+  DOTFILES_REPO / DOTFILES_REF / DOTFILES_DEPTH
+  DOTFILES_USE_ENCRYPTION  Set to "true"/"false" to skip the encryption prompt
+                           (required when running non-interactively, e.g. `curl | sh`).
+
+Note: this bootstrap is HTTPS-only. SSH is deprecated for keys-backup /
+gopass repos; auth is handled via the gh credential helper declared in
+the chezmoi-managed git config.
 
 Examples:
   ./init.sh
   ./init.sh --ref <tag-or-branch>
-  curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh | sh -s -- --ref <tag-or-branch>
+  DOTFILES_USE_ENCRYPTION=true curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh | sh -s -- --ref <tag-or-branch>
 EOF
 }
 
 repo="${DOTFILES_REPO:-signalridge}"
 ref="${DOTFILES_REF:-}"
 depth="${DOTFILES_DEPTH:-}"
-ssh="${DOTFILES_SSH:-}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -66,7 +70,8 @@ while [ $# -gt 0 ]; do
         }
         ;;
     --ssh)
-        ssh=1
+        echo "error: --ssh is no longer supported (HTTPS-only bootstrap). Auth flows through the gh credential helper." >&2
+        exit 2
         ;;
     --)
         shift
@@ -112,9 +117,6 @@ if [ -f "$script_dir/.chezmoiroot" ] || [ -f "$script_dir/.chezmoi.toml.tmpl" ];
     exec "$chezmoi" init --apply --source "$script_dir" "$@"
 else
     # Piped from curl/wget - clone from GitHub instead
-    if [ -n "$ssh" ]; then
-        set -- --ssh "$@"
-    fi
     if [ -n "$depth" ]; then
         set -- --depth "$depth" "$@"
     fi

--- a/init.sh
+++ b/init.sh
@@ -25,19 +25,39 @@ Environment:
                            (required when running non-interactively, e.g. `curl | sh`).
 
 Note: this bootstrap is HTTPS-only. SSH is deprecated for keys-backup /
-gopass repos; auth is handled via the gh credential helper declared in
-the chezmoi-managed git config.
+gopass repos and GitHub init repo URLs. Auth is handled via the gh
+credential helper declared in the chezmoi-managed git config.
 
 Examples:
   ./init.sh
   ./init.sh --ref <tag-or-branch>
-  DOTFILES_USE_ENCRYPTION=true curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh | sh -s -- --ref <tag-or-branch>
+  curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh | DOTFILES_USE_ENCRYPTION=false sh -s -- --ref <tag-or-branch>
 EOF
 }
 
 repo="${DOTFILES_REPO:-signalridge}"
 ref="${DOTFILES_REF:-}"
 depth="${DOTFILES_DEPTH:-}"
+
+normalize_repo() {
+    case "$1" in
+    git@github.com:*)
+        printf 'https://github.com/%s\n' "${1#git@github.com:}"
+        ;;
+    ssh://git@github.com/*)
+        printf 'https://github.com/%s\n' "${1#ssh://git@github.com/}"
+        ;;
+    https://github.com/*)
+        printf '%s\n' "$1"
+        ;;
+    */*)
+        printf 'https://github.com/%s.git\n' "${1%.git}"
+        ;;
+    *)
+        printf 'https://github.com/%s/dotfiles.git\n' "$1"
+        ;;
+    esac
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -117,6 +137,7 @@ if [ -f "$script_dir/.chezmoiroot" ] || [ -f "$script_dir/.chezmoi.toml.tmpl" ];
     exec "$chezmoi" init --apply --source "$script_dir" "$@"
 else
     # Piped from curl/wget - clone from GitHub instead
+    repo="$(normalize_repo "$repo")"
     if [ -n "$depth" ]; then
         set -- --depth "$depth" "$@"
     fi

--- a/init.sh
+++ b/init.sh
@@ -21,17 +21,24 @@ Options:
 
 Environment:
   DOTFILES_REPO / DOTFILES_REF / DOTFILES_DEPTH
-  DOTFILES_USE_ENCRYPTION  Set to "true"/"false" to skip the encryption prompt
-                           (required when running non-interactively, e.g. `curl | sh`).
+  DOTFILES_USE_ENCRYPTION  Override the encryption flag on re-apply
+                           ("true" or "false"). Does NOT make first-run
+                           non-interactive — identity prompts still
+                           require a TTY.
 
 Note: this bootstrap is HTTPS-only. SSH is deprecated for keys-backup /
 gopass repos and GitHub init repo URLs. Auth is handled via the gh
 credential helper declared in the chezmoi-managed git config.
 
+First-run is interactive. Don't pipe into `sh` — download then run, so
+chezmoi's prompts can read from your terminal:
+
+  curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh -o /tmp/init.sh
+  sh /tmp/init.sh --ref <tag-or-branch>
+
 Examples:
   ./init.sh
   ./init.sh --ref <tag-or-branch>
-  curl -fsLS https://raw.githubusercontent.com/signalridge/dotfiles/<tag-or-branch>/init.sh | DOTFILES_USE_ENCRYPTION=false sh -s -- --ref <tag-or-branch>
 EOF
 }
 

--- a/private_dot_config/aquaproj-aqua/aqua-policy.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua-policy.yaml
@@ -1,8 +1,7 @@
 ---
 # Aqua policy file: allow-list for non-standard registries.
-# After chezmoi apply, activate once with:
-#   aqua policy allow ~/.config/aquaproj-aqua/aqua-policy.yaml
-# AQUA_POLICY_CONFIG (set in ~/.zshenv) points aqua at this file.
+# Auto-allowed by .chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
+# on every `chezmoi apply`; AQUA_POLICY_CONFIG (set in ~/.zshenv) points aqua here.
 
 registries:
   - type: standard

--- a/private_dot_config/gh/private_hosts.yml.tmpl
+++ b/private_dot_config/gh/private_hosts.yml.tmpl
@@ -1,5 +1,5 @@
 github.com:
-  git_protocol: ssh
+  git_protocol: https
   users:
     {{ .gitUsername }}:
   user: {{ .gitUsername }}

--- a/private_dot_config/git/config.tmpl
+++ b/private_dot_config/git/config.tmpl
@@ -83,14 +83,14 @@
     rsq = rebase -i --autosquash
 
 # ─────────────────────────────────────────────────────────────
-# URL Rewriting - Use SSH instead of HTTPS for git operations
-# This allows using SSH keys for authentication
+# HTTPS auth via gh credential helper.
+# Covers all three auth scenarios with one config:
+#   - Interactive local:        `gh auth login -w` (browser OAuth)
+#   - Interactive headless:     `gh auth login`    (device-code, no -w)
+#   - Unattended (CI/cron):     export GH_TOKEN=ghp_xxx (gh reads env)
+# `gh auth git-credential get` returns whichever token gh has — OAuth-stored
+# or env-var. No `insteadOf` rewrites: HTTPS is the one true protocol.
 # ─────────────────────────────────────────────────────────────
-[url "ssh://git@github.com/"]
-    insteadOf = https://github.com/
-
-[url "ssh://git@gitlab.com/"]
-    insteadOf = https://gitlab.com/
-
-[url "ssh://git@bitbucket.org/"]
-    insteadOf = https://bitbucket.org/
+[credential "https://github.com"]
+    helper =
+    helper = !gh auth git-credential

--- a/private_dot_config/gopass/config.tmpl
+++ b/private_dot_config/gopass/config.tmpl
@@ -1,12 +1,18 @@
 # gopass configuration file
 # Managed by chezmoi - do not edit manually
+{{- $gopassRepository := .gopassRepository -}}
+{{- if hasPrefix "git@github.com:" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $gopassRepository) -}}
+{{- else if hasPrefix "ssh://git@github.com/" $gopassRepository -}}
+{{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $gopassRepository) -}}
+{{- end }}
 
 [mounts]
 	crypto = age
 	path = {{ .chezmoi.homeDir }}/.local/share/gopass/stores/root
 
 [mounts.root]
-	source_url = {{ .gopassRepository }}
+	source_url = {{ $gopassRepository }}
 
 [age]
 	ssh-key-path = {{ .chezmoi.homeDir }}/.ssh/main

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,6 +11,7 @@ echo "== Running bootstrap tests =="
 
 python3 "$ROOT/tests/test_setup_encryption_key.py"
 bash "$ROOT/tests/test_init_args.sh"
+bash "$ROOT/tests/test_github_https_normalization.sh"
 bash "$ROOT/tests/test_install_nix_arch.sh"
 bash "$ROOT/tests/test_chezmoiignore.sh"
 bash "$ROOT/tests/test_setup_gopass.sh"

--- a/tests/test_codex_config_rendering.sh
+++ b/tests/test_codex_config_rendering.sh
@@ -45,10 +45,12 @@ assert_file_not_contains() {
     fi
 }
 
+MODIFY_SCRIPT="$TMP_ROOT/modify_config.sh"
 RENDERED="$TMP_ROOT/config.toml"
-chezmoi execute-template --source "$ROOT" <"$ROOT/dot_codex/config.toml.tmpl" >"$RENDERED"
+chezmoi execute-template --source "$ROOT" <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$MODIFY_SCRIPT"
+bash "$MODIFY_SCRIPT" </dev/null >"$RENDERED"
 
-assert_file_contains "$RENDERED" 'model = "gpt-5.4"'
+assert_file_contains "$RENDERED" 'model = "gpt-5.5"'
 assert_file_contains "$RENDERED" 'model_reasoning_effort = "xhigh"'
 assert_file_not_contains "$RENDERED" 'service_tier ='
 assert_file_contains "$RENDERED" 'fast_mode = false'

--- a/tests/test_github_https_normalization.sh
+++ b/tests/test_github_https_normalization.sh
@@ -27,6 +27,7 @@ cat >"$CONFIG" <<'EOF'
 hostname = "test"
 work = false
 private = true
+useremail = "test@example.com"
 homeWifiSSIDs = ""
 platform = "darwin"
 installMasApps = false
@@ -141,6 +142,26 @@ if require_cmd git; then
         "git@gitlab.com:test/keys.git" \
         "git@gitlab.com:test/keys.git" \
         "non-github SSH untouched"
+
+    # Runtime: run_before_01 has an earlier fast-path origin normalizer that
+    # must not depend on later helper functions being defined.
+    rendered_run_before="$TMP_ROOT/run_before_01.sh"
+    render .chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl >"$rendered_run_before"
+    chmod +x "$rendered_run_before"
+
+    fast_home="$TMP_ROOT/run-before-home"
+    fast_repo="$fast_home/.local/share/keys-backup"
+    mkdir -p "$fast_repo/backup-files" "$fast_home/.ssh"
+    touch "$fast_home/.ssh/main" "$fast_repo/backup-list.txt"
+    git -C "$fast_repo" init -q
+    git -C "$fast_repo" remote add origin "git@github.com:test/keys.git"
+
+    HOME="$fast_home" KEYS_REPO="https://github.com/test/keys.git" bash "$rendered_run_before" >/dev/null
+    fast_origin="$(git -C "$fast_repo" remote get-url origin)"
+    if [[ "$fast_origin" != "https://github.com/test/keys.git" ]]; then
+        echo "run_before_01 fast path: expected HTTPS origin, got '$fast_origin'" >&2
+        exit 1
+    fi
 fi
 
 # ─────────────────────────────────────────────────────────────
@@ -170,5 +191,34 @@ assert_identity_render_fails_without_tty() {
 }
 
 assert_identity_render_fails_without_tty
+
+assert_use_encryption_env_overrides_config() {
+    local rendered
+    rendered=$(DOTFILES_USE_ENCRYPTION=false chezmoi execute-template \
+        --config "$CONFIG" \
+        --init --stdinisatty=false \
+        --source "$ROOT" \
+        <"$ROOT/.chezmoi.toml.tmpl")
+
+    assert_contains "$rendered" "useEncryption = false" "useEncryption env override"
+}
+
+assert_use_encryption_message_avoids_pipe_to_sh() {
+    local stderr
+    stderr=$(chezmoi execute-template \
+        --config /dev/null --config-format toml \
+        --init --stdinisatty=false \
+        --source "$ROOT" \
+        <"$ROOT/.chezmoi.toml.tmpl" 2>&1 >/dev/null) && {
+        echo "expected toml.tmpl render to fail when useEncryption is unset in non-TTY mode" >&2
+        echo "$stderr" >&2
+        exit 1
+    }
+    assert_contains "$stderr" "Download init.sh and run it interactively" "useEncryption fail message"
+    assert_not_contains "$stderr" "| DOTFILES_USE_ENCRYPTION" "useEncryption fail message"
+}
+
+assert_use_encryption_env_overrides_config
+assert_use_encryption_message_avoids_pipe_to_sh
 
 echo "test_github_https_normalization: OK"

--- a/tests/test_github_https_normalization.sh
+++ b/tests/test_github_https_normalization.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+require_cmd chezmoi || {
+    echo "SKIP: chezmoi not found" >&2
+    exit 0
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/github-https-normalization-test.XXXXXX")"
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+export HOME="$TMP_ROOT/home"
+mkdir -p "$HOME/.config/chezmoi"
+
+CONFIG="$TMP_ROOT/chezmoi.toml"
+cat >"$CONFIG" <<'EOF'
+[data]
+hostname = "test"
+work = false
+private = true
+homeWifiSSIDs = ""
+platform = "darwin"
+installMasApps = false
+timezone = "UTC"
+gitUsername = "test"
+gitEmail = "test@test.com"
+useEncryption = true
+headless = false
+gopassRepository = "git@github.com:test/pass.git"
+keysRepository = "ssh://git@github.com/test/keys.git"
+codexProviderAccount = "openai"
+opencodeProviderAccount = "openai"
+EOF
+
+render() {
+    local src="$1"
+    chezmoi execute-template --config "$CONFIG" --source "$ROOT" <"$ROOT/$src"
+}
+
+gopass_config="$(render private_dot_config/gopass/config.tmpl)"
+setup_gopass="$(render .chezmoiscripts/run_onchange_after_06_setup-gopass.sh.tmpl)"
+keys_manage="$(render dot_local/bin/executable_keys-manage.tmpl)"
+gh_hosts="$(render private_dot_config/gh/private_hosts.yml.tmpl)"
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "missing expected text in $label: $needle" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "unexpected text in $label: $needle" >&2
+        exit 1
+    fi
+}
+
+assert_contains "$gopass_config" "source_url = https://github.com/test/pass.git" "gopass config"
+assert_contains "$setup_gopass" "gopass clone --check-keys=false \"https://github.com/test/pass.git\"" "setup gopass"
+assert_contains "$keys_manage" "KEYS_REPO=\"https://github.com/test/keys.git\"" "keys-manage"
+assert_contains "$gh_hosts" "git_protocol: https" "gh hosts"
+
+assert_not_contains "$gopass_config" "git@github.com" "gopass config"
+assert_not_contains "$setup_gopass" "git@github.com" "setup gopass"
+assert_not_contains "$keys_manage" "git@github.com" "keys-manage"
+assert_not_contains "$gh_hosts" "git_protocol: ssh" "gh hosts"
+
+echo "test_github_https_normalization: OK"

--- a/tests/test_github_https_normalization.sh
+++ b/tests/test_github_https_normalization.sh
@@ -81,4 +81,94 @@ assert_not_contains "$setup_gopass" "git@github.com" "setup gopass"
 assert_not_contains "$keys_manage" "git@github.com" "keys-manage"
 assert_not_contains "$gh_hosts" "git_protocol: ssh" "gh hosts"
 
+# ─────────────────────────────────────────────────────────────
+# Runtime: normalize_github_origin rewrites existing SSH remotes.
+# Covers the upgrade case where a machine was set up on the SSH-era
+# config and already has `git@github.com:...` baked into .git/config.
+# ─────────────────────────────────────────────────────────────
+if require_cmd git; then
+    # keys-manage/core.sh expects these constants to be pre-declared by the
+    # keys-manage entry script. Export them here so we can source the lib
+    # for the helper under test without bringing in the full CLI. (`export`
+    # also tells shellcheck they're consumed externally — silences SC2034.)
+    export KEYS_REPO=""
+    export REPO_DIR="$TMP_ROOT/keys-backup"
+    export BACKUP_FILES_DIR="backup-files"
+    export BACKUP_LIST="$REPO_DIR/backup-list.txt"
+    export BACKUP_LIST_ENC="$REPO_DIR/backup-list.txt.enc"
+    export METADATA_FILE="$REPO_DIR/backup-metadata.json"
+    export METADATA_FILE_ENC="$REPO_DIR/backup-metadata.json.enc"
+    export CONTROL_STATE_DIR="$REPO_DIR/.keys-manage"
+    export CONTROL_BASELINE_LIST="$CONTROL_STATE_DIR/backup-list.remote.sha256"
+    export CONTROL_BASELINE_META="$CONTROL_STATE_DIR/backup-metadata.remote.sha256"
+    export HISTORY_LOG="$REPO_DIR/backup-history.log"
+    export RESTORE_SNAPSHOT_DIR="$REPO_DIR/restore-snapshots"
+    # shellcheck source=../dot_local/bin/lib/common
+    source "$ROOT/dot_local/bin/lib/common"
+    # shellcheck source=../dot_local/bin/lib/keys-manage/core.sh
+    source "$ROOT/dot_local/bin/lib/keys-manage/core.sh"
+
+    assert_origin_normalized() {
+        local input="$1"
+        local expected="$2"
+        local label="$3"
+        local dir
+        dir=$(mktemp -d "$TMP_ROOT/repo.XXXXXX")
+        git -C "$dir" init -q
+        git -C "$dir" remote add origin "$input"
+        normalize_github_origin "$dir" >/dev/null
+        local got
+        got=$(git -C "$dir" remote get-url origin)
+        if [[ "$got" != "$expected" ]]; then
+            echo "normalize_github_origin($label): expected '$expected', got '$got'" >&2
+            exit 1
+        fi
+    }
+
+    assert_origin_normalized \
+        "git@github.com:test/keys.git" \
+        "https://github.com/test/keys.git" \
+        "scp-style SSH"
+    assert_origin_normalized \
+        "ssh://git@github.com/test/keys.git" \
+        "https://github.com/test/keys.git" \
+        "ssh:// URL"
+    assert_origin_normalized \
+        "https://github.com/test/keys.git" \
+        "https://github.com/test/keys.git" \
+        "already HTTPS (no-op)"
+    assert_origin_normalized \
+        "git@gitlab.com:test/keys.git" \
+        "git@gitlab.com:test/keys.git" \
+        "non-github SSH untouched"
+fi
+
+# ─────────────────────────────────────────────────────────────
+# .chezmoi.toml.tmpl must fail loud when identity prompts are unset
+# and there's no TTY. Prior behavior silently wrote prompt-label
+# placeholders ("GitHub username", etc.) into the config, which then
+# leaked into URLs as `https://github.com/GitHub username/...`.
+# ─────────────────────────────────────────────────────────────
+assert_identity_render_fails_without_tty() {
+    local stderr
+    stderr=$(DOTFILES_USE_ENCRYPTION=false chezmoi execute-template \
+        --config /dev/null --config-format toml \
+        --init --stdinisatty=false \
+        --source "$ROOT" \
+        <"$ROOT/.chezmoi.toml.tmpl" 2>&1 >/dev/null) && {
+        echo "expected toml.tmpl render to fail when identity data is unset in non-TTY mode" >&2
+        echo "$stderr" >&2
+        exit 1
+    }
+    # Any of {hostname, useremail, gitUsername, gitEmail} should trigger the
+    # guard; the first one in source order wins. Match the shared suffix.
+    if [[ "$stderr" != *"is unset and there is no TTY to prompt"* ]]; then
+        echo "expected identity fail-fast message in stderr, got:" >&2
+        echo "$stderr" >&2
+        exit 1
+    fi
+}
+
+assert_identity_render_fails_without_tty
+
 echo "test_github_https_normalization: OK"

--- a/tests/test_init_args.sh
+++ b/tests/test_init_args.sh
@@ -29,14 +29,14 @@ chmod +x "$BIN/chezmoi"
 export PATH="$BIN:$PATH"
 
 # Copy init.sh into a directory that is NOT a chezmoi source dir, so it takes the
-# remote init path (where --repo/--ref/--depth/--ssh are used).
+# remote init path (where --repo/--ref/--depth are used).
 SCRIPT_DIR="$TMP_ROOT/script"
 mkdir -p "$SCRIPT_DIR"
 cp "$ROOT/init.sh" "$SCRIPT_DIR/init.sh"
 chmod +x "$SCRIPT_DIR/init.sh"
 
-"$SCRIPT_DIR/init.sh" --repo alice/dotfiles --ref v1 --depth 10 --ssh -- --foo bar
-expected="init --apply --branch v1 --depth 10 --ssh --foo bar alice/dotfiles"
+"$SCRIPT_DIR/init.sh" --repo alice/dotfiles --ref v1 --depth 10 -- --foo bar
+expected="init --apply --branch v1 --depth 10 --foo bar https://github.com/alice/dotfiles.git"
 got="$(cat "$ARGS_FILE")"
 if [[ "$got" != "$expected" ]]; then
     echo "unexpected chezmoi args:" >&2
@@ -45,11 +45,32 @@ if [[ "$got" != "$expected" ]]; then
     exit 1
 fi
 
+set +e
+out="$("$SCRIPT_DIR/init.sh" --ssh 2>&1)"
+rc=$?
+set -e
+if [[ $rc -ne 2 ]] || [[ "$out" != *"--ssh is no longer supported"* ]]; then
+    echo "expected --ssh deprecation error (rc=2)" >&2
+    echo "rc=$rc" >&2
+    echo "$out" >&2
+    exit 1
+fi
+
 "$SCRIPT_DIR/init.sh" --repo alice/dotfiles --branch v2 -- --baz
-expected="init --apply --branch v2 --baz alice/dotfiles"
+expected="init --apply --branch v2 --baz https://github.com/alice/dotfiles.git"
 got="$(cat "$ARGS_FILE")"
 if [[ "$got" != "$expected" ]]; then
     echo "unexpected chezmoi args for --branch alias:" >&2
+    echo "  expected: $expected" >&2
+    echo "  got:      $got" >&2
+    exit 1
+fi
+
+"$SCRIPT_DIR/init.sh" --repo git@github.com:alice/dotfiles.git
+expected="init --apply https://github.com/alice/dotfiles.git"
+got="$(cat "$ARGS_FILE")"
+if [[ "$got" != "$expected" ]]; then
+    echo "unexpected chezmoi args for SSH repo normalization:" >&2
     echo "  expected: $expected" >&2
     echo "  got:      $got" >&2
     exit 1

--- a/tests/test_keys_manage_nonmenu.sh
+++ b/tests/test_keys_manage_nonmenu.sh
@@ -55,6 +55,8 @@ mkdir -p "$LOCAL_REPO"
 (
     cd "$LOCAL_REPO"
     git init -b main >/dev/null
+    git config user.name "CI Test"
+    git config user.email "ci-test@example.com"
     git remote add origin "$REMOTE"
 
     cat >.gitignore <<'EOF'

--- a/tests/test_opencode_config_rendering.sh
+++ b/tests/test_opencode_config_rendering.sh
@@ -97,9 +97,13 @@ render_oh_my_opencode() {
 OPENCODE_DEFAULT="$TMP_ROOT/opencode-default.jsonc"
 OH_MY_OPENCODE="$TMP_ROOT/oh-my-opencode.jsonc"
 OPENCODE_WITH_GOPASS="$TMP_ROOT/opencode-with-gopass.jsonc"
+CODEX_MODIFY_SCRIPT="$TMP_ROOT/codex-modify-config.sh"
+CODEX_CONFIG="$TMP_ROOT/codex-config.toml"
 
 render_opencode "$OPENCODE_DEFAULT"
 render_oh_my_opencode "$OH_MY_OPENCODE"
+chezmoi execute-template --source "$ROOT" <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$CODEX_MODIFY_SCRIPT"
+bash "$CODEX_MODIFY_SCRIPT" </dev/null >"$CODEX_CONFIG"
 
 ACCOUNT_BIN="$TMP_ROOT/account-bin"
 mkdir -p "$ACCOUNT_BIN"
@@ -338,13 +342,13 @@ assert_file_not_contains "$ROOT/dot_local/bin/executable_codex-manage" 'Search a
 assert_file_not_contains "$ROOT/dot_local/bin/executable_codex-manage" 'check_mcp_server "tavily" "Tavily"'
 assert_file_not_contains "$ROOT/dot_local/bin/executable_codex-manage" 'tri-MCP readiness unknown'
 
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" '[mcp_servers.context7]'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" '[mcp_servers.serena]'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" 'git+https://github.com/oraios/serena'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" '"--context", "codex"'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" 'startup_timeout_sec = 30'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" '[mcp_servers.gitmcp]'
-assert_file_contains "$ROOT/dot_codex/config.toml.tmpl" 'url = "https://gitmcp.io/docs"'
+assert_file_contains "$CODEX_CONFIG" '[mcp_servers.context7]'
+assert_file_contains "$CODEX_CONFIG" '[mcp_servers.serena]'
+assert_file_contains "$CODEX_CONFIG" 'git+https://github.com/oraios/serena'
+assert_file_contains "$CODEX_CONFIG" '"--context", "codex"'
+assert_file_contains "$CODEX_CONFIG" 'startup_timeout_sec = 30'
+assert_file_contains "$CODEX_CONFIG" '[mcp_servers.gitmcp]'
+assert_file_contains "$CODEX_CONFIG" 'url = "https://gitmcp.io/docs"'
 
 assert_file_contains "$ROOT/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl" 'ensure_user_mcp_json "context7"'
 assert_file_contains "$ROOT/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl" '/.local/bin/mcp-context7'


### PR DESCRIPTION
## Summary

Follow-up to #529. That PR added defensive `-c "url.https://github.com/.insteadOf="` flags around git operations to work around the `insteadOf` rewrite that previously forced HTTPS → SSH. The cleaner fix is to drop the rewrite entirely: a single `gh auth git-credential` helper handles every auth scenario we care about with zero per-call defenses.

## Why drop SSH-everywhere?

For personal dotfiles on a few personal machines, SSH's advantages over HTTPS+gh-token largely don't apply (no deploy keys, no multi-org identity juggling, no unattended-cron private clones, no YubiKey-rooted SSH workflow). The `insteadOf` rule's only real benefit was "I copy-paste HTTPS URLs and they auto-upgrade to SSH" — paid for with a chicken-and-egg cold-start, plus per-call workarounds for `chezmoi init`, externals, gh-managed tools, and submodules.

After this PR: HTTPS is the one true protocol. `gh auth login` once per machine, all git operations (public, private, push, fetch) transparently use the OAuth token via `gh auth git-credential`. Cold-start hosts without gh fall back to the bootstrap logic in script 01 (PAT env or temporary gh install via nix).

## Headless coverage matrix

| Scenario | How auth flows |
|---|---|
| Local mac with browser | `gh auth login -w` → OAuth → gh helper supplies token |
| **Interactive headless (SSH'd in)** | `gh auth login` (no `-w`) → device code, open URL on phone → gh helper supplies token |
| **Unattended (CI/cron)** | `export GH_TOKEN=ghp_xxx` → gh reads env, no `gh auth login` needed → helper supplies env token |
| Cold-start fresh host | Script 01 bootstrap from #529 kicks in (PAT env or temp gh OAuth) |

## Changes

- `private_dot_config/git/config.tmpl`: three `insteadOf` blocks → one `[credential "https://github.com"] helper = !gh auth git-credential`
- `.chezmoi.toml.tmpl`: default `gopassRepository` / `keysRepository` switched to HTTPS URLs (SSH-URL overrides still work — script 01's bootstrap rewrites them transparently on cold start)
- `.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl`: drop now-redundant `-c "url.https://github.com/.insteadOf="` flags. Cold-start bootstrap (PAT / temp gh OAuth) preserved.
- `dot_local/bin/lib/keys-manage/{backup,core}.sh`: auth-failure hints point at `gh auth status` / `gh auth login` instead of `ssh -T` / `ssh-add`
- `docs/keys-manage-guide.md`, `docs/gopass-new-device-setup.md`: examples and troubleshooting steps switched to HTTPS + gh

`~/.ssh/config` is age-encrypted and managed out of band; the `Host github.com` block becomes inert (no git op ever takes the SSH path) but is harmless if left in place — kept as a manual escape hatch for ad-hoc `git clone git@github.com:...`.

## Review-feedback round 1 (commit `d50b760`)

End-to-end normalization of legacy SSH URLs so cold-start and upgraded hosts both land on HTTPS with the gh credential helper.

- `.chezmoi.toml.tmpl`: normalize `gopassRepository` / `keysRepository` at config time (covers users with stale `git@github.com:…` in `~/.config/chezmoi/chezmoi.toml`).
- `init.sh`: new `normalize_repo()` translates `git@…` / `ssh://git@…` / short `user[/repo]` into HTTPS.
- Render-layer fallbacks in `private_dot_config/gopass/config.tmpl`, `dot_local/bin/executable_keys-manage.tmpl`, `run_onchange_after_06_setup-gopass.sh.tmpl`.
- `private_dot_config/gh/private_hosts.yml.tmpl`: default `git_protocol: https`.
- `run_before_01`: `KEYS_REPO_AUTH_URL` / `KEYS_REPO_CLONE_URL` split with strip-after for both fetch and clone; `GIT_TERMINAL_PROMPT=0` around remote ops.
- `DOTFILES_USE_ENCRYPTION` now strictly validates `"true"`/`"false"` (anything else fails fast).
- README × 3 (en/zh/ja): replace deprecated `./init.sh --ssh` examples with the `DOTFILES_USE_ENCRYPTION=…` form.
- `tests/test_init_args.sh` + new `tests/test_github_https_normalization.sh`; CI workflow now triggers on push/PR to `main`.
- Sundry: `aqua policy allow` auto-run, codex test fixture rename follow-through, keys-manage CI git identity.

## Review-feedback round 2 (commit `219dbc1`)

Two correctness gaps surfaced in a deeper review pass.

### P1 — `curl | sh` silently wrote placeholder identity values

`promptStringOnce` in non-TTY mode falls back to its prompt label as the value, so the previously-recommended `curl ... | DOTFILES_USE_ENCRYPTION=false sh` one-liner would render `gitUsername = "GitHub username"` and a `gopassRepository = "https://github.com/GitHub username/passwords.git"` URL with embedded space — broken later at gopass-clone time with no trace back to root cause.

- `.chezmoi.toml.tmpl`: replace bare `promptStringOnce` calls for `hostname` / `useremail` / `gitUsername` / `gitEmail` with a `hasKey → stdinIsATTY → fail` cascade (same pattern as `useEncryption`).
- README × 3 + `init.sh` usage: drop pipe-to-sh from Option 1, replace with download-then-run; clarify that `DOTFILES_USE_ENCRYPTION` only covers the bool prompt — identity prompts still require a TTY.

### P2 — pre-existing keys-backup repos kept SSH origin after migration

Three call sites silently kept using SSH:
- `run_before_01` fast-path (`exit 0` if repo+files+key all present) ran before the SSH→HTTPS URL normalization, so upgraded machines never touched origin.
- `keys-manage backup.sh cmd_init` existing-repo branch returned success without inspecting origin.
- `keys-manage core.sh check_git_sync_status` explicitly set `GIT_SSH_COMMAND` and fetched against whatever URL was there — actively supporting the SSH path.

Fix:
- New `normalize_github_origin <repo_dir>` helper in `dot_local/bin/lib/keys-manage/core.sh` (idempotent; no-op for non-GitHub / already-HTTPS).
- Called from `check_git_sync_status` (before fetch) and `cmd_init` (existing-repo branch).
- Equivalent inline normalization in `run_before_01` BEFORE the fast-path check, so upgraded machines self-heal on next apply.

Tests in `tests/test_github_https_normalization.sh`:
- Runtime: source core.sh, init temp repos with SSH origin (scp-style + `ssh://` form), assert normalize rewrites them; assert already-HTTPS and non-GitHub SSH are left untouched.
- Render: assert `.chezmoi.toml.tmpl` with no TTY and no identity data fails with the expected "is unset and there is no TTY to prompt" message.

## Test plan

- [x] `pre-commit run` on all changed files (treefmt, shellcheck, template-render, typos, gitleaks — all green)
- [x] `bash tests/run.sh` — full suite green (init args, github_https_normalization, chezmoiignore, setup_gopass, keys_manage_nonmenu, toolchain_bootstrap, codex/opencode rendering, etc.)
- [x] P1 repro confirmed fixed: `DOTFILES_USE_ENCRYPTION=false chezmoi execute-template --init --stdinisatty=false …` now hard-fails with "hostname is unset and there is no TTY to prompt" instead of writing placeholder values.
- [x] P2 covered by new `normalize_github_origin` runtime test (4 input forms).
- [ ] Verify on a warm machine: after applying, `git clone https://github.com/signalridge/keypairs.git /tmp/t` works without prompting (uses gh token) — then `rm -rf /tmp/t`
- [ ] Verify `gh auth status` shows the helper active after apply
- [ ] Cold-start smoke: on a fresh VM, download `init.sh` and run interactively — should complete without any SSH key present (uses script 01 bootstrap)
- [ ] Upgrade smoke: on a host with pre-existing `keys-backup` repo at `git@github.com:...`, run `chezmoi apply` and confirm `git -C ~/.local/share/keys-backup remote get-url origin` is HTTPS after.
- [ ] Headless smoke: SSH into a server, run apply, complete device code on phone