### PR TITLE
chore(aqua): bump slipway to v0.4.0

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.3.4
+  - name: signalridge/slipway@v0.4.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.88


### PR DESCRIPTION
Bumps the aqua-pinned `signalridge/slipway` from `v0.3.4` to `v0.4.0`.

## Upstream changes ([v0.3.4...v0.4.0](https://github.com/signalridge/slipway/compare/v0.3.4...v0.4.0))
- fix(intake): reject invalid stdin classification and surface valid tokens (#43)
- refactor(governance): remove obsolete agent template surface (#45)
- feat(codebase-map): nudge discovery-scoped changes off an empty map (#41)

No config-format changes. Verified locally: `slipway 0.4.0` installs and runs via the aqua proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)