### PR TITLE
feat(tools): add vercel-labs/agent-browser CLI + skill

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -22,6 +22,7 @@ versions:
   cloudflareSkillsRev: 60147cbb773649eadca89cee92b4e0caf02234b4
   vercelLabsAgentSkillsRev: 180115660cfb8a86b808f117475a01f54caf3bc5
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
+  vercelLabsAgentBrowserRev: b4f2f37d7b4f954022bc77f8d6dce70e07072b00
   supabaseAgentSkillsRev: 577e626421fdb691902f158181e467a3dbf99410
   expoSkillsRev: fdd3df12151a208853fe540ffea9a67773446377
   microsoftSkillsRev: 858117a89d7e8f8c907141e1165b8816f3c18611

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -262,6 +262,21 @@
 {{- end }}
 
 # ------------------------------------------------------------------------------
+# vercel-labs/agent-browser skill stub
+# Discovery stub only; the real workflow content is served by the CLI at
+# runtime via `agent-browser skills get core`, so this file stays in sync with
+# whatever agent-browser version mise installs. The CLI itself comes from the
+# `npm:agent-browser` entry in mise/config.toml.tmpl.
+# ------------------------------------------------------------------------------
+[".agents/skills/ecosystem/vercel-labs/agent-browser"]
+    type = "archive"
+    url = "https://github.com/vercel-labs/agent-browser/archive/{{ $.versions.vercelLabsAgentBrowserRev }}.tar.gz"
+    exact = true
+    stripComponents = 3
+    include = ["agent-browser-*/skills/agent-browser/**"]
+    refreshPeriod = "168h"
+
+# ------------------------------------------------------------------------------
 # supabase/agent-skills database best practices
 # ------------------------------------------------------------------------------
 [".agents/skills/ecosystem/supabase/supabase-postgres-best-practices"]

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -47,6 +47,7 @@ jobs:
           cloudflare_skills_rev=$(gh api repos/cloudflare/skills/commits/main -q '.sha')
           vercel_labs_agent_skills_rev=$(gh api repos/vercel-labs/agent-skills/commits/main -q '.sha')
           vercel_labs_next_skills_rev=$(gh api repos/vercel-labs/next-skills/commits/main -q '.sha')
+          vercel_labs_agent_browser_rev=$(gh api repos/vercel-labs/agent-browser/commits/main -q '.sha')
           supabase_agent_skills_rev=$(gh api repos/supabase/agent-skills/commits/main -q '.sha')
           expo_skills_rev=$(gh api repos/expo/skills/commits/main -q '.sha')
           microsoft_skills_rev=$(gh api repos/microsoft/skills/commits/main -q '.sha')
@@ -79,6 +80,7 @@ jobs:
             echo "cloudflare_skills_rev=$cloudflare_skills_rev"
             echo "vercel_labs_agent_skills_rev=$vercel_labs_agent_skills_rev"
             echo "vercel_labs_next_skills_rev=$vercel_labs_next_skills_rev"
+            echo "vercel_labs_agent_browser_rev=$vercel_labs_agent_browser_rev"
             echo "supabase_agent_skills_rev=$supabase_agent_skills_rev"
             echo "expo_skills_rev=$expo_skills_rev"
             echo "microsoft_skills_rev=$microsoft_skills_rev"
@@ -112,6 +114,7 @@ jobs:
           sed -i 's/cloudflareSkillsRev: .*/cloudflareSkillsRev: ${{ steps.versions.outputs.cloudflare_skills_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/vercelLabsAgentSkillsRev: .*/vercelLabsAgentSkillsRev: ${{ steps.versions.outputs.vercel_labs_agent_skills_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/vercelLabsNextSkillsRev: .*/vercelLabsNextSkillsRev: ${{ steps.versions.outputs.vercel_labs_next_skills_rev }}/' .chezmoidata/versions.yaml
+          sed -i 's/vercelLabsAgentBrowserRev: .*/vercelLabsAgentBrowserRev: ${{ steps.versions.outputs.vercel_labs_agent_browser_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/supabaseAgentSkillsRev: .*/supabaseAgentSkillsRev: ${{ steps.versions.outputs.supabase_agent_skills_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/expoSkillsRev: .*/expoSkillsRev: ${{ steps.versions.outputs.expo_skills_rev }}/' .chezmoidata/versions.yaml
           sed -i 's/microsoftSkillsRev: .*/microsoftSkillsRev: ${{ steps.versions.outputs.microsoft_skills_rev }}/' .chezmoidata/versions.yaml

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -62,6 +62,11 @@ lua = "5.4"
 "npm:@ccusage/codex" = "latest"
 "npm:@ccusage/opencode" = "latest"
 
+# agent-browser: fast native Rust browser-automation CLI for AI agents.
+# The npm package ships the prebuilt binary; run `agent-browser install` once
+# to fetch Chrome for Testing (or it auto-detects an existing Chrome/Brave).
+"npm:agent-browser" = "latest"
+
 [settings]
 # Keep auto_install enabled for normal mise workflow.
 # Process storms were caused by shell PATH/init ordering, not this flag.


### PR DESCRIPTION
## What

Adds the [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser) browser-automation CLI and its Claude Code skill, managed through this repo's existing conventions.

## Changes

| File | Change |
|---|---|
| `private_dot_config/mise/config.toml.tmpl` | Add `"npm:agent-browser"` via the mise npm backend, alongside the other global JS CLIs |
| `.chezmoidata/versions.yaml` | Pin `vercelLabsAgentBrowserRev` to a commit SHA |
| `.chezmoiexternal.toml.tmpl` | Pull the skill stub into `.agents/skills/ecosystem/vercel-labs/agent-browser` via the same archive mechanism as the other ecosystem skills |
| `.github/workflows/update-versions.yml` | Register the repo so the rev pin auto-bumps |

## Why the skill is wired this way

agent-browser's `SKILL.md` is a **version-stable discovery stub** that defers to `agent-browser skills get core` at runtime, so the live workflow content always matches whatever version mise installs. A pinned static copy never goes stale, which fits the repo's existing `chezmoiexternal` + version-pin pattern exactly — no ad-hoc `npx skills add` stub to drift out of management.

## Verification

Applied and smoke-tested locally:
- CLI installed: `agent-browser 0.27.0`
- Chrome for Testing 149 provisioned via `agent-browser install`
- Skill stub on disk; `~/.claude/skills` → `~/.agents/skills` symlink resolves it
- `skills list` lists all 6 skills; live `open → snapshot → close` on example.com succeeds
- All pre-commit hooks pass (including template render/validation)

## Note

First-time setup on a new machine still needs one `agent-browser install` to fetch Chrome (noted in the mise config comment); the CLI itself installs automatically via mise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)