### PR TITLE
fix(bootstrap): isolate age/nix bootstrap installs from flakey-managed profile

### DIFF
--- a/.chezmoidata/nix.yaml
+++ b/.chezmoidata/nix.yaml
@@ -26,6 +26,13 @@ nix:
                 collection-langjapanese
               ]
             ))
+      # age: chezmoi's encryption backend. MUST be managed here so the decryption
+      # wrapper's fast path (~/.nix-profile/bin/age) is always satisfied and it never
+      # falls through to `nix profile add` against this profile. flakey-profile installs
+      # packages in a representation the modern `nix profile` command does not track, so
+      # any bare `nix profile add` here rewrites the manifest from scratch and silently
+      # drops every flakey-installed package (tmux, wget, ...). See age_command_wrapper.sh.
+      - age
       - aria2
       - git
       - certbot

--- a/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
+++ b/.chezmoiscripts/run_before_01_setup-encryption-key.sh.tmpl
@@ -173,12 +173,32 @@ require_cmd() {
     command -v "$cmd" >/dev/null 2>&1 || return 1
 }
 
+# Isolated bootstrap profile for tools needed before the flakey-profile switch
+# (script 03) runs. It MUST be separate from the default profile (~/.nix-profile):
+# flakey-profile installs packages in a representation the modern `nix profile`
+# command does not track, so a bare `nix profile add` against the default profile
+# rewrites its manifest and silently drops every flakey-installed package
+# (tmux, wget, ...). Installing here, and prepending its bin to PATH, keeps these
+# bootstrap tools available without ever touching the flakey-managed profile.
+BOOTSTRAP_PROFILE="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles/dotfiles-bootstrap"
+
 maybe_install_with_nix() {
     local tool="$1"
     require_cmd "$tool" && return 0
     require_cmd nix || return 1
-    info "Installing $tool with nix profile..."
-    nix --extra-experimental-features 'nix-command flakes' profile add "nixpkgs#$tool" >/dev/null
+    info "Installing $tool with nix (isolated bootstrap profile)..."
+    # `nix profile add --profile` does NOT create the parent dir (unlike the
+    # default profile), so ensure it exists first or the add fails on a cold device.
+    mkdir -p "$(dirname "$BOOTSTRAP_PROFILE")"
+    nix --extra-experimental-features 'nix-command flakes' profile add \
+        --profile "$BOOTSTRAP_PROFILE" "nixpkgs#$tool" >/dev/null
+    case ":$PATH:" in
+    *":$BOOTSTRAP_PROFILE/bin:"*) ;;
+    *)
+        PATH="$BOOTSTRAP_PROFILE/bin:$PATH"
+        export PATH
+        ;;
+    esac
     require_cmd "$tool"
 }
 

--- a/.chezmoitemplates/shell/age_command_wrapper.sh
+++ b/.chezmoitemplates/shell/age_command_wrapper.sh
@@ -3,9 +3,23 @@ set -euo pipefail
 
 AGE_BIN="$HOME/.nix-profile/bin/age"
 
-# Fast path: prefer profile-managed age binary.
+# Isolated bootstrap profile. Kept strictly separate from the default profile
+# (~/.nix-profile), which flakey-profile manages declaratively. flakey-profile
+# installs packages in a representation the modern `nix profile` command does NOT
+# track, so a bare `nix profile add` against the default profile rewrites its
+# manifest from scratch and silently drops every flakey-installed package
+# (tmux, wget, git, ...). Installing age here instead never touches that profile.
+BOOTSTRAP_PROFILE="${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles/dotfiles-bootstrap"
+BOOTSTRAP_AGE="$BOOTSTRAP_PROFILE/bin/age"
+
+# Fast path: age managed by flakey-profile in the default profile (steady state).
 if [[ -x "$AGE_BIN" ]]; then
     exec "$AGE_BIN" "$@"
+fi
+
+# Previously bootstrapped age (cold start, before the profile switch has run).
+if [[ -x "$BOOTSTRAP_AGE" ]]; then
+    exec "$BOOTSTRAP_AGE" "$@"
 fi
 
 # Fallback to any age already in PATH.
@@ -26,11 +40,17 @@ if ! command -v nix >/dev/null 2>&1; then
     exit 1
 fi
 
-# Install age once into user profile, then execute it.
-nix --extra-experimental-features 'nix-command flakes' profile add "nixpkgs#age" >/dev/null
-if [[ -x "$AGE_BIN" ]]; then
-    exec "$AGE_BIN" "$@"
+# Install age once into the ISOLATED bootstrap profile (never the default profile),
+# then execute it. This bootstraps decryption on a cold device without clobbering
+# the flakey-profile-managed default profile.
+# `nix profile add --profile` does NOT create the parent dir (unlike the default
+# profile), so ensure it exists first or the add fails on a cold device.
+mkdir -p "$(dirname "$BOOTSTRAP_PROFILE")" 2>/dev/null || true
+nix --extra-experimental-features 'nix-command flakes' profile add \
+    --profile "$BOOTSTRAP_PROFILE" "nixpkgs#age" >/dev/null 2>&1 || true
+if [[ -x "$BOOTSTRAP_AGE" ]]; then
+    exec "$BOOTSTRAP_AGE" "$@"
 fi
 
-# Last-resort fallback.
+# Last-resort fallback: ephemeral run, no profile mutation.
 exec nix --extra-experimental-features 'nix-command flakes' run "nixpkgs#age" -- "$@"


### PR DESCRIPTION
## Problem

`flakey-profile` manages the default profile (`~/.nix-profile`) in a representation the modern `nix profile` command does **not** track. Any bare `nix profile add` against the default profile rewrites its manifest from scratch and **silently drops every flakey-installed package** (tmux, wget, git, ...).

The old `age_command_wrapper.sh` did exactly this: when `age` was missing it ran `nix profile add nixpkgs#age` against the default profile. The profile generation history confirmed the corruption in practice — bare-`add` generations (`…-profile`) alternating with flakey generations (`…-flake-profile`).

## Fix

- **`age` → flakey-managed list** (`nix.yaml`): the wrapper's fast path `~/.nix-profile/bin/age` is satisfied in steady state and never falls through to a profile-mutating install.
- **Isolated bootstrap profile**: all cold-start installs (age in the wrapper; git/openssl/jq/gh in `run_before_01`) now go to `…/nix/profiles/dotfiles-bootstrap`, which never touches the default profile. Its `bin` is prepended to PATH for the bootstrap script's own use.
- **Parent-dir creation**: `nix profile add --profile <path>` does **not** auto-create the parent dir (unlike the default profile) — verified it fails with `error: cannot read directory …: No such file or directory` on a cold device where `~/.local/state/nix/profiles/` doesn't exist yet. Added `mkdir -p` before each add. The wrapper's `mkdir` is non-fatal (`|| true`) to preserve its graceful degradation to `nix run`.

## Verification

- Profile generation history on a live machine shows the alternating bare/flakey corruption pattern this prevents.
- Empirically reproduced the missing-parent `nix profile add --profile` failure, and confirmed `mkdir -p` + add succeeds end-to-end.
- `bash -n` syntax-checked the wrapper and the template-stripped `run_before_01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)