### PR TITLE
chore(aqua): update pinned packages (2026-06-04)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,7 +21,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.161
+  - name: anthropics/claude-code@v2.1.162
   - name: openai/codex@rust-v0.136.0
   - name: anomalyco/opencode@v1.15.13
   - name: direnv/direnv@v2.37.1
@@ -29,7 +29,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.5.18
+  - name: jdx/mise@v2026.6.0
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -37,7 +37,7 @@ packages:
   - name: dandavison/delta@0.19.2
   - name: Wilfred/difftastic@0.69.0
   - name: eza-community/eza@v0.23.4
-  - name: fastfetch-cli/fastfetch@2.63.1
+  - name: fastfetch-cli/fastfetch@2.64.0
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.73.1
   - name: gopasspw/gopass@v1.16.1
@@ -73,7 +73,7 @@ packages:
   - name: starship/starship@v1.25.1
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.47.0
+  - name: crate-ci/typos@v1.47.1
   - name: zizmorcore/zizmor@v1.25.2
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
@@ -108,10 +108,10 @@ packages:
   - name: kubernetes-sigs/krew@v0.5.0
   - name: aquasecurity/trivy@v0.71.0
   - name: anchore/syft@v1.45.0
-  - name: anchore/grype@v0.112.0
+  - name: anchore/grype@v0.113.0
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0
-  - name: terraform-linters/tflint@v0.63.0
+  - name: terraform-linters/tflint@v0.63.1
   - name: quarto-dev/quarto-cli@v1.9.38
   - name: typst/typst@v0.14.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.