### PR TITLE
fix: require must-set vars (work, gopass/keys repos) instead of guessing/silent defaults

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,7 +1,19 @@
 encryption = "age"
 
 {{/* boolean feature tags */}}
-{{- $work := promptBoolOnce . "work" "Is this a work machine" -}}{{/* true if this machine is a work machine */}}
+{{/* work must be set explicitly. In a non-TTY install (curl ... | sh)
+     promptBoolOnce silently returns its zero value (false), making the machine
+     private=true and applying private configuration — wrong, and
+     privacy-relevant, on an actual work machine. Force an explicit signal:
+     chezmoi data, else prompt on a TTY, else fail loudly. */}}
+{{- $work := false -}}{{/* true if this machine is a work machine */}}
+{{- if hasKey . "work" -}}
+{{-   $work = .work -}}
+{{- else if stdinIsATTY -}}
+{{-   $work = promptBoolOnce . "work" "Is this a work machine" -}}
+{{- else -}}
+{{-   fail "work is unset and there is no TTY to prompt.\nDownload init.sh and run it interactively so chezmoi prompts can read from your terminal:\n  curl -fsSL <init-url> -o /tmp/init.sh && sh /tmp/init.sh\nIf this is a re-apply, work is persisted in chezmoi data after the first apply." -}}
+{{- end -}}
 {{- $private := not $work -}}{{/* true if this machine should have private configuration  */}}
 {{- $headless := false -}}{{/* true if this machine does not have a screen and keyboard */}}
 {{/* useEncryption must be set explicitly. The historical silent default to

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -153,12 +153,18 @@ encryption = "age"
 {{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "ssh://git@github.com/" $gopassRepository) -}}
 {{- end -}}
 
-{{/* keys-manage backup repository (HTTPS; auth via gh credential helper) */}}
-{{- $keysRepository := printf "https://github.com/%s/keypairs.git" $gitUsername -}}
+{{/* keys-manage backup repository (HTTPS; auth via gh credential helper).
+     Required when encryption is enabled — no guessed default, so a wrong repo
+     name can never be written silently in a non-interactive install. */}}
+{{- $keysRepository := "" -}}
 {{- if hasKey . "keysRepository" -}}
 {{-   $keysRepository = .keysRepository -}}
-{{- else if and (stdinIsATTY) $useEncryption -}}
-{{-   $keysRepository = promptStringOnce . "keysRepository" "keys-manage backup repository URL" $keysRepository -}}
+{{- else if $useEncryption -}}
+{{-   if stdinIsATTY -}}
+{{-     $keysRepository = promptStringOnce . "keysRepository" "keys-manage backup repository URL (e.g. https://github.com/you/keypairs.git)" -}}
+{{-   else -}}
+{{-     fail (printf "keysRepository is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{-   end -}}
 {{- end -}}
 {{- if hasPrefix "git@github.com:" $keysRepository -}}
 {{-   $keysRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $keysRepository) -}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -133,12 +133,19 @@ encryption = "age"
 {{-   $opencodeProviderAccount = .opencodeProvider -}}{{/* backward compatibility */}}
 {{- end -}}
 
-{{/* gopass password store repository (HTTPS; auth via gh credential helper) */}}
-{{- $gopassRepository := printf "https://github.com/%s/passwords.git" $gitUsername -}}
+{{/* gopass password store repository (HTTPS; auth via gh credential helper).
+     Required when encryption is enabled — no guessed default, so a wrong repo
+     name (e.g. an assumed "passwords.git") can never be written silently in a
+     non-interactive install. */}}
+{{- $gopassRepository := "" -}}
 {{- if hasKey . "gopassRepository" -}}
 {{-   $gopassRepository = .gopassRepository -}}
-{{- else if and (stdinIsATTY) $useEncryption -}}
-{{-   $gopassRepository = promptStringOnce . "gopassRepository" "gopass repository URL" $gopassRepository -}}
+{{- else if $useEncryption -}}
+{{-   if stdinIsATTY -}}
+{{-     $gopassRepository = promptStringOnce . "gopassRepository" "gopass repository URL (e.g. https://github.com/you/password-store.git)" -}}
+{{-   else -}}
+{{-     fail (printf "gopassRepository is unset and there is no TTY to prompt.\n%s" $nonInteractiveHelp) -}}
+{{-   end -}}
 {{- end -}}
 {{- if hasPrefix "git@github.com:" $gopassRepository -}}
 {{-   $gopassRepository = printf "https://github.com/%s" (trimPrefix "git@github.com:" $gopassRepository) -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -68,6 +68,9 @@ Library/
 {{- if not .useEncryption }}
 .chezmoiscripts/01_setup-encryption-key.sh
 .chezmoiscripts/06_setup-gopass.sh
+# gopass is an encryption-gated feature (06_setup-gopass.sh above is skipped);
+# don't write its config with an empty source_url when encryption is disabled.
+.config/gopass/config
 .ssh/*
 {{- end }}
 


### PR DESCRIPTION
## Problem

Investigation started from a new-machine failure: `gopass clone` hit `Repository not found` because the template **guessed** a repo name (`<user>/passwords.git`) when `gopassRepository` wasn't set. Auditing `.chezmoi.toml.tmpl` for the same class of bug surfaced three variables that resolve to a silent (and possibly wrong) value in a non-interactive install instead of failing loudly.

## Variable audit

| Variable | Dependency | Before | After |
|---|---|---|---|
| `gopassRepository` | `useEncryption` | guessed `<user>/passwords.git` | required: data → prompt → `fail` |
| `keysRepository` | `useEncryption` | guessed `<user>/keypairs.git` | required: data → prompt → `fail` |
| `work` | — (drives `private`) | raw `promptBoolOnce` → silent `false` in non-TTY | required: data → prompt → `fail` |

All three now mirror the already-hardened identity-variable pattern (`hostname`, `gitUsername`, …).

**`work` matters most:** a silent `false` makes the machine `private=true` and applies **private configuration on a work machine** — the exact cold-start footgun the L7-12 comment says was deliberately removed from `useEncryption`, but `work` still had it.

### Left as-is (safe optional defaults, no footgun)
`installMasApps`, `homeWifiSSIDs`, `claude/codex/opencodeProviderAccount`, `jjSigningKey` (`~/.ssh/main.pub` only when encryption), `timezone` (auto-detect → UTC), `headless` (os-derived). A wrong/empty value here is harmless or self-evident.

## Behavior change

Non-interactive (`curl | sh`) first installs that omit a required value now **fail with an actionable message** instead of silently writing a wrong config. Re-applies are unaffected — these values are persisted in `[data]` after the first apply.

## Verification

- `chezmoi execute-template --init` renders correctly for valid inputs.
- pre-commit "Validate templates (render + check)" passes on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)