### PR TITLE
chore(aqua): bump slipway to v0.3.3

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.3.2
+  - name: signalridge/slipway@v0.3.3
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## Summary

Bumps the aqua-pinned `signalridge/slipway` from **v0.3.2 → v0.3.3** ([release](https://github.com/signalridge/slipway/releases/tag/v0.3.3), published 2026-05-31).

## Details

- Single-line pin update in `private_dot_config/aquaproj-aqua/aqua.yaml`.
- No registry/policy changes needed — `aqua-policy.yaml` allow-lists the entire `third-party` local registry.

## Verification

Applied locally and installed via aqua:

```
$ slipway --version
slipway 0.3.3
  commit: ba148a3
  built:  2026-05-31T07:01:29Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)