### PR TITLE
feat(tools): replace npx with bun/bunx for MCP servers and JS installs

### DIFF
--- a/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
@@ -177,7 +177,7 @@ ensure_user_mcp_http() {
     esac
 }
 
-ensure_user_mcp_json "slack" '{"command":"npx","args":["-y","@anthropic/mcp-server-slack"],"env":{"SLACK_BOT_TOKEN":"${SLACK_BOT_TOKEN}","SLACK_TEAM_ID":"${SLACK_TEAM_ID}"}}'
+ensure_user_mcp_json "slack" '{"command":"bunx","args":["@anthropic/mcp-server-slack"],"env":{"SLACK_BOT_TOKEN":"${SLACK_BOT_TOKEN}","SLACK_TEAM_ID":"${SLACK_TEAM_ID}"}}'
 
 ensure_user_mcp_json "slack-explorer" '{"command":"docker","args":["run","-i","--rm","--pull","always","ghcr.io/shibayu36/slack-explorer-mcp:latest"],"env":{"SLACK_USER_TOKEN":"${SLACK_USER_TOKEN}"}}'
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -75,6 +75,8 @@
       "Bash(mise:*)",
       "Bash(npm:*)",
       "Bash(npx:*)",
+      "Bash(bun:*)",
+      "Bash(bunx:*)",
       "Bash(nix:*)",
       "Bash(chezmoi:*)"
     ],

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -149,8 +149,8 @@ base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 # =============================================================================
 
 [mcp_servers.notion]
-command = "npx"
-args = ["-y", "@anthropic/mcp-server-notion"]
+command = "bunx"
+args = ["@anthropic/mcp-server-notion"]
 [mcp_servers.notion.env]
 NOTION_API_KEY = "${NOTION_API_KEY}"
 
@@ -170,8 +170,8 @@ startup_timeout_sec = 30
 AQUA_GLOBAL_CONFIG = "{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml"
 
 [mcp_servers.slack]
-command = "npx"
-args = ["-y", "@anthropic/mcp-server-slack"]
+command = "bunx"
+args = ["@anthropic/mcp-server-slack"]
 [mcp_servers.slack.env]
 SLACK_BOT_TOKEN = "${SLACK_BOT_TOKEN}"
 SLACK_TEAM_ID = "${SLACK_TEAM_ID}"

--- a/dot_local/bin/executable_mcp-context7
+++ b/dot_local/bin/executable_mcp-context7
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib/common"
 
-require_cmd npx
+require_cmd bunx
 
 CONTEXT7_PACKAGE="@upstash/context7-mcp@2.1.1"
 CONTEXT7_GOPASS_PATH="context7/api_key"
@@ -23,7 +23,7 @@ fi
 if [[ -n "$context7_api_key" ]]; then
     export CONTEXT7_API_KEY="$context7_api_key"
     # Keep key in env only to avoid exposing it through argv/process list.
-    exec npx -y "$CONTEXT7_PACKAGE" "$@"
+    exec bunx "$CONTEXT7_PACKAGE" "$@"
 fi
 
-exec npx -y "$CONTEXT7_PACKAGE" "$@"
+exec bunx "$CONTEXT7_PACKAGE" "$@"

--- a/dot_local/bin/executable_mcp-postgres
+++ b/dot_local/bin/executable_mcp-postgres
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib/common"
 
-require_cmd npx
+require_cmd bunx
 
 PG_DSN_GOPASS_PATH="postgres/api_key"
 
@@ -28,4 +28,4 @@ fi
 # Upstream server-postgres currently requires DSN as argv[1].
 # This means DSN may be visible in process listings on the local machine.
 log_warn "server-postgres requires DSN as argv; DSN may be visible in process list"
-exec npx -y @modelcontextprotocol/server-postgres@0.6.2 "$PG_DSN" "$@"
+exec bunx @modelcontextprotocol/server-postgres@0.6.2 "$PG_DSN" "$@"

--- a/dot_local/bin/executable_mcp-tavily
+++ b/dot_local/bin/executable_mcp-tavily
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib/common"
 
-require_cmd npx
+require_cmd bunx
 
 # Keep path simple as requested.
 TAVILY_GOPASS_PATH="tavily/api_key"
