### PR TITLE
chore(versions): update pinned versions (2026-06-06)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -26,7 +26,7 @@ versions:
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: 145a923cce95c2cef20643302e8811363fa2e51d
   microsoftSkillsRev: 619745888df8014bc963929896f9a279c6d12641
-  sickn33AntigravitySkillsRev: 43af20cbe0dc298c40ff709993d8b4f7b4a274b6
+  sickn33AntigravitySkillsRev: 9d486d0899e0c4474939861469ac43339f128344
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.1` |
| nix-index-database | `2026-05-31-064259` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `504191c59a67888cae225ea54fe03aa502ef0319` |
| getsentry/skills | `493bb49084f6a8add1eaefb85a952e999f362415` |
| trailofbits/skills | `d5fe2e6a7896236c3102fd5477e833623ad70298` |
| cloudflare/skills | `c5b7b06b073fa0b4abbd63964630f97d81da69c4` |
| vercel-labs/agent-skills | `4ec6f84b61cd3c931046c3e6e398f3ae7de372f7` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `145a923cce95c2cef20643302e8811363fa2e51d` |
| microsoft/skills | `619745888df8014bc963929896f9a279c6d12641` |
| sickn33/antigravity-awesome-skills | `9d486d0899e0c4474939861469ac43339f128344` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `a2ace14a88a6746f64f1f53ed8272d6788828038` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |