### PR TITLE
fix(skills): scope activation to current directory

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -285,7 +285,7 @@ Skills は `.chezmoiexternal.toml.tmpl` 経由で次のソースから同期さ�
 - Go、Rust、Swift、TypeScript/JavaScript、Zig の言語別 suite
 - `xurl`、`x-create`、`daily.dev`、Reddit、Remotion、Humanizer 系（`humanizer-en`、`qu-ai-wei`、`humanizer-ja`）などの social/writing/media skills
 
-同期先は `~/.harnesses/skills` の共有 harness ライブラリです。実際に有効化する symlink は `skill-activate` で管理します。`skill-activate user --category typescript` でカテゴリ全体を有効化できます。ピッカーでは `Ctrl-A` でハイライト中の項目のカテゴリ全体を切り替えます。
+同期先は `~/.harnesses/skills` の共有ライブラリです。プロジェクトディレクトリで `skill-activate` を実行すると、そのディレクトリの `./.claude/skills` と `./.codex/skills` の symlink だけを管理します。`skill-activate --category typescript` で現在のディレクトリにカテゴリ全体を有効化できます。`skill-activate --sync` は既存の Claude-only/Codex-only の半端な状態を修復します。ピッカーでは `Ctrl-A` でハイライト中の項目のカテゴリ全体を切り替えます。
 
 ### 品質プロトコル
 
@@ -319,7 +319,7 @@ Skills は `.chezmoiexternal.toml.tmpl` 経由で次のソースから同期さ�
 - Go、Rust、Swift、TypeScript/JavaScript、Zig の言語別 suite
 - `xurl`、`x-create`、`daily.dev`、Reddit、Remotion、Humanizer 系（`humanizer-en`、`qu-ai-wei`、`humanizer-ja`）などの social/writing/media skills
 
-同期先は `~/.harnesses/skills` の共有 harness ライブラリです。実際に有効化する symlink は `skill-activate` で管理します。`skill-activate user --category typescript` でカテゴリ全体を有効化できます。ピッカーでは `Ctrl-A` でハイライト中の項目のカテゴリ全体を切り替えます。
+同期先は `~/.harnesses/skills` の共有ライブラリです。プロジェクトディレクトリで `skill-activate` を実行すると、そのディレクトリの `./.claude/skills` と `./.codex/skills` の symlink だけを管理します。`skill-activate --category typescript` で現在のディレクトリにカテゴリ全体を有効化できます。`skill-activate --sync` は既存の Claude-only/Codex-only の半端な状態を修復します。ピッカーでは `Ctrl-A` でハイライト中の項目のカテゴリ全体を切り替えます。
 
 ### Account / Provider 管理
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Skills are synced via `.chezmoiexternal.toml.tmpl` from:
 - language suites for Go, Rust, Swift, TypeScript/JavaScript, and Zig
 - social, writing, and media skills including `xurl`, `x-create`, `daily.dev`, Reddit, Remotion, and Humanizer variants (`humanizer-en`, `qu-ai-wei`, `humanizer-ja`)
 
-They are normalized into `~/.harnesses/skills` as a shared harness library; use `skill-activate` to curate active symlinks. `skill-activate user --category typescript` activates a whole category, and `Ctrl-A` toggles the highlighted category in the picker.
+They are normalized into `~/.harnesses/skills` as a shared library; use `skill-activate` from a project directory to curate active symlinks in `./.claude/skills` and `./.codex/skills`. `skill-activate --category typescript` activates a whole category for the current directory, `skill-activate --sync` repairs existing Claude-only/Codex-only partial pairs, and `Ctrl-A` toggles the highlighted category in the picker.
 
 ### Quality Protocols
 
@@ -319,7 +319,7 @@ Claude hooks in `dot_claude/hooks/` provide workflow guardrails and formatting a
 - language suites for Go, Rust, Swift, TypeScript/JavaScript, and Zig
 - social, writing, and media skills including `xurl`, `x-create`, `daily.dev`, Reddit, Remotion, and Humanizer variants (`humanizer-en`, `qu-ai-wei`, `humanizer-ja`)
 
-They are normalized into `~/.harnesses/skills` as a shared harness library; use `skill-activate` to curate active symlinks. `skill-activate user --category typescript` activates a whole category, and `Ctrl-A` toggles the highlighted category in the picker.
+They are normalized into `~/.harnesses/skills` as a shared library; use `skill-activate` from a project directory to curate active symlinks in `./.claude/skills` and `./.codex/skills`. `skill-activate --category typescript` activates a whole category for the current directory, `skill-activate --sync` repairs existing Claude-only/Codex-only partial pairs, and `Ctrl-A` toggles the highlighted category in the picker.
 
 ### Account + Provider Control
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -283,7 +283,7 @@ skills 由 `.chezmoiexternal.toml.tmpl` 从以下来源同步：
 - Go、Rust、Swift、TypeScript/JavaScript、Zig 语言套件
 - social、writing、media skills，包括 `xurl`、`x-create`、`daily.dev`、Reddit、Remotion 和 Humanizer 变体（`humanizer-en`、`qu-ai-wei`、`humanizer-ja`）
 
-同步后统一落到 `~/.harnesses/skills` 共享 harness 库；实际启用的 symlink 由 `skill-activate` 管理。`skill-activate user --category typescript` 可一次启用整个类别；在选择器里按 `Ctrl-A` 可切换当前高亮项所在的整个类别。
+同步后统一落到 `~/.harnesses/skills` 共享库；在项目目录运行 `skill-activate`，只会管理当前目录的 `./.claude/skills` 与 `./.codex/skills` symlink。`skill-activate --category typescript` 可为当前目录一次启用整个类别；`skill-activate --sync` 可修复已有的 Claude-only/Codex-only 半激活状态；在选择器里按 `Ctrl-A` 可切换当前高亮项所在的整个类别。
 
 ### 质量协议
 
@@ -317,7 +317,7 @@ skills 由 `.chezmoiexternal.toml.tmpl` 从以下来源同步：
 - Go、Rust、Swift、TypeScript/JavaScript、Zig 语言套件
 - social、writing、media skills，包括 `xurl`、`x-create`、`daily.dev`、Reddit、Remotion 和 Humanizer 变体（`humanizer-en`、`qu-ai-wei`、`humanizer-ja`）
 
-最终统一到 `~/.harnesses/skills` 共享 harness 库；实际启用的 symlink 由 `skill-activate` 管理。`skill-activate user --category typescript` 可一次启用整个类别；在选择器里按 `Ctrl-A` 可切换当前高亮项所在的整个类别。
+最终统一到 `~/.harnesses/skills` 共享库；在项目目录运行 `skill-activate`，只会管理当前目录的 `./.claude/skills` 与 `./.codex/skills` symlink。`skill-activate --category typescript` 可为当前目录一次启用整个类别；`skill-activate --sync` 可修复已有的 Claude-only/Codex-only 半激活状态；在选择器里按 `Ctrl-A` 可切换当前高亮项所在的整个类别。
 
 ### Account 与 Provider 管理
 

--- a/dot_claude/run_after_ensure-skill-dirs.sh
+++ b/dot_claude/run_after_ensure-skill-dirs.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 #
-# Claude Code and Codex each read a CURATED set of per-skill symlinks managed
-# by `skill-activate`, not a single symlink to the whole ~/.harnesses/skills
-# library. Ensure both user-level dirs are real directories (convert any
-# leftover whole-dir symlink) and leave their contents alone. Empty by default
-# → no user-level skills are active until you pick them. Project-level sets
-# live in each project's ./.claude/skills and ./.harnesses/skills.
+# Keep Claude Code and Codex user-level skill dirs as real directories, not
+# leftover whole-dir symlinks to the shared ~/.harnesses/skills library.
+# `skill-activate` intentionally does not manage these user-level dirs; it only
+# writes per-project symlinks under the current directory's ./.claude/skills and
+# ./.codex/skills.
 
 set -euo pipefail
 

--- a/dot_local/bin/executable_skill-activate
+++ b/dot_local/bin/executable_skill-activate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # skill-activate — a live on/off panel for curating which library skills are
-# active for Claude plus either the project harness set or user Codex set.
+# active for Claude plus the matching current-directory Codex set.
 # Tab/Space flips one skill on/off in place (the ● updates live). Ctrl-A flips
 # every skill in the highlighted row's category; Enter leaves.
 # Toggling is fast — the library is scanned ONCE up front and the panel just
@@ -11,22 +11,21 @@
 #   ~/.harnesses/skills/<category>/<skill>/SKILL.md   (e.g. cloud/, python/, ai-llm/)
 # so the panel groups by the folder directly — no sidecar mapping file.
 #
-# Active sets (flat symlinks into the library):
-#   project (default): ./.claude/skills/ + ./.harnesses/skills/
-#   user             : ~/.claude/skills/ + ~/.codex/skills/    (keep minimal)
+# Active set (flat symlinks into the shared library):
+#   current directory: ./.claude/skills/ + ./.codex/skills/
 #
 # Usage:
-#   skill-activate [project|user]      live on/off panel (default: project)
-#   skill-activate [scope] --active    list active skills
-#   skill-activate [scope] --list      print the rows (no fzf)
-#   skill-activate [scope] --category <category>
-#                                      activate every skill in a category
-#   skill-activate [scope] --clear     deactivate everything for the scope
+#   skill-activate                    live on/off panel
+#   skill-activate --active           list active skills
+#   skill-activate --list             print the rows (no fzf)
+#   skill-activate --sync             repair partial Claude/Codex pairs
+#   skill-activate --category <category>
+#                                     activate every skill in a category
+#   skill-activate --clear            deactivate everything for the current dir
 
 set -euo pipefail
 
 library="${SKILL_LIBRARY:-$HOME/.harnesses/skills}"
-scope="project"
 mode="pick"
 category_name=""
 internal=""
@@ -40,14 +39,18 @@ if [ "${1:-}" = "__rows" ] || [ "${1:-}" = "__toggle" ] || [ "${1:-}" = "__toggl
     tname="$1"
     shift
   fi
-  scope="${1:-project}"
-  pidx="${2:-}"
+  pidx="${1:-}"
 else
   while [ $# -gt 0 ]; do
     case "$1" in
-    project | user) scope="$1" ;;
+    project) ;;
+    user)
+      echo "skill-activate: user scope was removed; run from the target project directory instead" >&2
+      exit 2
+      ;;
     --active) mode="active" ;;
     --list) mode="list" ;;
+    --sync) mode="sync" ;;
     --category | --activate-category)
       [ $# -ge 2 ] || {
         echo "skill-activate: $1 requires a category name" >&2
@@ -71,22 +74,9 @@ else
   done
 fi
 
-case "$scope" in
-project)
-  claude_dir="$PWD/.claude/skills"
-  codex_dir="$PWD/.harnesses/skills"
-  target_label="Claude + harness"
-  ;;
-user)
-  claude_dir="$HOME/.claude/skills"
-  codex_dir="$HOME/.codex/skills"
-  target_label="Claude + Codex"
-  ;;
-*)
-  echo "skill-activate: scope must be 'project' or 'user'" >&2
-  exit 2
-  ;;
-esac
+claude_dir="$PWD/.claude/skills"
+codex_dir="$PWD/.codex/skills"
+target_label="Claude + Codex current dir"
 
 [ -d "$library" ] || {
   echo "skill-activate: library not found: $library" >&2
@@ -101,7 +91,23 @@ require_real_dir() {
   fi
 }
 
-mark() { if [ -e "$claude_dir/$1" ]; then printf '●'; else printf '○'; fi; }
+skill_active_full() {
+  [ -e "$claude_dir/$1" ] && [ -e "$codex_dir/$1" ]
+}
+
+skill_active_any() {
+  [ -e "$claude_dir/$1" ] || [ -e "$codex_dir/$1" ]
+}
+
+mark() {
+  if skill_active_full "$1"; then
+    printf '●'
+  elif skill_active_any "$1"; then
+    printf '◐'
+  else
+    printf '○'
+  fi
+}
 
 activate_skill() {
   local name="$1"
@@ -145,6 +151,24 @@ set_category_state() {
   [ "$matched" -eq 1 ]
 }
 
+sync_active_pairs() {
+  local index_file="$1"
+  local synced=0
+  local name
+  local cat
+  local sdir
+  local desc
+
+  while IFS=$'\t' read -r name cat sdir desc; do
+    if skill_active_any "$name" && ! skill_active_full "$name"; then
+      activate_skill "$name" "$sdir"
+      synced=$((synced + 1))
+    fi
+  done <"$index_file"
+
+  printf '%s\n' "$synced"
+}
+
 category_all_active() {
   local category="$1"
   local index_file="$2"
@@ -157,7 +181,7 @@ category_all_active() {
 
   while IFS=$'\t' read -r name cat sdir desc; do
     any=1
-    [ -e "$claude_dir/$name" ] || inactive=1
+    skill_active_full "$name" || inactive=1
   done < <(awk -F'\t' -v c="$category" '$2==c' "$index_file")
 
   [ "$any" -eq 1 ] && [ "$inactive" -eq 0 ]
@@ -192,7 +216,7 @@ if [ "$internal" = "__toggle" ]; then
   mkdir -p "$claude_dir" "$codex_dir" 2>/dev/null || true
   sdir=$(skill_dir_for_name "$tname" "$pidx")
   [ -n "$sdir" ] || exit 0
-  if [ -e "$claude_dir/$tname" ]; then
+  if skill_active_full "$tname"; then
     deactivate_skill "$tname"
   else
     activate_skill "$tname" "$sdir"
@@ -234,6 +258,15 @@ list)
   rows_from "$idx" | cut -f2-
   exit 0
   ;;
+sync)
+  require_real_dir "$claude_dir"
+  require_real_dir "$codex_dir"
+  mkdir -p "$claude_dir" "$codex_dir"
+  n=$(sync_active_pairs "$idx")
+  hs=${claude_dir/#$HOME/\~}
+  echo "current dir: synced $n partial skill(s) ($target_label) in $hs"
+  exit 0
+  ;;
 category)
   require_real_dir "$claude_dir"
   require_real_dir "$codex_dir"
@@ -244,7 +277,7 @@ category)
   fi
   n=$(awk -F'\t' -v c="$category_name" '$2==c{n++} END{print n+0}' "$idx")
   hs=${claude_dir/#$HOME/\~}
-  echo "$scope: activated $n skill(s) in category '$category_name' ($target_label) in $hs"
+  echo "current dir: activated $n skill(s) in category '$category_name' ($target_label) in $hs"
   exit 0
   ;;
 clear)
@@ -252,7 +285,7 @@ clear)
     [ -L "$d" ] && continue
     [ -d "$d" ] && find "$d" -maxdepth 1 -type l -delete 2>/dev/null || true
   done
