### PR TITLE
chore(aqua): bump slipway to v0.3.4

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.3.3
+  - name: signalridge/slipway@v0.3.4
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
## Summary
- Bump pinned `signalridge/slipway` from `v0.3.4` ← `v0.3.3` in the aqua manifest.
- [Release v0.3.4](https://github.com/signalridge/slipway/releases/tag/v0.3.4) (published 2026-05-31).

## Changes
- `private_dot_config/aquaproj-aqua/aqua.yaml`: `signalridge/slipway@v0.3.3` → `@v0.3.4`

No registry/policy changes needed — the third-party registry is generically allow-listed and there is no checksum lockfile.

## Verification
- `chezmoi apply` + `aqua i` → installed locally, `slipway 0.3.4` (commit `6782af2`) confirmed on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)