### PR TITLE
chore(aqua): bump slipway to v0.5.0

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.4.1
+  - name: signalridge/slipway@v0.5.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89


### PR DESCRIPTION
## Summary

Bumps the pinned `signalridge/slipway` governance CLI from `v0.4.1` to `v0.5.0` in the aqua manifest.

## Type of Change

- [x] `chore` - Maintenance, dependencies, CI/CD

## Changes

- `private_dot_config/aquaproj-aqua/aqua.yaml`: `signalridge/slipway@v0.4.1` → `@v0.5.0`

Upstream v0.5.0 ([release](https://github.com/signalridge/slipway/releases/tag/v0.5.0)):
- feat(evidence): add task ledger and closeout reuse (#63)
- fix(governance): add stale planning recovery (#64)
- fix(workflow): issue #53 tier 1 next/done diagnostics (#60)

## Testing

- [x] `chezmoi apply` succeeded; `slipway --version` reports `0.5.0` (commit 82f92be)
- [x] Pre-commit hooks pass locally
- [x] Tested on: macOS (darwin/arm64)

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or sensitive data included
- [x] Templates render correctly (check CI Lint job)
- [x] Nix flake checks pass (if nix-config changes) — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)