### PR TITLE
feat(skills): Model B — nested library + curated user-level skills

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -31,53 +31,104 @@
 
 # ------------------------------------------------------------------------------
 # wshobson/agents plugins (skills only)
-# - Skills are shared for Claude + Codex via .agents/skills/
-# - Hardcoded plugin list (single source of truth in this template)
+# - Enumerated per-skill and nested as <plugin>/<skill> so the folder is the
+#   category. A per-plugin exact glob + `exclude` tripped chezmoi's
+#   "inconsistent state"; per-skill externals avoid it. Curate by adding /
+#   removing entries — the dropped skills are simply not listed.
 # ------------------------------------------------------------------------------
-{{- $wshobsonPlugins := list
-  "developer-essentials"
-  "python-development"
-  "backend-development"
-  "systems-programming"
-  "documentation-generation"
-  "llm-application-dev"
-  "data-engineering"
-  "javascript-typescript"
-  "frontend-mobile-development"
-  "shell-scripting"
-  "observability-monitoring"
-  "cloud-infrastructure"
-  "cicd-automation"
-  "kubernetes-operations"
+{{- $wshobsonSkills := list
+  "developer-essentials/auth-implementation-patterns"
+  "developer-essentials/bazel-build-optimization"
+  "developer-essentials/debugging-strategies"
+  "developer-essentials/e2e-testing-patterns"
+  "developer-essentials/error-handling-patterns"
+  "developer-essentials/git-advanced-workflows"
+  "developer-essentials/monorepo-management"
+  "developer-essentials/sql-optimization-patterns"
+  "python-development/async-python-patterns"
+  "python-development/python-anti-patterns"
+  "python-development/python-background-jobs"
+  "python-development/python-code-style"
+  "python-development/python-configuration"
+  "python-development/python-design-patterns"
+  "python-development/python-error-handling"
+  "python-development/python-observability"
+  "python-development/python-packaging"
+  "python-development/python-performance-optimization"
+  "python-development/python-project-structure"
+  "python-development/python-resilience"
+  "python-development/python-resource-management"
+  "python-development/python-testing-patterns"
+  "python-development/python-type-safety"
+  "backend-development/api-design-principles"
+  "backend-development/architecture-patterns"
+  "backend-development/cqrs-implementation"
+  "backend-development/event-store-design"
+  "backend-development/microservices-patterns"
+  "backend-development/projection-patterns"
+  "backend-development/saga-orchestration"
+  "backend-development/temporal-python-testing"
+  "backend-development/workflow-orchestration-patterns"
+  "systems-programming/go-concurrency-patterns"
+  "systems-programming/memory-safety-patterns"
+  "systems-programming/rust-async-patterns"
+  "documentation-generation/architecture-decision-records"
+  "documentation-generation/changelog-automation"
+  "documentation-generation/openapi-spec-generation"
+  "llm-application-dev/embedding-strategies"
+  "llm-application-dev/hybrid-search-implementation"
+  "llm-application-dev/langchain-architecture"
+  "llm-application-dev/llm-evaluation"
+  "llm-application-dev/prompt-engineering-patterns"
+  "llm-application-dev/rag-implementation"
+  "llm-application-dev/similarity-search-patterns"
+  "llm-application-dev/vector-index-tuning"
+  "data-engineering/airflow-dag-patterns"
+  "data-engineering/data-quality-frameworks"
+  "data-engineering/dbt-transformation-patterns"
+  "data-engineering/spark-optimization"
+  "javascript-typescript/javascript-testing-patterns"
+  "javascript-typescript/modern-javascript-patterns"
+  "javascript-typescript/nodejs-backend-patterns"
+  "javascript-typescript/typescript-advanced-types"
+  "frontend-mobile-development/react-native-architecture"
+  "frontend-mobile-development/react-state-management"
+  "frontend-mobile-development/tailwind-design-system"
+  "shell-scripting/bash-defensive-patterns"
+  "shell-scripting/bats-testing-patterns"
+  "shell-scripting/shellcheck-configuration"
+  "observability-monitoring/distributed-tracing"
+  "observability-monitoring/grafana-dashboards"
+  "observability-monitoring/prometheus-configuration"
+  "observability-monitoring/slo-implementation"
+  "cloud-infrastructure/cost-optimization"
+  "cloud-infrastructure/hybrid-cloud-networking"
+  "cloud-infrastructure/istio-traffic-management"
+  "cloud-infrastructure/linkerd-patterns"
+  "cloud-infrastructure/mtls-configuration"
+  "cloud-infrastructure/multi-cloud-architecture"
+  "cloud-infrastructure/service-mesh-observability"
+  "cloud-infrastructure/terraform-module-library"
+  "cicd-automation/deployment-pipeline-design"
+  "cicd-automation/github-actions-templates"
+  "cicd-automation/gitlab-ci-patterns"
+  "cicd-automation/secrets-management"
+  "kubernetes-operations/gitops-workflow"
+  "kubernetes-operations/helm-chart-scaffolding"
+  "kubernetes-operations/k8s-manifest-generator"
+  "kubernetes-operations/k8s-security-policies"
 }}
-{{/* Per-plugin surgical exclusions: drop individual redundant sub-skills
-     without dropping the whole plugin archive. With exact = true, chezmoi
-     removes any excluded skill dir on apply/refresh and keeps it gone. */}}
-{{- $wshobsonExcludes := dict
-  "developer-essentials" (list
-    "agents-*/plugins/developer-essentials/skills/code-review-excellence/**"
-    "agents-*/plugins/developer-essentials/skills/nx-workspace-patterns/**"
-    "agents-*/plugins/developer-essentials/skills/turborepo-caching/**")
-  "python-development" (list
-    "agents-*/plugins/python-development/skills/uv-package-manager/**")
-  "frontend-mobile-development" (list
-    "agents-*/plugins/frontend-mobile-development/skills/nextjs-app-router-patterns/**")
-}}
-{{- range $plugin := $wshobsonPlugins }}
-[".agents/skills/{{ $plugin }}"]
+{{- range $entry := $wshobsonSkills }}
+{{- $parts := splitList "/" $entry }}
+{{- $plugin := index $parts 0 }}
+{{- $skill := index $parts 1 }}
+[".agents/skills/{{ $plugin }}/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/wshobson/agents/archive/{{ $.versions.claudeWshobsonAgentsRev }}.tar.gz"
     checksum.sha256 = "{{ $.versions.claudeWshobsonAgentsSha256 }}"
     exact = true
-    stripComponents = 4
-    include = ["agents-*/plugins/{{ $plugin }}/skills/**"]
-{{- if hasKey $wshobsonExcludes $plugin }}
-    exclude = [
-{{- range $pattern := index $wshobsonExcludes $plugin }}
-      "{{ $pattern }}",
-{{- end }}
-    ]
-{{- end }}
+    stripComponents = 5
+    include = ["agents-*/plugins/{{ $plugin }}/skills/{{ $skill }}/**"]
     refreshPeriod = "168h"
 
 {{- end }}

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -19,121 +19,65 @@
     refreshPeriod = "168h"
 
 # ==============================================================================
-# Shared AI Skills (Claude Code + Codex CLI)
-#
-# All skills land FLAT at ~/.agents/skills/<skill>/SKILL.md (no collection
-# namespace dirs). This is the single layout both tools discover natively:
-#   - Claude Code only finds DIRECT children ~/.claude/skills/<skill>/ and does
-#     NOT recurse, so the flat layout is required for it to see every skill
-#     (~/.claude/skills is a single symlink -> ~/.agents/skills).
-#   - Codex scans .agents/skills (recursively) and is happy either way.
-#
-# Hardcoded skill lists in this template are the single source of truth. Each
-# external owns exactly one ~/.agents/skills/<skill> dir; targets must be unique
-# across every source (no two skills may share a name).
-# Agents and commands remain in ~/.claude/ (Claude Code specific).
+# Shared AI Tools Plugins
+# Skills are shared between Claude Code and Codex CLI via ~/.agents/skills/
+# Agents and commands remain in ~/.claude/ (Claude Code specific)
+# Hardcoded plugin/skill lists in this template are the single source of truth
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# wshobson/agents plugins (skills only)
-# - Enumerated per-skill (was a per-plugin `skills/**` glob) so each skill can
-#   land flat at .agents/skills/<skill>. Curate by adding/removing list entries;
-#   omission replaces the old per-plugin `exclude` patterns.
-# - "<plugin>/<skill>" — plugin selects the archive subtree, skill is the target.
+# Shared AI Skills (hardcoded baseline for Claude + Codex)
 # ------------------------------------------------------------------------------
-{{- $wshobsonSkills := list
-  "developer-essentials/auth-implementation-patterns"
-  "developer-essentials/bazel-build-optimization"
-  "developer-essentials/debugging-strategies"
-  "developer-essentials/e2e-testing-patterns"
-  "developer-essentials/error-handling-patterns"
-  "developer-essentials/git-advanced-workflows"
-  "developer-essentials/monorepo-management"
-  "developer-essentials/sql-optimization-patterns"
-  "python-development/async-python-patterns"
-  "python-development/python-anti-patterns"
-  "python-development/python-background-jobs"
-  "python-development/python-code-style"
-  "python-development/python-configuration"
-  "python-development/python-design-patterns"
-  "python-development/python-error-handling"
-  "python-development/python-observability"
-  "python-development/python-packaging"
-  "python-development/python-performance-optimization"
-  "python-development/python-project-structure"
-  "python-development/python-resilience"
-  "python-development/python-resource-management"
-  "python-development/python-testing-patterns"
-  "python-development/python-type-safety"
-  "backend-development/api-design-principles"
-  "backend-development/architecture-patterns"
-  "backend-development/cqrs-implementation"
-  "backend-development/event-store-design"
-  "backend-development/microservices-patterns"
-  "backend-development/projection-patterns"
-  "backend-development/saga-orchestration"
-  "backend-development/temporal-python-testing"
-  "backend-development/workflow-orchestration-patterns"
-  "systems-programming/go-concurrency-patterns"
-  "systems-programming/memory-safety-patterns"
-  "systems-programming/rust-async-patterns"
-  "documentation-generation/architecture-decision-records"
-  "documentation-generation/changelog-automation"
-  "documentation-generation/openapi-spec-generation"
-  "llm-application-dev/embedding-strategies"
-  "llm-application-dev/hybrid-search-implementation"
-  "llm-application-dev/langchain-architecture"
-  "llm-application-dev/llm-evaluation"
-  "llm-application-dev/prompt-engineering-patterns"
-  "llm-application-dev/rag-implementation"
-  "llm-application-dev/similarity-search-patterns"
-  "llm-application-dev/vector-index-tuning"
-  "data-engineering/airflow-dag-patterns"
-  "data-engineering/data-quality-frameworks"
-  "data-engineering/dbt-transformation-patterns"
-  "data-engineering/spark-optimization"
-  "javascript-typescript/javascript-testing-patterns"
-  "javascript-typescript/modern-javascript-patterns"
-  "javascript-typescript/nodejs-backend-patterns"
-  "javascript-typescript/typescript-advanced-types"
-  "frontend-mobile-development/react-native-architecture"
-  "frontend-mobile-development/react-state-management"
-  "frontend-mobile-development/tailwind-design-system"
-  "shell-scripting/bash-defensive-patterns"
-  "shell-scripting/bats-testing-patterns"
-  "shell-scripting/shellcheck-configuration"
-  "observability-monitoring/distributed-tracing"
-  "observability-monitoring/grafana-dashboards"
-  "observability-monitoring/prometheus-configuration"
-  "observability-monitoring/slo-implementation"
-  "cloud-infrastructure/cost-optimization"
-  "cloud-infrastructure/hybrid-cloud-networking"
-  "cloud-infrastructure/istio-traffic-management"
-  "cloud-infrastructure/linkerd-patterns"
-  "cloud-infrastructure/mtls-configuration"
-  "cloud-infrastructure/multi-cloud-architecture"
-  "cloud-infrastructure/service-mesh-observability"
-  "cloud-infrastructure/terraform-module-library"
-  "cicd-automation/deployment-pipeline-design"
-  "cicd-automation/github-actions-templates"
-  "cicd-automation/gitlab-ci-patterns"
-  "cicd-automation/secrets-management"
-  "kubernetes-operations/gitops-workflow"
-  "kubernetes-operations/helm-chart-scaffolding"
-  "kubernetes-operations/k8s-manifest-generator"
-  "kubernetes-operations/k8s-security-policies"
+
+# ------------------------------------------------------------------------------
+# wshobson/agents plugins (skills only)
+# - Skills are shared for Claude + Codex via .agents/skills/
+# - Hardcoded plugin list (single source of truth in this template)
+# ------------------------------------------------------------------------------
+{{- $wshobsonPlugins := list
+  "developer-essentials"
+  "python-development"
+  "backend-development"
+  "systems-programming"
+  "documentation-generation"
+  "llm-application-dev"
+  "data-engineering"
+  "javascript-typescript"
+  "frontend-mobile-development"
+  "shell-scripting"
+  "observability-monitoring"
+  "cloud-infrastructure"
+  "cicd-automation"
+  "kubernetes-operations"
 }}
-{{- range $entry := $wshobsonSkills }}
-{{- $parts := splitList "/" $entry }}
-{{- $plugin := index $parts 0 }}
-{{- $skill := index $parts 1 }}
-[".agents/skills/{{ $skill }}"]
+{{/* Per-plugin surgical exclusions: drop individual redundant sub-skills
+     without dropping the whole plugin archive. With exact = true, chezmoi
+     removes any excluded skill dir on apply/refresh and keeps it gone. */}}
+{{- $wshobsonExcludes := dict
+  "developer-essentials" (list
+    "agents-*/plugins/developer-essentials/skills/code-review-excellence/**"
+    "agents-*/plugins/developer-essentials/skills/nx-workspace-patterns/**"
+    "agents-*/plugins/developer-essentials/skills/turborepo-caching/**")
+  "python-development" (list
+    "agents-*/plugins/python-development/skills/uv-package-manager/**")
+  "frontend-mobile-development" (list
+    "agents-*/plugins/frontend-mobile-development/skills/nextjs-app-router-patterns/**")
+}}
+{{- range $plugin := $wshobsonPlugins }}
+[".agents/skills/{{ $plugin }}"]
     type = "archive"
     url = "https://github.com/wshobson/agents/archive/{{ $.versions.claudeWshobsonAgentsRev }}.tar.gz"
     checksum.sha256 = "{{ $.versions.claudeWshobsonAgentsSha256 }}"
     exact = true
-    stripComponents = 5
-    include = ["agents-*/plugins/{{ $plugin }}/skills/{{ $skill }}/**"]
+    stripComponents = 4
+    include = ["agents-*/plugins/{{ $plugin }}/skills/**"]
+{{- if hasKey $wshobsonExcludes $plugin }}
+    exclude = [
+{{- range $pattern := index $wshobsonExcludes $plugin }}
+      "{{ $pattern }}",
+{{- end }}
+    ]
+{{- end }}
     refreshPeriod = "168h"
 
 {{- end }}
@@ -141,7 +85,7 @@
 # ------------------------------------------------------------------------------
 # anthropics/skills (source-available, NOT open source)
 # License: https://github.com/anthropics/skills - see LICENSE.txt in each skill
-# Skills go to .agents/skills/{skill}/ (flat, shared)
+# Skills go to .agents/skills/anthropics/{skill}/ (Shared)
 # - Hardcoded skill list
 # ------------------------------------------------------------------------------
 {{- $anthropicsSkills := list
@@ -163,7 +107,7 @@
 }}
 
 {{- range $skill := $anthropicsSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/anthropics/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/anthropics/skills/archive/{{ $.versions.claudeAnthropicsSkillsRev }}.tar.gz"
     checksum.sha256 = "{{ $.versions.claudeAnthropicsSkillsSha256 }}"
@@ -176,7 +120,7 @@
 
 # ------------------------------------------------------------------------------
 # Ecosystem skills pack (official upstream, cross-domain)
-# - All land flat at .agents/skills/<skill>/
+# - Namespace: .agents/skills/ecosystem/
 # - Keep this focused on high-signal, actively maintained skills
 # ------------------------------------------------------------------------------
 
@@ -191,7 +135,7 @@
   "transcribe"
 }}
 {{- range $skill := $openaiCuratedSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/openai/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/openai/skills/archive/{{ $.versions.openaiSkillsRev }}.tar.gz"
     exact = true
@@ -215,7 +159,7 @@
   "hugging-face-cli"
 }}
 {{- range $skill := $huggingfaceSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/huggingface/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/huggingface/skills/archive/{{ $.versions.huggingfaceSkillsRev }}.tar.gz"
     exact = true
@@ -234,7 +178,7 @@
   "skill-scanner"
 }}
 {{- range $skill := $getsentrySkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/getsentry/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/getsentry/skills/archive/{{ $.versions.getsentrySkillsRev }}.tar.gz"
     exact = true
@@ -247,7 +191,7 @@
 # ------------------------------------------------------------------------------
 # trailofbits/skills utility set (security/SAST/review skills delegated to slipway)
 # ------------------------------------------------------------------------------
-[".agents/skills/sharp-edges"]
+[".agents/skills/ecosystem/trailofbits/sharp-edges"]
     type = "archive"
     url = "https://github.com/trailofbits/skills/archive/{{ $.versions.trailofbitsSkillsRev }}.tar.gz"
     exact = true
@@ -255,7 +199,7 @@
     include = ["skills-*/plugins/sharp-edges/skills/sharp-edges/**"]
     refreshPeriod = "168h"
 
-[".agents/skills/using-gh-cli"]
+[".agents/skills/ecosystem/trailofbits/using-gh-cli"]
     type = "archive"
     url = "https://github.com/trailofbits/skills/archive/{{ $.versions.trailofbitsSkillsRev }}.tar.gz"
     exact = true
@@ -263,7 +207,7 @@
     include = ["skills-*/plugins/gh-cli/skills/using-gh-cli/**"]
     refreshPeriod = "168h"
 
-[".agents/skills/modern-python"]
+[".agents/skills/ecosystem/trailofbits/modern-python"]
     type = "archive"
     url = "https://github.com/trailofbits/skills/archive/{{ $.versions.trailofbitsSkillsRev }}.tar.gz"
     exact = true
@@ -280,7 +224,7 @@
   "web-perf"
 }}
 {{- range $skill := $cloudflareSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/cloudflare/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/cloudflare/skills/archive/{{ $.versions.cloudflareSkillsRev }}.tar.gz"
     exact = true
@@ -298,7 +242,7 @@
   "web-design-guidelines"
 }}
 {{- range $skill := $vercelSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/vercel-labs/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/vercel-labs/agent-skills/archive/{{ $.versions.vercelLabsAgentSkillsRev }}.tar.gz"
     exact = true
@@ -317,7 +261,7 @@
   "next-cache-components"
 }}
 {{- range $skill := $vercelNextSkills }}
-[".agents/skills/{{ $skill }}"]
+[".agents/skills/ecosystem/vercel-labs/{{ $skill }}"]
     type = "archive"
     url = "https://github.com/vercel-labs/next-skills/archive/{{ $.versions.vercelLabsNextSkillsRev }}.tar.gz"
     exact = true
@@ -334,7 +278,7 @@
 # whatever agent-browser version mise installs. The CLI itself comes from the
 # `npm:agent-browser` entry in mise/config.toml.tmpl.
 # ------------------------------------------------------------------------------
-[".agents/skills/agent-browser"]
+[".agents/skills/ecosystem/vercel-labs/agent-browser"]
     type = "archive"
     url = "https://github.com/vercel-labs/agent-browser/archive/{{ $.versions.vercelLabsAgentBrowserRev }}.tar.gz"
     exact = true
@@ -345,7 +289,7 @@
 # ------------------------------------------------------------------------------
 # supabase/agent-skills database best practices
 # ------------------------------------------------------------------------------
-[".agents/skills/supabase-postgres-best-practices"]
+[".agents/skills/ecosystem/supabase/supabase-postgres-best-practices"]
     type = "archive"
     url = "https://github.com/supabase/agent-skills/archive/{{ $.versions.supabaseAgentSkillsRev }}.tar.gz"
     exact = true
@@ -356,7 +300,7 @@
 # ------------------------------------------------------------------------------
 # expo/skills deployment workflows
 # ------------------------------------------------------------------------------
-[".agents/skills/expo-deployment"]
+[".agents/skills/ecosystem/expo/expo-deployment"]
     type = "archive"
     url = "https://github.com/expo/skills/archive/{{ $.versions.expoSkillsRev }}.tar.gz"
     exact = true
@@ -364,7 +308,7 @@
     include = ["skills-*/plugins/expo-deployment/skills/expo-deployment/**"]
     refreshPeriod = "168h"
 
-[".agents/skills/expo-cicd-workflows"]
+[".agents/skills/ecosystem/expo/expo-cicd-workflows"]
     type = "archive"
     url = "https://github.com/expo/skills/archive/{{ $.versions.expoSkillsRev }}.tar.gz"
     exact = true
@@ -375,7 +319,7 @@
 # ------------------------------------------------------------------------------
 # microsoft/skills azure deployment workflow
 # ------------------------------------------------------------------------------
-[".agents/skills/azd-deployment"]
+[".agents/skills/ecosystem/microsoft/azd-deployment"]
     type = "archive"
     url = "https://github.com/microsoft/skills/archive/{{ $.versions.microsoftSkillsRev }}.tar.gz"
     exact = true
@@ -386,7 +330,7 @@
 # ------------------------------------------------------------------------------
 # sickn33/antigravity-awesome-skills aws deployment workflow (non-MCP)
 # ------------------------------------------------------------------------------
-[".agents/skills/aws-serverless"]
+[".agents/skills/ecosystem/sickn33/aws-serverless"]
     type = "archive"
     url = "https://github.com/sickn33/antigravity-awesome-skills/archive/{{ $.versions.sickn33AntigravitySkillsRev }}.tar.gz"
     exact = true
@@ -396,9 +340,10 @@
 
 # ------------------------------------------------------------------------------
 # xdevplatform/xurl official X API skill
+# - Shared for Claude + Codex under ~/.agents/skills/social-media/
 # - Pinned to the xurl v1.1.1 release commit so skill instructions match the CLI
 # ------------------------------------------------------------------------------
-[".agents/skills/xurl"]
+[".agents/skills/social-media/xurl"]
     type = "archive"
     url = "https://github.com/xdevplatform/xurl/archive/{{ $.versions.xurlSkillRev }}.tar.gz"
     exact = true
@@ -414,7 +359,7 @@
 # - Install x-create only; do not install x-publish because publishing is handled
 #   by the official xurl CLI/API path, not browser automation.
 # ------------------------------------------------------------------------------
-[".agents/skills/x-create"]
+[".agents/skills/social-media/x-create"]
     type = "archive"
     url = "https://github.com/kangarooking/x-skills/archive/{{ $.versions.xSkillsRev }}.tar.gz"
     exact = true
@@ -428,7 +373,7 @@
 # - daily-dev-ask: developer-focused search over community-vetted articles
 # - Requires daily.dev Plus and a DAILY_DEV_TOKEN; no browser automation.
 # ------------------------------------------------------------------------------
-[".agents/skills/daily.dev"]
+[".agents/skills/social-media/daily.dev"]
     type = "archive"
     url = "https://github.com/dailydotdev/daily/archive/{{ $.versions.dailyDevSkillsRev }}.tar.gz"
     exact = true
@@ -436,7 +381,7 @@
     include = ["daily-*/skills/daily.dev/**"]
     refreshPeriod = "168h"
 
-[".agents/skills/daily-dev-ask"]
+[".agents/skills/social-media/daily-dev-ask"]
     type = "archive"
     url = "https://github.com/dailydotdev/daily/archive/{{ $.versions.dailyDevSkillsRev }}.tar.gz"
     exact = true
@@ -451,7 +396,7 @@
 # - Use as the Reddit community-research layer before drafting subreddit-specific
 #   posts manually or through a separate reviewed publishing path.
 # ------------------------------------------------------------------------------
-[".agents/skills/reddit"]
+[".agents/skills/social-media/reddit"]
     type = "archive"
     url = "https://github.com/resciencelab/opc-skills/archive/{{ $.versions.opcSkillsRev }}.tar.gz"
     exact = true
@@ -462,7 +407,7 @@
 # ------------------------------------------------------------------------------
 # nextlevelbuilder/ui-ux-pro-max-skill (skills only)
 # - Shared UI/UX design intelligence skill for Claude + Codex
-# - SKILL.md + runtime data/scripts assets under .agents/skills/ui-ux-pro-max/
+# - Keep SKILL.md and runtime assets in ~/.agents/skills/
 # ------------------------------------------------------------------------------
 [".agents/skills/ui-ux-pro-max"]
     type = "archive"
@@ -494,7 +439,7 @@
 # ------------------------------------------------------------------------------
 # signalridge custom skills (managed in dedicated repos)
 # ------------------------------------------------------------------------------
-[".agents/skills/zig-development-playbook"]
+[".agents/skills/ecosystem/signalridge/zig-development-playbook"]
     type = "archive"
     url = "https://github.com/signalridge/zig-development-playbook-skill/archive/{{ $.versions.zigDevelopmentPlaybookSkillRev }}.tar.gz"
     exact = true
@@ -502,7 +447,7 @@
     include = ["zig-development-playbook-skill-*/skills/zig-development-playbook/**"]
     refreshPeriod = "168h"
 
-[".agents/skills/rust-development-playbook"]
+[".agents/skills/ecosystem/signalridge/rust-development-playbook"]
     type = "archive"
     url = "https://github.com/signalridge/rust-development-playbook-skill/archive/{{ $.versions.rustDevelopmentPlaybookSkillRev }}.tar.gz"
     exact = true
@@ -511,15 +456,15 @@
     refreshPeriod = "168h"
 
 # ------------------------------------------------------------------------------
-# Humanizer skills (remove AI tone)
-# - humanizer-en / humanizer-ja: blader/humanizer lineage (English / Japanese)
-# - qu-ai-wei: Chinese-native de-AI-tone skill (MIT), replaces the old
-#   op7418/Humanizer-zh translation. Ships SKILL.md + references/ (loaded on
-#   demand). Simplified Chinese only; explicit trigger /qu-ai-wei.
+# Humanizer / de-AI-tone skills (multilingual namespace)
+# - multilingual/humanizer-en : blader/humanizer (English)
+# - multilingual/humanizer-ja : kgraph57/humanizer-ja (Japanese)
+# - multilingual/qu-ai-wei    : Chinese-native de-AI-tone skill (MIT), replaces
+#                               the old op7418/Humanizer-zh translation
 # - Commit-pinned via revisions in .chezmoidata/versions.yaml
 # ------------------------------------------------------------------------------
 
-[".agents/skills/humanizer-en"]
+[".agents/skills/multilingual/humanizer-en"]
     type = "archive"
     url = "https://github.com/blader/humanizer/archive/{{ $.versions.humanizerEnRev }}.tar.gz"
     exact = true
@@ -530,7 +475,7 @@
     ]
     refreshPeriod = "168h"
 
-[".agents/skills/qu-ai-wei"]
+[".agents/skills/multilingual/qu-ai-wei"]
     type = "archive"
     url = "https://github.com/LifelongLazyLearner/qu-ai-wei/archive/{{ $.versions.quAiWeiRev }}.tar.gz"
     exact = true
@@ -542,7 +487,7 @@
     ]
     refreshPeriod = "168h"
 
-[".agents/skills/humanizer-ja"]
+[".agents/skills/multilingual/humanizer-ja"]
     type = "archive"
     url = "https://github.com/kgraph57/humanizer-ja/archive/{{ $.versions.humanizerJaRev }}.tar.gz"
     exact = true

--- a/dot_claude/run_after_ensure-claude-skills-dir.sh
+++ b/dot_claude/run_after_ensure-claude-skills-dir.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Claude Code reads ~/.claude/skills as a CURATED set of per-skill symlinks
+# (managed interactively by `skill-activate`), not a single symlink to the
+# whole library. Ensure it is a real directory: convert any leftover
+# whole-dir symlink (e.g. an older ~/.claude/skills -> ~/.agents/skills) and
+# create it empty if missing. Contents (the curated symlinks) are left alone,
+# so a fresh machine starts with NO user-level skills active by default.
+
+set -euo pipefail
+
+d="$HOME/.claude/skills"
+[ -L "$d" ] && rm -f "$d"
+mkdir -p "$d"

--- a/dot_claude/symlink_skills.tmpl
+++ b/dot_claude/symlink_skills.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.agents/skills


### PR DESCRIPTION
Fixes the three issues that surfaced after #578 merged: #578 was the **flat, all-skills-global** model, but the intended end state is **curated** — a nested master library plus per-scope active sets that `skill-activate` (#579) manages.

| Issue | Cause | Fix |
|---|---|---|
| `skill-activate` errors: `~/.claude/skills is a symlink` | #578's `symlink_skills.tmpl` made it one symlink to the whole library | Drop the template; make it a **real curated dir** |
| Skills not organized by folder | #578 flattened the library | **Re-nest** the library → `~/.agents/skills/<category>/<skill>` |
| All ~138 skills active by default | single symlink = everything always on | Default **empty**; pick with `skill-activate` |

## Changes
- **`.chezmoiexternal.toml.tmpl`**: re-nest every external target to `<category>/<skill>` (folders = categories). Keeps the curation from #576 (wshobson excludes, openai/vercel trims) and the qu-ai-wei swap (now `multilingual/qu-ai-wei`, pinned `quAiWeiRev`).
- **Remove `dot_claude/symlink_skills.tmpl`**: `~/.claude/skills` is no longer a whole-dir symlink, so Claude Code no longer auto-loads the entire library.
- **Add `dot_claude/run_after_ensure-claude-skills-dir.sh`**: ensures `~/.claude/skills` is a real directory (converts a leftover whole-dir symlink), empty by default → **no user-level skills active until you pick them**.

Codex still reads the library directly (`~/.codex/skills -> ~/.agents/skills`, recursive) — unaffected. The library can stay nested because Claude reads the curated active dir, not the library.

## Rollout (after merge, from the **main** source) — order matters
```bash
chezmoi -R apply                                   # re-nest library + ensure ~/.claude/skills is a real empty dir
find ~/.agents/skills -type d -empty -delete       # drop the old flat shells
skill-activate user                                # now pick your global set (default: none)
```
> ⚠️ Apply **before** activating: the live library is still flat (#578), so symlinks made now would dangle after the re-nest. Until this merges, don't `chezmoi apply` from main (it would restore the old whole-dir symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)