### PR TITLE
chore(aqua): bump slipway to v0.3.0

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.2.0
+  - name: signalridge/slipway@v0.3.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## Summary
Bumps the `signalridge/slipway` aqua pin from **v0.2.0 → v0.3.0** ([latest release](https://github.com/signalridge/slipway/releases/tag/v0.3.0), published 2026-05-30).

## Details
- Single-line change in `private_dot_config/aquaproj-aqua/aqua.yaml`.
- No `registry.yaml` change needed — the third-party registry asset template (`slipway_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz`) already matches v0.3.0's asset naming.
- No aqua checksum file in the repo, so no checksum update required.

## Verification
```
$ aqua exec -- slipway --version
slipway 0.3.0
  commit: 778c20c
  built:  2026-05-30T07:10:52Z
```
The v0.3.0 binary downloads and runs cleanly. The aqua shim picks it up system-wide after the next `chezmoi apply` (script 05 re-runs the aqua install on config-hash change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)