### PR TITLE
chore(aqua): update pinned packages (2026-06-01)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,7 +21,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.158
+  - name: anthropics/claude-code@v2.1.159
   - name: openai/codex@rust-v0.135.0
   - name: anomalyco/opencode@v1.15.13
   - name: direnv/direnv@v2.37.1
@@ -29,7 +29,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.5.16
+  - name: jdx/mise@v2026.5.18
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.