### PR TITLE
chore(aqua): bump slipway to v0.3.2

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.3.1
+  - name: signalridge/slipway@v0.3.2
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## What

Bump `signalridge/slipway` from **v0.3.1** to **v0.3.2** in the aqua manifest.

## Why

v0.3.2 is the latest release (published 2026-05-30). Follow-up to #547.

## Details

- Release assets match the existing third-party registry template (`slipway_{version}_{os}_{arch}.tar.gz`); no `registry.yaml` change needed.
- Covered by the existing `aqua-policy.yaml` third-party registry allow-list; no policy change needed.
- Verified installed binary: `slipway 0.3.2` (commit `fbf23bb`, built 2026-05-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)