### PR TITLE
chore(aqua): update pinned packages (2026-05-30)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,7 +21,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.154
+  - name: anthropics/claude-code@v2.1.157
   - name: openai/codex@rust-v0.135.0
   - name: anomalyco/opencode@v1.15.12
   - name: direnv/direnv@v2.37.1
@@ -47,7 +47,7 @@ packages:
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
   - name: git-lfs/git-lfs@v3.7.1
   - name: charmbracelet/glow@v2.1.2
-  - name: carapace-sh/carapace-bin@v1.6.6
+  - name: carapace-sh/carapace-bin@v1.7.0
   - name: jqlang/jq@jq-1.8.1
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
@@ -73,7 +73,7 @@ packages:
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.46.3
+  - name: crate-ci/typos@v1.47.0
   - name: zizmorcore/zizmor@v1.25.2
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.