### PR TITLE
chore(versions): update pinned versions (2026-06-04)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -25,8 +25,8 @@ versions:
   vercelLabsAgentBrowserRev: 90050f2913159875e2c3719e424746396ccb3cbf
   supabaseAgentSkillsRev: 759fddfc29ebc96b88b4bebb89ebb484a39aa6e2
   expoSkillsRev: fdd3df12151a208853fe540ffea9a67773446377
-  microsoftSkillsRev: 5e4ea8a892c5bffcf1b488903751135e4abc505f
-  sickn33AntigravitySkillsRev: 99b7d3b95757ab991b01244ff5015c267b8f1550
+  microsoftSkillsRev: 1733106c8b98635167e1a13155be932ccc92b9d5
+  sickn33AntigravitySkillsRev: 519aa98f9afe08a5494017d5540925473d428374
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.1` |
| nix-index-database | `2026-05-31-064259` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `49abf82b2ef2ff2bcc6ca072aac0fe8627390a1d` |
| getsentry/skills | `b10e2db21d3165de1904bdf3fa64285016765fe5` |
| trailofbits/skills | `c94841be3deae8a880fa1a9078979adac7ca3dbc` |
| cloudflare/skills | `60147cbb773649eadca89cee92b4e0caf02234b4` |
| vercel-labs/agent-skills | `4ec6f84b61cd3c931046c3e6e398f3ae7de372f7` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `759fddfc29ebc96b88b4bebb89ebb484a39aa6e2` |
| expo/skills | `fdd3df12151a208853fe540ffea9a67773446377` |
| microsoft/skills | `1733106c8b98635167e1a13155be932ccc92b9d5` |
| sickn33/antigravity-awesome-skills | `519aa98f9afe08a5494017d5540925473d428374` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `a2ace14a88a6746f64f1f53ed8272d6788828038` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |