### PR TITLE
chore(versions): update pinned versions (2026-06-01)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -7,7 +7,7 @@ versions:
   aquaInstaller: v4.0.4
   aquaInstallerSha256: acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28
   aquaVersion: v2.59.1
-  nixIndexDb: 2026-05-24-062331
+  nixIndexDb: 2026-05-31-064259
   paperlib: 3.1.12
   claudeWshobsonAgentsRev: 0818067b4ecad18c234b2ae427cc44f2053792d4
   claudeWshobsonAgentsSha256: d4324ca3724f9946cd1af40c66e16a143d620ed06f4eb67519809df6ecda961e
@@ -16,7 +16,7 @@ versions:
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
   openaiSkillsRev: a8924c2a35cfa290458852c4fad17c9133054c2e
-  huggingfaceSkillsRev: c471b5e941d69fc4a99cdbc09497d5b338f07a0e
+  huggingfaceSkillsRev: 49abf82b2ef2ff2bcc6ca072aac0fe8627390a1d
   getsentrySkillsRev: b10e2db21d3165de1904bdf3fa64285016765fe5
   trailofbitsSkillsRev: c94841be3deae8a880fa1a9078979adac7ca3dbc
   cloudflareSkillsRev: 60147cbb773649eadca89cee92b4e0caf02234b4
@@ -26,7 +26,7 @@ versions:
   supabaseAgentSkillsRev: 577e626421fdb691902f158181e467a3dbf99410
   expoSkillsRev: fdd3df12151a208853fe540ffea9a67773446377
   microsoftSkillsRev: 684313b5263c04177dd0e232571feae1c9079573
-  sickn33AntigravitySkillsRev: 472f39688b1b4e1afacef0d9fa2d7b40e7dc7c42
+  sickn33AntigravitySkillsRev: 22710e9767607233281cae3298a92d30b55406d5
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.1` |
| nix-index-database | `2026-05-31-064259` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `49abf82b2ef2ff2bcc6ca072aac0fe8627390a1d` |
| getsentry/skills | `b10e2db21d3165de1904bdf3fa64285016765fe5` |
| trailofbits/skills | `c94841be3deae8a880fa1a9078979adac7ca3dbc` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `180115660cfb8a86b808f117475a01f54caf3bc5` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `577e626421fdb691902f158181e467a3dbf99410` |
| expo/skills | `fdd3df12151a208853fe540ffea9a67773446377` |
| microsoft/skills | `684313b5263c04177dd0e232571feae1c9079573` |
| sickn33/antigravity-awesome-skills | `22710e9767607233281cae3298a92d30b55406d5` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `a2ace14a88a6746f64f1f53ed8272d6788828038` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |