### PR TITLE
feat(bootstrap): two-phase aqua install; keep source-backend tools in aqua

### DIFF
--- a/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
@@ -44,4 +44,27 @@ if [[ -f "$aqua_policy_path" ]]; then
     "$aqua_cmd" policy allow "$aqua_policy_path"
 fi
 
+# Two-phase install: some packages' registry entries use a source-build
+# backend (cargo / go_install, e.g. eza, tokei, gopls) that needs cargo/go on
+# PATH. Those toolchains are managed by mise, which is itself an aqua package —
+# so install mise first, use it to put Go/Rust on PATH, then do the full
+# install. This makes the step self-contained on a fresh machine (mise's own
+# full install still runs later in script 07).
+echo "    Phase 1: installing mise (bootstrap toolchain manager)"
+"$aqua_cmd" install -t bootstrap
+
+mise_bin="$aqua_bin_dir/mise"
+if [[ -x "$mise_bin" ]]; then
+    echo "    Phase 1: installing Go/Rust toolchains via mise"
+    "$mise_bin" install go rust
+    # Use `mise env` (not `mise activate`): activate relies on a shell hook that
+    # never fires in a non-interactive one-shot, and mise's shims route through
+    # aqua-proxy (argv0-based) so they can't expose cargo/go here. `mise env`
+    # injects the real tool bin dirs (~/.cargo/bin, the Go install bin) directly.
+    eval "$("$mise_bin" env -s bash)"
+else
+    echo "    Warning: mise not found after phase 1; source-build packages may fail"
+fi
+
+echo "    Phase 2: installing all aqua packages"
 "$aqua_cmd" install

--- a/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
@@ -50,21 +50,26 @@ fi
 # so install mise first, use it to put Go/Rust on PATH, then do the full
 # install. This makes the step self-contained on a fresh machine (mise's own
 # full install still runs later in script 07).
-echo "    Phase 1: installing mise (bootstrap toolchain manager)"
+echo "    Phase 1: installing bootstrap-tagged packages (mise)"
 "$aqua_cmd" install -t bootstrap
 
 mise_bin="$aqua_bin_dir/mise"
-if [[ -x "$mise_bin" ]]; then
-    echo "    Phase 1: installing Go/Rust toolchains via mise"
-    "$mise_bin" install go rust
-    # Use `mise env` (not `mise activate`): activate relies on a shell hook that
-    # never fires in a non-interactive one-shot, and mise's shims route through
-    # aqua-proxy (argv0-based) so they can't expose cargo/go here. `mise env`
-    # injects the real tool bin dirs (~/.cargo/bin, the Go install bin) directly.
-    eval "$("$mise_bin" env -s bash)"
-else
-    echo "    Warning: mise not found after phase 1; source-build packages may fail"
+if [[ ! -x "$mise_bin" ]]; then
+    # Phase 1 was supposed to produce mise; if it didn't, phase 2's source-build
+    # backends (cargo/go_install) would fail with a confusing "cargo/go not
+    # found" error. Fail loudly here with the real cause instead.
+    echo "    Error: mise not found at $mise_bin after phase 1 — cannot put" >&2
+    echo "    Go/Rust on PATH; source-build packages (eza/tokei/gopls) would fail." >&2
+    exit 1
 fi
+
+echo "    Phase 1: installing Go/Rust toolchains via mise"
+"$mise_bin" install go rust
+# Use `mise env` (not `mise activate`): activate relies on a shell hook that
+# never fires in a non-interactive one-shot, and mise's shims route through
+# aqua-proxy (argv0-based) so they can't expose cargo/go here. `mise env`
+# injects the real tool bin dirs (~/.cargo/bin, the Go install bin) directly.
+eval "$("$mise_bin" env -s bash)"
 
 echo "    Phase 2: installing all aqua packages"
 "$aqua_cmd" install

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -25,7 +25,13 @@ packages:
   - name: openai/codex@rust-v0.135.0
   - name: anomalyco/opencode@v1.15.12
   - name: direnv/direnv@v2.37.1
+  # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
+  # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
+  # the full install — letting source-build backends (cargo/go_install, e.g.
+  # eza/tokei/gopls) compile on a fresh machine.
   - name: jdx/mise@v2026.5.16
+    tags:
+      - bootstrap
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
@@ -75,10 +81,12 @@ packages:
   - name: astral-sh/ruff@0.15.15
   - name: astral-sh/ty@0.0.40
   - name: j178/prek@v0.4.3
