### PR TITLE
fix(skills): quote oss-launch SKILL.md description to fix YAML parse error

### DIFF
--- a/dot_agents/skills/social-media/oss-x-post/SKILL.md
+++ b/dot_agents/skills/social-media/oss-x-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oss-launch
-description: Turn one open-source release/topic into platform-tailored posts and publish them through a gated, auditable path. Use when the user wants to announce or promote an OSS project/release across X, Bluesky, dev.to, Reddit, Hacker News, etc. Triggers: "announce my release", "promote my repo", "post about this project", "oss launch", "Show HN", "发布开源项目", "宣传项目".
+description: 'Turn one open-source release/topic into platform-tailored posts and publish them through a gated, auditable path. Use when the user wants to announce or promote an OSS project/release across X, Bluesky, dev.to, Reddit, Hacker News, etc. Triggers: "announce my release", "promote my repo", "post about this project", "oss launch", "Show HN", "发布开源项目", "宣传项目".'
 ---
 
 # OSS Launch


### PR DESCRIPTION
## What

Quote the `description` value in `dot_agents/skills/social-media/oss-x-post/SKILL.md` frontmatter.

## Why

Loading the skill failed with:

```
invalid YAML: mapping values are not allowed in this context at line 2 column 259
```

The `description` value contained `Triggers: ` (colon followed by a space). In an unquoted YAML scalar, `: ` is interpreted as the start of a new mapping key, so the parser errored at the `Triggers:` position.

## Fix

Wrap the entire `description` value in single quotes. The value contains only double quotes (and no single quotes), so single-quoting is safe and needs no escaping. Verified the frontmatter now parses cleanly with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)