-  echo "cleared $scope ($target_label)"
+  echo "cleared current dir ($target_label)"
   exit 0
   ;;
 esac
@@ -267,17 +300,17 @@ mkdir -p "$claude_dir" "$codex_dir"
 self=$(command -v "$0" 2>/dev/null || true)
 [ -x "$self" ] || self="$0"
 hs=${claude_dir/#$HOME/\~}
-header="$scope ($target_label) → $hs
-Tab/Space: toggle one skill   │   Ctrl-A: toggle ALL skills in the highlighted category   │   Enter/Esc: done   │   ● on  ○ off
-CLI equivalent: skill-activate $scope --category <category>"
+header="current dir ($target_label) → $hs
+Tab/Space: toggle one skill   │   Ctrl-A: toggle ALL skills in the highlighted category   │   Enter/Esc: done   │   ● both  ◐ partial  ○ off
+CLI equivalents: skill-activate --category <category>   │   skill-activate --sync"
 
 rows_from "$idx" | fzf \
   --delimiter='\t' --with-nth='2..' --no-multi --cycle --reverse --height='100%' \
   --header="$header" \
   --header-first \
-  --bind="tab:execute-silent($self __toggle {1} $scope $idx)+reload-sync($self __rows $scope $idx)" \
-  --bind="space:execute-silent($self __toggle {1} $scope $idx)+reload-sync($self __rows $scope $idx)" \
-  --bind="ctrl-a:execute-silent($self __toggle_category {1} $scope $idx)+reload-sync($self __rows $scope $idx)" \
+  --bind="tab:execute-silent($self __toggle {1} $idx)+reload-sync($self __rows $idx)" \
+  --bind="space:execute-silent($self __toggle {1} $idx)+reload-sync($self __rows $idx)" \
+  --bind="ctrl-a:execute-silent($self __toggle_category {1} $idx)+reload-sync($self __rows $idx)" \
   --bind="enter:accept" \
   --bind="esc:accept" \
   --preview="sed -n '1,40p' \"\$(awk -F'\t' -v n={1} '\$1==n{print \$3}' '$idx')/SKILL.md\"" \
@@ -285,4 +318,4 @@ rows_from "$idx" | fzf \
   >/dev/null || true
 
 n=$(find "$claude_dir" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
-echo "$scope: $n skill(s) active ($target_label) in $hs"
+echo "current dir: $n skill(s) active ($target_label) in $hs"

--- a/tests/test_skill_activate.sh
+++ b/tests/test_skill_activate.sh
@@ -57,6 +57,12 @@ run_skill_activate() {
     HOME="$HOME_DIR" SKILL_LIBRARY="$LIBRARY" bash "$CLI" "$@"
 }
 
+run_skill_activate_in() {
+    local workdir="$1"
+    shift
+    HOME="$HOME_DIR" SKILL_LIBRARY="$LIBRARY" bash -c 'cd "$1" && shift && bash "$@"' bash "$workdir" "$CLI" "$@"
+}
+
 make_skill "typescript" "ts-one" "First TypeScript skill"
 make_skill "typescript" "ts-two" "Second TypeScript skill"
 make_skill "python" "py-one" "Python skill"
@@ -64,21 +70,42 @@ make_skill "python" "py-one" "Python skill"
 help_output="$(bash "$CLI" --help)"
 assert_contains "$help_output" "Ctrl-A flips"
 assert_contains "$help_output" "every skill in the highlighted row's category"
-assert_contains "$help_output" "skill-activate [scope] --category <category>"
+assert_contains "$help_output" "skill-activate --category <category>"
+assert_contains "$help_output" "skill-activate --sync"
+assert_contains "$help_output" "current directory: ./.claude/skills/ + ./.codex/skills/"
 
-list_output="$(run_skill_activate user --list)"
+PROJECT_DIR="$TMP_ROOT/project"
+mkdir -p "$PROJECT_DIR"
+
+list_output="$(run_skill_activate_in "$PROJECT_DIR" --list)"
 assert_contains "$list_output" "typescript"
 assert_contains "$list_output" "ts-one"
 assert_contains "$list_output" "ts-two"
 
-category_output="$(run_skill_activate user --category typescript)"
+category_output="$(run_skill_activate_in "$PROJECT_DIR" --category typescript)"
 assert_contains "$category_output" "activated 2 skill(s) in category 'typescript'"
-assert_symlink_to "$HOME_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
-assert_symlink_to "$HOME_DIR/.claude/skills/ts-two" "$LIBRARY/typescript/ts-two"
-assert_symlink_to "$HOME_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
-assert_symlink_to "$HOME_DIR/.codex/skills/ts-two" "$LIBRARY/typescript/ts-two"
-assert_missing "$HOME_DIR/.claude/skills/py-one"
-assert_missing "$HOME_DIR/.codex/skills/py-one"
+assert_symlink_to "$PROJECT_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PROJECT_DIR/.claude/skills/ts-two" "$LIBRARY/typescript/ts-two"
+assert_symlink_to "$PROJECT_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PROJECT_DIR/.codex/skills/ts-two" "$LIBRARY/typescript/ts-two"
+assert_missing "$PROJECT_DIR/.claude/skills/py-one"
+assert_missing "$PROJECT_DIR/.codex/skills/py-one"
+assert_missing "$HOME_DIR/.claude/skills/ts-one"
+assert_missing "$HOME_DIR/.codex/skills/ts-one"
+assert_missing "$PROJECT_DIR/.harnesses/skills/ts-one"
+assert_missing "$PROJECT_DIR/.harnesses/skills/ts-two"
+
+legacy_project_output="$(run_skill_activate_in "$PROJECT_DIR" project --category python)"
+assert_contains "$legacy_project_output" "activated 1 skill(s) in category 'python'"
+assert_symlink_to "$PROJECT_DIR/.claude/skills/py-one" "$LIBRARY/python/py-one"
+assert_symlink_to "$PROJECT_DIR/.codex/skills/py-one" "$LIBRARY/python/py-one"
+
+if run_skill_activate_in "$PROJECT_DIR" user --category typescript >"$TMP_ROOT/user.out" 2>"$TMP_ROOT/user.err"; then
+    fail "expected user scope to fail"
+fi
+assert_contains "$(cat "$TMP_ROOT/user.err")" "user scope was removed"
+assert_missing "$HOME_DIR/.claude/skills/ts-two"
+assert_missing "$HOME_DIR/.codex/skills/ts-two"
 
 IDX="$TMP_ROOT/index.tsv"
 {
@@ -87,18 +114,49 @@ IDX="$TMP_ROOT/index.tsv"
     printf 'ts-two\ttypescript\t%s\tSecond TypeScript skill\n' "$LIBRARY/typescript/ts-two"
 } >"$IDX"
 
-run_skill_activate __toggle_category ts-one user "$IDX"
+PARTIAL_DIR="$TMP_ROOT/partial-project"
+mkdir -p "$PARTIAL_DIR/.claude/skills"
+ln -sfn "$LIBRARY/typescript/ts-one" "$PARTIAL_DIR/.claude/skills/ts-one"
+partial_list_output="$(run_skill_activate_in "$PARTIAL_DIR" --list)"
+assert_contains "$partial_list_output" "◐"
+sync_output="$(run_skill_activate_in "$PARTIAL_DIR" --sync)"
+assert_contains "$sync_output" "synced 1 partial skill(s)"
+assert_symlink_to "$PARTIAL_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PARTIAL_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_missing "$HOME_DIR/.claude/skills/ts-one"
+assert_missing "$HOME_DIR/.codex/skills/ts-one"
+rm -f "$PARTIAL_DIR/.codex/skills/ts-one"
+run_skill_activate_in "$PARTIAL_DIR" __toggle ts-one "$IDX"
+assert_symlink_to "$PARTIAL_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PARTIAL_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
+
+PARTIAL_CATEGORY_DIR="$TMP_ROOT/partial-category-project"
+mkdir -p "$PARTIAL_CATEGORY_DIR/.claude/skills"
+ln -sfn "$LIBRARY/typescript/ts-one" "$PARTIAL_CATEGORY_DIR/.claude/skills/ts-one"
+ln -sfn "$LIBRARY/typescript/ts-two" "$PARTIAL_CATEGORY_DIR/.claude/skills/ts-two"
+run_skill_activate_in "$PARTIAL_CATEGORY_DIR" __toggle_category ts-one "$IDX"
+assert_symlink_to "$PARTIAL_CATEGORY_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PARTIAL_CATEGORY_DIR/.claude/skills/ts-two" "$LIBRARY/typescript/ts-two"
+assert_symlink_to "$PARTIAL_CATEGORY_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PARTIAL_CATEGORY_DIR/.codex/skills/ts-two" "$LIBRARY/typescript/ts-two"
+
+run_skill_activate_in "$PROJECT_DIR" __toggle_category ts-one "$IDX"
 assert_missing "$HOME_DIR/.claude/skills/ts-one"
 assert_missing "$HOME_DIR/.claude/skills/ts-two"
 assert_missing "$HOME_DIR/.codex/skills/ts-one"
 assert_missing "$HOME_DIR/.codex/skills/ts-two"
+assert_missing "$PROJECT_DIR/.claude/skills/ts-one"
+assert_missing "$PROJECT_DIR/.claude/skills/ts-two"
+assert_missing "$PROJECT_DIR/.codex/skills/ts-one"
+assert_missing "$PROJECT_DIR/.codex/skills/ts-two"
 
-run_skill_activate __toggle_category ts-one user "$IDX"
-assert_symlink_to "$HOME_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
-assert_symlink_to "$HOME_DIR/.claude/skills/ts-two" "$LIBRARY/typescript/ts-two"
-assert_missing "$HOME_DIR/.claude/skills/py-one"
+run_skill_activate_in "$PROJECT_DIR" __toggle_category ts-one "$IDX"
+assert_symlink_to "$PROJECT_DIR/.claude/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PROJECT_DIR/.claude/skills/ts-two" "$LIBRARY/typescript/ts-two"
+assert_symlink_to "$PROJECT_DIR/.codex/skills/ts-one" "$LIBRARY/typescript/ts-one"
+assert_symlink_to "$PROJECT_DIR/.codex/skills/ts-two" "$LIBRARY/typescript/ts-two"
 
-if run_skill_activate user --category missing >"$TMP_ROOT/missing.out" 2>"$TMP_ROOT/missing.err"; then
+if run_skill_activate_in "$PROJECT_DIR" --category missing >"$TMP_ROOT/missing.out" 2>"$TMP_ROOT/missing.err"; then
     fail "expected missing category to fail"
 fi
 assert_contains "$(cat "$TMP_ROOT/missing.err")" "category not found: missing"


### PR DESCRIPTION
## Summary
- make `skill-activate` manage only the current directory, writing `./.claude/skills` and `./.codex/skills`
- reject the removed `user` scope while keeping `project` as a compatibility no-op
- fix the Codex project target from `./.harnesses/skills` to `./.codex/skills`
- add `◐` partial-state display plus `--sync` to repair existing Claude-only/Codex-only project activations
- update README guidance and regression coverage

## Verification
- `bash tests/run.sh`
- `shellcheck dot_local/bin/executable_skill-activate tests/test_skill_activate.sh dot_claude/run_after_ensure-skill-dirs.sh`
- `git diff --check`
- live repro in `/Users/yixianlu/ghq/github.com/signalridge/slipway`: `.claude/skills=53`, `.codex/skills=53`, `full=53 partial=0`, and `~/.codex/skills` symlinks stayed `0` after `skill-activate --sync`