### PR TITLE
perf(ci): drop Nix store cache; rely on binary cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - name: Restore Nix cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('nix-config/**/*.nix', 'nix-config/**/*.tmpl', 'nix-config/.flake-*.lock', '.github/workflows/*.yml', '.pre-commit-config.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-          gc-max-store-size-macos: 2G
       - name: Install tools
         run: |
           nix profile install nixpkgs#pre-commit nixpkgs#treefmt nixpkgs#shfmt nixpkgs#shellcheck nixpkgs#statix nixpkgs#nixfmt nixpkgs#stylua nixpkgs#selene nixpkgs#chezmoi nixpkgs#prettier nixpkgs#typos nixpkgs#gitleaks
@@ -58,13 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - name: Restore Nix cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('nix-config/**/*.nix', 'nix-config/**/*.tmpl', 'nix-config/.flake-*.lock', '.github/workflows/*.yml', '.pre-commit-config.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-          gc-max-store-size-macos: 2G
       - name: Install chezmoi
         run: nix profile install nixpkgs#chezmoi
       - name: Setup chezmoi


### PR DESCRIPTION
## Problem

The Nix cache restore dominated CI. On the macOS runner, restoring the Nix store took **~516s (8.6 min)** due to slow tar extraction on APFS, while the job does only ~20s of real work (`nix flake check --no-build` builds nothing). On linux the restore (~24s) plus the cache-save overhead also cost more than just pulling tools from `cache.nixos.org`.

## Change

Remove `cache-nix-action` from **all** jobs (lint + nix matrix). nix-installer already configures the public binary cache (`cache.nixos.org`), which covers chezmoi, eval deps, and the lint toolchain faster than the GH Actions cache round-trip.

## Measured (PR CI, all green)

| Job | Before (cached) | After (no cache) |
|-----|-----------------|------------------|
| Lint | 79s | **54s** |
| Nix (linux) | 50s | **42s** |
| Nix (darwin) | 605s | **116s** |
| **CI total (parallel)** | **~10min** | **~2min** |

Empirically faster across the board — the binary cache makes the GH Actions cache redundant and the restore/save overhead was net-negative even on linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)