+  - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.16.0
   - name: orhun/git-cliff@v2.13.1
   - name: numtide/treefmt@v2.5.0
+  - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
   - name: hatoo/oha@v1.14.0
   - name: ClementTsang/bottom@0.12.3

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -44,6 +44,7 @@ packages:
   - name: cli/cli@v2.93.0
   - name: dlvhdr/gh-dash@v4.24.1
   - name: x-motemen/ghq@v1.10.1
+  - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
   - name: git-lfs/git-lfs@v3.7.1
   - name: charmbracelet/glow@v2.1.2
   - name: carapace-sh/carapace-bin@v1.6.6

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -37,9 +37,6 @@ go = "latest"
 # that crosspost itself lacks. Replaces the raw toot/goat CLIs.
 "npm:@humanwhocodes/crosspost" = "1.0.4"
 
-# GitLab CLI for open-source repo/MR ops (orthogonal to social publishing).
-glab = "1.99.0"
-
 # Rust
 rust = "latest"
 

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -26,11 +26,6 @@ uv = "latest"
 # Go
 go = "latest"
 
-# gopls: Go LSP. No upstream binaries (Go-modules-only) — must build via
-# `go install`. Routed through mise so the bootstrap doesn't need `go` on
-# PATH at the aqua-install step.
-"go:golang.org/x/tools/gopls" = "0.22.0"
-
 # Official X API CLI. Use the Go backend because the npm package can lag
 # GitHub releases, and xurl is not in the aqua standard registry yet.
 # Kept for X *reads* (search/whoami/timeline); publishing goes through the
@@ -47,11 +42,6 @@ glab = "1.99.0"
 
 # Rust
 rust = "latest"
-
-# tokei: line counter. The aqua registry uses the cargo backend (no stable
-# darwin/arm64 release artifact upstream), so route it through mise instead
-# to avoid needing `cargo` on PATH at the aqua-install step.
-"cargo:tokei" = "14.0.0"
 
 # Lua 5.4 runtime (replaces nix lua5_4)
 lua = "5.4"


### PR DESCRIPTION
## Summary

Supersedes #532 (will close) and reverts the per-package mise migration from #531. Instead of moving every cargo/go_install-backed aqua package into mise, fix the **root cause once** so aqua stays the single CLI manifest — *everything that can use aqua, does*.

### The root cause

`aqua install` (bootstrap script 05) ran **before** the Go/Rust toolchains existed. Those toolchains are managed by mise, which is installed at script 07 — *after* aqua. So any package whose standard-registry entry resolves to a source-build backend (`cargo` / `go_install`) failed with `exec: "cargo"/"go": executable file not found in $PATH`. The complete set in this config is `eza`, `tokei` (cargo) and `gopls` (go_install).

### The fix

1. Tag the `jdx/mise` package `bootstrap` in `aqua.yaml`.
2. Script 05 now does a two-phase install:
   - `aqua i -t bootstrap` — install mise only (self-contained binary, no toolchain needed)
   - `mise install go rust` — install the toolchains
   - `eval "$(mise env -s bash)"` — put `cargo`/`go` on PATH
   - `aqua install` — full install; source backends can now build
3. `tokei` and `gopls` move back into `aqua.yaml`, and their `cargo:`/`go:` entries are removed from mise config. `eza` was already in `aqua.yaml` (never in mise) — it was simply broken by the same ordering bug and is now unblocked.

### Why `mise env`, not `mise activate`

`mise activate` relies on a shell hook that never fires in a non-interactive one-shot script, and mise's shims route through aqua-proxy (argv0-based dispatch) so they can't expose `cargo`/`go` to a child `aqua` process. `mise env -s bash` injects the real tool bin dirs (`~/.cargo/bin`, the Go install bin) directly. Verified non-interactively with `AQUA_GLOBAL_CONFIG` set (as the script does):

```
cargo: /Users/.../.cargo/bin/cargo
go:    /Users/.../.local/share/mise/installs/go/1.26.3/bin/go
```

## Test plan

- [ ] Fresh machine: `chezmoi apply` → script 05 phase 1 installs mise + go/rust, phase 2 builds eza/tokei/gopls from source successfully (no PATH error)
- [ ] `which eza tokei gopls` resolve via aqua (`~/.local/share/aquaproj-aqua/bin`), not mise shims
- [ ] Re-apply on an existing machine is idempotent (mise install go rust = no-op; aqua skips installed)
- [ ] `mise install` (step 07) no longer lists eza/tokei/gopls

## Follow-up

Close #532; this replaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
