### PR TITLE
fix(bootstrap): export AQUA_POLICY_CONFIG in aqua install; default to xhigh thinking

### DIFF
--- a/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_05_aqua-install-tools.sh.tmpl
@@ -37,10 +37,17 @@ else
     exit 0
 fi
 
-# Re-approve the policy file whenever its hash changes, otherwise aqua's
-# policy gate rejects non-standard registry packages with code 002.
-aqua_policy_path="${AQUA_POLICY_CONFIG:-$HOME/.config/aquaproj-aqua/aqua-policy.yaml}"
+# Policy gate: aqua rejects non-standard registry packages (code 002) unless a
+# policy file both (a) allows the registry and (b) is exported via
+# AQUA_POLICY_CONFIG so install actually loads it. Without the env var aqua
+# falls back to its standard-registry-only default policy, so `aqua policy
+# allow` alone is not enough — on a fresh machine ~/.zshenv hasn't been sourced
+# yet, so we must export it here ourselves. Resolve it next to the config we
+# picked above so the source-dir fallback works too.
+aqua_policy_path="$(dirname "$AQUA_CONFIG_PATH")/aqua-policy.yaml"
 if [[ -f "$aqua_policy_path" ]]; then
+    export AQUA_POLICY_CONFIG="$aqua_policy_path"
+    # Re-approve whenever the policy file's hash changes.
     "$aqua_cmd" policy allow "$aqua_policy_path"
 fi
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -164,5 +164,7 @@
       }
     ]
   },
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh"
 }


### PR DESCRIPTION
## Summary

Two unrelated changes bundled together:

### 1. `fix(bootstrap)` — aqua install rejected the third-party slipway package
`chezmoi apply` failed at script 05 phase 2 with aqua code 002 (`this package isn't allowed`) for `signalridge/slipway`.

**Root cause:** the script ran `aqua policy allow` (which only *trusts* the policy file) but never **exported `AQUA_POLICY_CONFIG`**, relying on it being inherited from `~/.zshenv`. On a fresh machine (zshenv not yet sourced) or any non-interactive apply the var is unset, so aqua falls back to its standard-registry-only default policy and rejects the third-party package. Trusting a policy file aqua never loads is a no-op.

**Fix:** export `AQUA_POLICY_CONFIG` before `aqua install`, and derive the policy path from the resolved config's directory so the source-dir fallback works too (instead of hardcoding `$HOME/.config`).

Verified locally: reproduced the exact 002 error with the var unset; install succeeds (`slipway 0.2.0`) after the fix; rendered script passes shellcheck.

### 2. `chore(claude)` — default to maximum persistable thinking
Persist `alwaysThinkingEnabled: true` and `effortLevel: "xhigh"` in the global Claude Code settings template. `xhigh` is the highest value that can be saved (`max` is session-only).

## Test plan
- [x] Reproduced 002 failure with `AQUA_POLICY_CONFIG` unset
- [x] `aqua install` succeeds after fix; slipway binary present
- [x] `shellcheck` clean on rendered script
- [x] `chezmoi apply` renders valid settings.json with the new keys
- [x] pre-commit hooks pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)