### PR TITLE
chore(aqua): bump slipway to v0.3.1

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.3.0
+  - name: signalridge/slipway@v0.3.1
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## Summary
Bump the aqua-managed `signalridge/slipway` pin from `v0.3.0` → `v0.3.1` ([release](https://github.com/signalridge/slipway/releases/tag/v0.3.1), 2026-05-30).

## Details
- Only `private_dot_config/aquaproj-aqua/aqua.yaml` changes — the v0.3.1 release assets match the existing `registry.yaml` naming pattern (`slipway_0.3.1_{os}_{arch}.tar.gz`, Windows `.zip`), and `aqua-policy.yaml` already allow-lists the third-party registry, so no registry/policy changes are needed.

## Verification
Applied locally and confirmed the binary resolves:
```
$ slipway --version
slipway 0.3.1
  commit: 02ffb9f
  built:  2026-05-30T15:26:48Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)