### PR TITLE
feat(mcp): cross-configure claude-code-mcp and codex-mcp

### DIFF
--- a/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
@@ -190,3 +190,7 @@ ensure_user_mcp_json "tavily" '{"command":"{{ .chezmoi.homeDir }}/.local/bin/mcp
 ensure_user_mcp_json "postgres" '{"command":"{{ .chezmoi.homeDir }}/.local/bin/mcp-postgres","args":[]}'
 ensure_user_mcp_http "gitmcp" "https://gitmcp.io/docs"
 ensure_user_mcp_http "deepwiki" "https://mcp.deepwiki.com/mcp"
+
+# Wraps Codex as MCP tools so Claude can delegate coding tasks to Codex.
+# https://github.com/xihuai18/codex-mcp
+ensure_user_mcp_json "codex-mcp" '{"command":"bunx","args":["@leo000001/codex-mcp"]}'

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -186,6 +186,12 @@ url = "https://gitmcp.io/docs"
 [mcp_servers.deepwiki]
 url = "https://mcp.deepwiki.com/mcp"
 
+# Wraps Claude Code as MCP tools so Codex can delegate coding tasks to Claude.
+# https://github.com/xihuai18/claude-code-mcp
+[mcp_servers.claude-code-mcp]
+command = "bunx"
+args = ["@leo000001/claude-code-mcp"]
+
 # =============================================================================
 # Profiles
 # =============================================================================


### PR DESCRIPTION
## What

Bridge Claude Code and Codex via MCP so each agent can delegate coding tasks to the other. Configured **cross-wise** to avoid self-reference:

| Config | Added MCP server | Effect |
|--------|------------------|--------|
| Codex (`dot_codex/modify_config.toml.tmpl`) | `claude-code-mcp` | Codex can call Claude |
| Claude (`run_after_11_sync-claude-mcp.sh.tmpl`) | `codex-mcp` | Claude can call Codex |

## Why cross-configured

`claude-code-mcp` wraps Claude as a tool, `codex-mcp` wraps Codex as a tool. Each is only useful inside the *other* agent — putting a server inside the agent it wraps would be a redundant self-reference. So Codex gets the Claude wrapper and vice versa.

## Details

- Sources: [xihuai18/claude-code-mcp](https://github.com/xihuai18/claude-code-mcp) (`@leo000001/claude-code-mcp`), [xihuai18/codex-mcp](https://github.com/xihuai18/codex-mcp) (`@leo000001/codex-mcp`)
- Uses `bunx` to match repo convention (#544 replaced npx with bun/bunx for MCP servers)
- Codex change is in the `modify_` template's heredoc; `[projects.*]` trust sections remain preserved by the existing awk pass
- Claude change is one idempotent `ensure_user_mcp_json` line in the sync script

## Verification (applied locally)

- Codex: `claude-code-mcp` enabled, no `codex-mcp` self-ref, 5 `[projects.*]` sections preserved
- Claude: `codex-mcp` reports ✓ Connected, no `claude-code-mcp` self-ref
- Pre-commit template render/check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)