### PR TITLE
chore(nix): update flake.lock for darwin (2026-06-07)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780743301,
-        "narHash": "sha256-V8aeyef4HScxw9ZBNxtKa0MQumfQtP0+yvF86h2aUl0=",
+        "lastModified": 1780800359,
+        "narHash": "sha256-ns/ElaYtJVe2vlueemfJBL6QbOLdxP5kloqEY/yi2jg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "1f26bfb970a2ba8c3169b99a2edba9c4ca72b2d6",
+        "rev": "8bc97e497b7cbd64c9fe0f0cf2247af8f575fa4e",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780743265,
-        "narHash": "sha256-yql7oROXAWHV3SYSokfZLLoH53ZTcdLQRWxHpfrYFdA=",
+        "lastModified": 1780799691,
+        "narHash": "sha256-fHQVaor1AEWxZ0k6oHqMhNCcCP+BVSulD4UW5W0cCT4=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "c142b3df99fa1049eedaa630d25b3d2e9056b01a",
+        "rev": "70c59ad5bd4c9f712e42a1f8b196bc61575605f3",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.