@@ -28,4 +28,4 @@ fi
 export TAVILY_API_KEY
 
 # Pin package version for reproducibility.
-exec npx -y tavily-mcp@0.2.16 "$@"
+exec bunx tavily-mcp@0.2.16 "$@"

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -2,8 +2,15 @@
 # https://mise.jdx.dev/configuration.html
 
 [tools]
-# Node.js (used for global JS CLIs via npm/npx)
+# Node.js — still REQUIRED at runtime even after the bun migration: globally
+# installed JS CLIs keep their `#!/usr/bin/env node` shebangs, so `node` must
+# stay on PATH. bun replaces npx (MCP wrappers) and the npm install backend,
+# not the Node runtime itself.
 node = "lts"
+
+# Bun — runs MCP servers via `bunx` (see ~/.local/bin/mcp-*) and, via
+# settings.npm.package_manager below, becomes the installer for all `npm:` CLIs.
+bun = "latest"
 
 # Terraform (replaces tenv)
 terraform = "latest"
@@ -88,6 +95,17 @@ trusted_config_paths = [
 # Always keep latest versions
 always_keep_download = false
 always_keep_install = false
+
+[settings.npm]
+# Use bun as the installer/runner for every `npm:` backend tool above.
+# Unified toolchain + much faster installs. Node still provides the runtime.
+# CAVEAT: this switch is global (no per-package opt-out). bun also skips
+# package lifecycle scripts by default — if a tool that downloads a binary in
+# postinstall goes missing after `mise install`, add `bun_args = "--trust"` to
+# that specific tool entry. Known risk: @google/gemini-cli has bun-install
+# issues; verify `gemini --version` after switching, and revert this to "npm"
+# if it breaks.
+package_manager = "bun"
 
 [env]
 # Add local bin to PATH


### PR DESCRIPTION
## Summary

Migrate the JavaScript toolchain from `npx` to **bun/bunx**. `bunx` replaces every `npx -y` call (MCP servers) and bun becomes the install backend for mise `npm:` tools. **Node is intentionally kept** as a passive runtime — globally installed JS CLIs still resolve their `#!/usr/bin/env node` shebangs to node, so removing it would break `gemini-cli` and lose Node's reference compatibility for zero practical gain.

## Type of Change

- [x] `feat` - New feature or functionality

## Changes

- **MCP wrappers** (`mcp-context7` / `mcp-tavily` / `mcp-postgres`): `exec bunx …` instead of `npx -y …`; `require_cmd bunx`
- **codex + claude MCP configs** (notion / slack): `command = "bunx"`, dropped `-y`
- **mise** (`config.toml.tmpl`): add `bun = "latest"`; keep `node = "lts"`; set `[settings.npm] package_manager = "bun"` so npm-backend installs go through bun
- **Claude settings**: allowlist `Bash(bun:*)` / `Bash(bunx:*)` (kept `Bash(npx:*)` as fallback)

## Why bun

- MCP cold start ~10 ms vs ~200 ms for npx
- `bunx` resolves the `ERR_MODULE_NOT_FOUND` class of issues that npx hits with `@upstash/context7-mcp` (upstream-recommended workaround)
- Unified, faster install backend

## Notes / caveats

- `package_manager = "bun"` is **global** (no per-package opt-out) and only takes effect on the next (re)install/upgrade — existing globals keep working. bun skips lifecycle scripts by default; add `bun_args = "--trust"` per-tool if a postinstall-binary tool goes missing.
- **`@google/gemini-cli` has known bun-install issues** (google-gemini/gemini-cli#2714). If `gemini --version` breaks after it gets reinstalled via bun, revert that one setting to `"npm"`.

## Testing

- [x] Pre-commit hooks pass locally (incl. `Validate templates (render + check)`)
- [x] `mise` config renders + validates as TOML (`package_manager=bun`, `bun=latest`, `node=lts`)
- [x] `shellcheck -S error` clean on the three edited wrappers
- [ ] Tested on: macOS (pending `chezmoi apply` + `mise install` on host)

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or sensitive data included
- [x] Templates render correctly (check CI Lint job)
- [x] Nix flake checks pass (if nix-config changes) — n/a, no nix-config changes