### PR TITLE
fix(tmux): detect live agent busy state

### DIFF
--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -246,7 +246,7 @@ Left: `session`
 
 Right: `git` | `AI agents`
 
-`AI agents` is provided by `~/.config/tmux/tmux2k-ai.sh`. It reports foreground `claude`, `codex`, and `opencode` sessions attached to tmux panes as stable dots, for example `󰚩 ■○■`. Non-current panes use `■` for busy and `□` for idle or unknown; the current pane uses `●` for busy and `○` for idle or unknown. The shape highlights the current window without changing the underlying busy state. The busy signal comes from `tmux-ai-agent-state` hooks, with a narrow fallback to Claude/Codex's visible "esc to interrupt" TUI status for already-running sessions that have not loaded hooks yet. It does not use tmux `window_activity`, generic pane content changes, keyboard input, CPU, or network heuristics.
+`AI agents` is provided by `~/.config/tmux/tmux2k-ai.sh`. It reports foreground `claude`, `codex`, and `opencode` sessions attached to tmux panes as stable dots, for example `󰚩 ■○■`. Non-current panes use `■` for busy and `□` for idle or unknown; the current pane uses `●` for busy and `○` for idle or unknown. The shape highlights the current window without changing the underlying busy state. The busy signal comes from `tmux-ai-agent-state` hooks, with a narrow fallback to Claude/Codex's visible "esc to interrupt" TUI status when hook state is missing or stale. It does not use tmux `window_activity`, generic pane content changes, keyboard input, CPU, or network heuristics.
 
 ---
 

--- a/private_dot_config/tmux/executable_tmux2k-ai.sh
+++ b/private_dot_config/tmux/executable_tmux2k-ai.sh
@@ -244,6 +244,10 @@ pane_is_busy() {
         return 0
         ;;
     idle)
+        # Session-start or resume hooks can write an idle baseline before Codex
+        # begins an automatic continuation. If the live TUI footer says the
+        # turn is interruptible, treat that as the fresher signal.
+        pane_tui_looks_busy "$pane_id" && return 0
         return 1
         ;;
     esac

--- a/tests/test_tmux_ai_status.sh
+++ b/tests/test_tmux_ai_status.sh
@@ -260,8 +260,12 @@ assert_file_contains "$state_dir/_2.state" "state=idle"
 assert_equals "$(run_status s:2)" "AI ■○■"
 
 TMUX_AI_BUSY_PANES="%2"
-assert_equals "$(run_status s:2)" "AI ■○■"
+assert_equals "$(run_status s:2)" "AI ■●■"
 unset TMUX_AI_BUSY_PANES
+
+TMUX_AI_STALE_BUSY_PANES="%2"
+assert_equals "$(run_status s:2)" "AI ■○■"
+unset TMUX_AI_STALE_BUSY_PANES
 
 codex_abort_transcript="$TMP_ROOT/codex-abort.jsonl"
 cat >"$codex_abort_transcript" <<'EOF'


### PR DESCRIPTION
## Summary
- Treat a live Claude/Codex `esc to interrupt` footer as fresher than a stale idle hook state.
- Preserve protection against old scrollback forcing a busy state.
- Update tmux AI status docs for stale hook fallback behavior.

## Tests
- `bash tests/test_tmux_ai_status.sh`
- `bash tests/test_codex_config_rendering.sh`
- `git diff --cached --check`
- `bash tests/run.sh`