### PR TITLE
fix(bootstrap): route eza via mise; stop the aqua source-backend whack-a-mole

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -6,6 +6,12 @@ registries:
     type: local
     path: registry.yaml
 packages:
+  # NOTE: do NOT add packages that the registry resolves to the `cargo` or
+  # `go_install` backend (source builds) here. They need cargo/go on PATH,
+  # which mise only provides at bootstrap step 07 — after this aqua-install
+  # step (05) — so a fresh machine fails. Route such tools through mise's
+  # `cargo:`/`go:` backends instead (see ~/.config/mise/config.toml).
+  # Known cases already moved: eza, tokei (cargo), gopls (go_install).
   # ----- third-party registry (see registry.yaml) -----
   - name: signalridge/slipway@v0.1.0
     registry: third-party
@@ -30,7 +36,6 @@ packages:
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.69.0
-  - name: eza-community/eza@v0.23.4
   - name: fastfetch-cli/fastfetch@2.63.1
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.73.1

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -53,6 +53,11 @@ rust = "latest"
 # to avoid needing `cargo` on PATH at the aqua-install step.
 "cargo:tokei" = "14.0.0"
 
+# eza: ls replacement. Same reason as tokei — the pinned aqua registry
+# resolves eza to the cargo backend, which would need `cargo` on PATH during
+# the aqua-install step (before mise installs the Rust toolchain).
+"cargo:eza" = "0.23.4"
+
 # Lua 5.4 runtime (replaces nix lua5_4)
 lua = "5.4"
 


### PR DESCRIPTION
## Summary

Follow-up to #531. A fresh machine still failed at `aqua install` (bootstrap step 05):

```
ERR install the package ... package_name=eza-community/eza ...
cargo_command="cargo install --version 0.23.4 eza"
error="cargo install: ... exec: \"cargo\": executable file not found in $PATH"
```

`eza` is the same class of problem as the gopls/tokei fix in #531 — the pinned standard registry (`v4.470.0`) resolves it to the **cargo** backend, which needs `cargo` on PATH. But the Rust toolchain is only installed by mise at step 07, *after* this aqua step. I'd moved gopls + tokei but missed eza.

Enumerating the aqua pkg cache (`pkgs/cargo/crates.io/*`, `pkgs/go_install/*`) confirms the **complete** set of source-build backends in this config is exactly `{eza, tokei, gopls}` — eza is the last one.

## Changes

- Move `eza-community/eza@0.23.4` from aqua → mise `"cargo:eza" = "0.23.4"`.
- Add a header comment in `aqua.yaml` documenting the rule (no cargo/go_install-backend packages in aqua; route them through mise) so this stops recurring.

## Test plan

- [ ] Fresh machine: `chezmoi apply` reaches step 05 `aqua install` with **zero** source-backend packages → no `cargo`/`go` PATH error
- [ ] Step 07 `mise install` installs eza via cargo (after Rust toolchain) → `which eza` points to `~/.local/share/mise/shims/`, `eza --version` reports 0.23.4

## Note

The remaining structural risk is someone adding a new cargo/go-backend package to aqua in the future. The header comment is the cheap guard. A heavier permanent fix (reorder bootstrap so toolchains exist before `aqua install`) is possible but deferred — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)