### PR TITLE
chore(aqua): update slipway to v0.5.1

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.5.0
+  - name: signalridge/slipway@v0.5.1
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89


### PR DESCRIPTION
Summary:
- Update signalridge/slipway aqua pin from v0.5.0 to v0.5.1.

Verification:
- git diff --check
- bash tests/test_toolchain_bootstrap.sh
- pre-commit hooks via git commit