### PR TITLE
fix(skills): clarify category activation hints

### DIFF
--- a/dot_local/bin/executable_skill-activate
+++ b/dot_local/bin/executable_skill-activate
@@ -2,8 +2,8 @@
 #
 # skill-activate — a live on/off panel for curating which library skills are
 # active for Claude plus either the project harness set or user Codex set.
-# Tab/Space flips a skill on/off in place (the ● updates live); Ctrl-A flips
-# the highlighted skill's whole category; Enter leaves.
+# Tab/Space flips one skill on/off in place (the ● updates live). Ctrl-A flips
+# every skill in the highlighted row's category; Enter leaves.
 # Toggling is fast — the library is scanned ONCE up front and the panel just
 # re-reads that cached index.
 #
@@ -267,10 +267,13 @@ mkdir -p "$claude_dir" "$codex_dir"
 self=$(command -v "$0" 2>/dev/null || true)
 [ -x "$self" ] || self="$0"
 hs=${claude_dir/#$HOME/\~}
+header="$scope ($target_label) → $hs
+Tab/Space: toggle one skill   │   Ctrl-A: toggle ALL skills in the highlighted category   │   Enter/Esc: done   │   ● on  ○ off
+CLI equivalent: skill-activate $scope --category <category>"
 
 rows_from "$idx" | fzf \
   --delimiter='\t' --with-nth='2..' --no-multi --cycle --reverse --height='100%' \
-  --header="$scope ($target_label) → $hs   │   Tab/Space: toggle skill   Ctrl-A: toggle category   Enter: done   │   ● on  ○ off" \
+  --header="$header" \
   --header-first \
   --bind="tab:execute-silent($self __toggle {1} $scope $idx)+reload-sync($self __rows $scope $idx)" \
   --bind="space:execute-silent($self __toggle {1} $scope $idx)+reload-sync($self __rows $scope $idx)" \

--- a/tests/test_skill_activate.sh
+++ b/tests/test_skill_activate.sh
@@ -61,6 +61,11 @@ make_skill "typescript" "ts-one" "First TypeScript skill"
 make_skill "typescript" "ts-two" "Second TypeScript skill"
 make_skill "python" "py-one" "Python skill"
 
+help_output="$(bash "$CLI" --help)"
+assert_contains "$help_output" "Ctrl-A flips"
+assert_contains "$help_output" "every skill in the highlighted row's category"
+assert_contains "$help_output" "skill-activate [scope] --category <category>"
+
 list_output="$(run_skill_activate user --list)"
 assert_contains "$list_output" "typescript"
 assert_contains "$list_output" "ts-one"


### PR DESCRIPTION
## Summary
- make `skill-activate` help clarify that `Ctrl-A` toggles every skill in the highlighted row category
- expand the fzf header into a multi-line hint with the equivalent `skill-activate <scope> --category <category>` command
- add regression coverage for the help text

## How to use
- TUI: highlight any skill in the category, then press `Ctrl-A` to toggle the whole category
- CLI: `skill-activate user --category typescript` or `skill-activate project --category typescript`

## Validation
- `bash tests/test_skill_activate.sh`
- `bash tests/run.sh`
- `git diff --check`
- `shellcheck dot_local/bin/executable_skill-activate tests/test_skill_activate.sh`
- `chezmoi apply --force ~/.local/bin/skill-activate`
- `chezmoi status ~/.local/bin/skill-activate`