### PR TITLE
chore(aqua): bump signalridge/slipway to v0.2.0

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.1.0
+  - name: signalridge/slipway@v0.2.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## Summary
- Bump `signalridge/slipway` from `v0.1.0` to `v0.2.0` in the aqua package manifest.

## Test plan
- Pre-commit hooks (yaml check, treefmt) passed on commit.
- `aqua install` will pull the new version on next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)