### PR TITLE
feat(pi): install and configure Pi coding agent (native, multi-provider)

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -1,0 +1,35 @@
+pi:
+  # Pi Coding Agent configuration
+  # Repo: https://github.com/earendil-works/pi  (npm @earendil-works/pi-coding-agent)
+  #
+  # Pi natively supports multiple providers: it ships a built-in model registry
+  # (anthropic, openai, deepseek, zai/glm, kimi-coding, minimax, google, xai,
+  # groq, ...) and switches provider/model at runtime via `/model`, with auth via
+  # `/login`, env vars, or ~/.pi/agent/auth.json. So no account-switching wrappers
+  # are needed — this file only sets the startup default and any CUSTOM (non
+  # built-in) providers.
+
+  # ===== Startup defaults -> ~/.pi/agent/settings.json =====
+  defaults:
+    theme: dark
+    defaultThinkingLevel: medium
+    defaultProvider: anthropic
+    defaultModel: claude-opus-4-8
+  # ===== Custom providers (NOT in Pi's built-in registry) -> ~/.pi/agent/models.json =====
+  # Only providers Pi does not know natively. apiKey uses "$<env>" (no secrets);
+  # set the env var, or authenticate via /login (stored in auth.json), then pick
+  # the model with /model. Remove these if you don't use them.
+  customProviders:
+    qwen: # Alibaba DashScope (OpenAI-compatible)
+      base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+      api: openai-completions
+      env: DASHSCOPE_API_KEY
+      models:
+        - qwen3-coder-plus
+        - qwen3-max
+    doubao: # ByteDance Ark v3 (OpenAI-compatible)
+      base_url: https://ark.cn-beijing.volces.com/api/v3
+      api: openai-completions
+      env: ARK_API_KEY
+      models:
+        - doubao-seed-1-6-thinking-250715

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -75,6 +75,20 @@ Library/
 {{- end }}
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Pi coding agent runtime/secret state — Pi writes these into ~/.pi/agent at
+# runtime; never version-control them (settings.json/models.json/extensions are
+# managed via dot_pi/, everything below is owned by Pi or the user).
+# ─────────────────────────────────────────────────────────────────────────────
+.pi/agent/auth.json
+.pi/agent/sessions/
+.pi/agent/trust.json
+.pi/agent/keybindings.json
+.pi/agent/npm/
+.pi/agent/git/
+.pi/agent/logs/
+.pi/agent/extensions/*/node_modules/
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Ignored directories
 # ─────────────────────────────────────────────────────────────────────────────
 backup/

--- a/.chezmoiscripts/run_onchange_after_13_pi-mcp-adapter.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_13_pi-mcp-adapter.sh.tmpl
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Install the pi-mcp-adapter extension, which adds MCP support to Pi (Pi has no
+# native MCP). Pi reads MCP servers from ~/.pi/agent/mcp.json (managed by
+# chezmoi). Idempotent: installs only if not already present; upgrade later with
+# `pi update`. Re-runs only when this script changes.
+
+echo ":: [13] Installing pi-mcp-adapter (MCP support for Pi)"
+
+cd "$HOME"
+
+# Locate the aqua-managed mise; pi is a mise-managed tool, so invoke it via
+# `mise exec` (same approach as the mise-install script).
+aqua_bin_dir="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin"
+[[ -d "$aqua_bin_dir" ]] && export PATH="$aqua_bin_dir:$PATH"
+
+mise_cmd="$aqua_bin_dir/mise"
+if [[ ! -x "$mise_cmd" ]]; then
+    if command -v mise &>/dev/null; then
+        mise_cmd="$(command -v mise)"
+    else
+        echo "    Skipped (mise not found)"
+        exit 0
+    fi
+fi
+
+if ! "$mise_cmd" exec -- pi --version &>/dev/null; then
+    echo "    Skipped (pi not installed yet; run mise install first)"
+    exit 0
+fi
+
+if "$mise_cmd" exec -- pi list 2>/dev/null | grep -qi "pi-mcp-adapter"; then
+    echo "    Already installed"
+    exit 0
+fi
+
+echo "    pi install npm:pi-mcp-adapter"
+if ! "$mise_cmd" exec -- pi install npm:pi-mcp-adapter </dev/null; then
+    echo "    Warning: 'pi install npm:pi-mcp-adapter' failed (MCP will be unavailable in Pi)"
+fi

--- a/dot_local/bin/executable_tmux-ai-agent-state
+++ b/dot_local/bin/executable_tmux-ai-agent-state
@@ -5,7 +5,7 @@
 #   tmux-ai-agent-state claude busy
 #   tmux-ai-agent-state claude idle
 #
-# The script intentionally never fails the caller. Claude and Codex run these
+# The script intentionally never fails the caller. Claude, Codex and Pi run these
 # hooks inline with user workflows; status collection must not block prompts.
 set -u
 
@@ -24,6 +24,9 @@ agent_tool_for_command() {
         ;;
     codex | codex-aarch64-* | codex-x86_64-*)
         printf '%s\n' "codex"
+        ;;
+    pi | pi-aarch64-* | pi-x86_64-*)
+        printf '%s\n' "pi"
         ;;
     *)
         return 1
@@ -104,7 +107,7 @@ write_state() {
     local server_pid pane_tty pid cache_dir state_file now
     local transcript_path turn_id transcript_line_count
 
-    [[ "$tool" =~ ^(claude|codex)$ ]] || return 0
+    [[ "$tool" =~ ^(claude|codex|pi)$ ]] || return 0
     [[ "$state" =~ ^(busy|idle)$ ]] || return 0
     [[ -n "$pane_id" ]] || return 0
     command -v tmux >/dev/null 2>&1 || return 0

--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -1,0 +1,27 @@
+# Pi Coding Agent Global Instructions
+
+Pragmatic engineering: clarity, correctness, minimal change. Prefer repo conventions, solve root causes, verify before declaring done, state assumptions/risks briefly.
+
+## Tooling
+
+Repo-native first; defaults advisory (`uv/ruff`, `nix`, `aqua/mise`, `gh/ghq`); user/repo policy overrides. Treat hook output as instructions — act on the remediation before continuing.
+
+## MCP routing
+
+MCP tools are provided by the `pi-mcp-adapter` extension; servers are configured in `~/.pi/agent/mcp.json`.
+
+- Docs/API -> Context7
+- Web/news -> Tavily
+- Code navigation -> Serena (symbolic/semantic; avoid full-file reads when a query suffices)
+- Browser/E2E -> agent-browser (CLI)
+- Repo Q&A -> DeepWiki (public) / gitmcp (private)
+- Database/SQL -> postgres
+
+User preference overrides; fall back when unavailable; no sensitive data in queries.
+
+## Workflow & guardrails
+
+- Worktree default `one-task-one-branch-one-worktree` (`.worktrees/<branch>`); for governed changes `slipway` provisions it automatically (`feat/<slug>`) — don't create one manually. Use `wt-*` for non-slipway work.
+- Installs: detect lockfiles, resolve signal-vs-preference conflicts explicitly, no mixed managers without confirmation.
+- Use `slipway` for governed changes (multi-step features, sensitive domains, formal review); artifacts in `artifacts/changes/<slug>/`; skip trivial edits.
+- Sensitive domains (Auth/AuthZ, Credentials/PII, Financial, Schema migration, Irreversible ops, External API contracts): never bypass confirmation; never install without preflight.

--- a/dot_pi/agent/extensions/tmux-state/index.ts
+++ b/dot_pi/agent/extensions/tmux-state/index.ts
@@ -1,0 +1,28 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Bridge Pi's session lifecycle into the shared tmux AI-agent status indicator
+// (~/.local/bin/tmux-ai-agent-state), so a `pi` pane reports busy/idle exactly
+// like the `claude` and `codex` panes. Pi has no native hooks (the hooks API
+// became the extensions API in v0.31.0), so this replaces codex's
+// [[hooks.SessionStart]] / [[hooks.Stop]] config blocks.
+//
+// Best-effort by design: status collection must never disrupt or block the
+// session, so every invocation swallows its errors.
+const STATE_SCRIPT = join(homedir(), ".local", "bin", "tmux-ai-agent-state");
+
+export default function (pi: ExtensionAPI) {
+  const setState = async (state: "busy" | "idle"): Promise<void> => {
+    try {
+      await pi.exec(STATE_SCRIPT, ["pi", state], { timeout: 2000 });
+    } catch {
+      // ignore: the tmux indicator is non-essential
+    }
+  };
+
+  pi.on("session_start", () => setState("idle"));
+  pi.on("before_agent_start", () => setState("busy"));
+  pi.on("agent_end", () => setState("idle"));
+  pi.on("session_shutdown", () => setState("idle"));
+}

--- a/dot_pi/agent/extensions/tmux-state/package.json
+++ b/dot_pi/agent/extensions/tmux-state/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pi-ext-tmux-state",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Bridge Pi session lifecycle to the shared tmux AI-agent status indicator",
+  "type": "module",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  }
+}

--- a/dot_pi/agent/mcp.json.tmpl
+++ b/dot_pi/agent/mcp.json.tmpl
@@ -1,0 +1,49 @@
+{{- /*
+  ~/.pi/agent/mcp.json — MCP servers for the pi-mcp-adapter extension.
+  Same shape as codex/claude MCP config. stdio servers reuse the shared
+  ~/.local/bin/mcp-* wrappers; remote servers use "url". Managed by chezmoi
+  (dot_pi/agent/mcp.json.tmpl). The adapter is installed by
+  .chezmoiscripts/run_onchange_after_13_pi-mcp-adapter.sh.tmpl.
+*/ -}}
+{
+  "mcpServers": {
+    "context7": {
+      "command": "{{ .chezmoi.homeDir }}/.local/bin/mcp-context7",
+      "args": [],
+      "lifecycle": "lazy"
+    },
+    "tavily": {
+      "command": "{{ .chezmoi.homeDir }}/.local/bin/mcp-tavily",
+      "args": [],
+      "lifecycle": "lazy"
+    },
+    "postgres": {
+      "command": "{{ .chezmoi.homeDir }}/.local/bin/mcp-postgres",
+      "args": [],
+      "lifecycle": "lazy"
+    },
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide-assistant",
+        "--project",
+        ".",
+        "--enable-web-dashboard",
+        "false"
+      ],
+      "env": {
+        "AQUA_GLOBAL_CONFIG": "{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml"
+      },
+      "lifecycle": "lazy"
+    },
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "lifecycle": "lazy"
+    }
+  }
+}

--- a/dot_pi/agent/models.json.tmpl
+++ b/dot_pi/agent/models.json.tmpl
@@ -1,0 +1,26 @@
+{{- /*
+  ~/.pi/agent/models.json — CUSTOM providers only.
+
+  Pi ships a built-in model registry (~25 providers: anthropic, openai, deepseek,
+  zai/glm, kimi-coding, minimax, google, xai, groq, ...). Those need NO entry here.
+  We emit only the providers under `customProviders` in .chezmoidata/pi.yaml that
+  Pi does not know natively (e.g. qwen, doubao).
+
+  apiKey uses the "$<env>" form (from each provider's `env`); set that env var, or
+  authenticate via /login (stored in auth.json). No secret is stored in this file.
+*/ -}}
+{{- $providers := dict -}}
+{{- if hasKey .pi "customProviders" -}}
+{{-   range $name, $cfg := .pi.customProviders -}}
+{{-     $env := printf "%s_API_KEY" (upper $name) -}}
+{{-     if hasKey $cfg "env" -}}{{- $env = $cfg.env -}}{{- end -}}
+{{-     $p := dict "baseUrl" $cfg.base_url "api" $cfg.api "apiKey" (printf "$%s" $env) -}}
+{{-     if hasKey $cfg "models" -}}
+{{-       $models := list -}}
+{{-       range $cfg.models -}}{{- $models = append $models (dict "id" .) -}}{{- end -}}
+{{-       $p = set $p "models" $models -}}
+{{-     end -}}
+{{-     $providers = set $providers $name $p -}}
+{{-   end -}}
+{{- end -}}
+{{ dict "providers" $providers | toPrettyJson -}}

--- a/dot_pi/agent/modify_settings.json.tmpl
+++ b/dot_pi/agent/modify_settings.json.tmpl
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# chezmoi modify_ script: merge managed Pi settings into ~/.pi/agent/settings.json,
+# preserving any keys Pi or the user writes (e.g. via /settings, /model). Managed
+# keys (defaultProvider/defaultModel/theme/...) always win on re-apply.
+#
+# Defaults come from .chezmoidata/pi.yaml. Switch provider/model at runtime with
+# Pi's native /model command; this only sets the startup default.
+set -euo pipefail
+
+EXISTING="$(cat)"
+{{ $d := .pi.defaults -}}
+{{- $managed := dict "defaultProvider" $d.defaultProvider "defaultModel" $d.defaultModel "theme" $d.theme "defaultThinkingLevel" $d.defaultThinkingLevel "enableSkillCommands" true -}}
+MANAGED="$(cat <<'PI_SETTINGS_EOF'
+{{ $managed | toPrettyJson }}
+PI_SETTINGS_EOF
+)"
+
+if command -v jq >/dev/null 2>&1 && printf '%s' "$EXISTING" | jq -e . >/dev/null 2>&1; then
+    # Deep-merge: existing settings as base, managed keys override.
+    jq -s '.[0] * .[1]' <(printf '%s' "$EXISTING") <(printf '%s' "$MANAGED")
+else
+    printf '%s\n' "$MANAGED"
+fi

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.11.2
+  - name: signalridge/slipway@v0.11.3
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -61,6 +61,10 @@ lua = "5.4"
 # Gemini CLI managed via npm backend (replaces nix gemini-cli)
 "npm:@google/gemini-cli" = "latest"
 
+# Pi coding agent (earendil-works). Binary is `pi`. Requires node >=22.19,
+# satisfied by `node = "lts"` above. Auth/config under ~/.pi/agent (chezmoi-managed).
+"npm:@earendil-works/pi-coding-agent" = "latest"
+
 # AI coding usage analyzers
 "npm:ccusage" = "latest"
 "npm:@ccusage/codex" = "latest"

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -18,4 +18,6 @@ includes = ["*.lua"]
 command = "prettier"
 options = ["--write"]
 includes = ["*.md", "*.json", "*.yaml", "*.yml"]
-excludes = ["CLAUDE.md"]
+# modify_* are chezmoi modify_ scripts (bash), even when their target is .json
+# (e.g. ~/.pi/agent/settings.json) — never format them as their target type.
+excludes = ["CLAUDE.md", "modify_*"]


### PR DESCRIPTION
## Summary

Adds the **Pi coding agent** (`@earendil-works/pi-coding-agent`, binary `pi`) as a native, multi-provider AI CLI alongside `claude`/`codex`.

Pi ships a built-in multi-provider model registry, so it's configured the **native** way — no gopass account-switching wrappers (they'd be redundant).

## What's included

- **Install**: mise `npm:@earendil-works/pi-coding-agent` (pinned `latest`)
- **Config** (`~/.pi/agent/`, driven by `.chezmoidata/pi.yaml`):
  - `settings.json` via a `modify_` script that merges managed keys (`defaultProvider`/`defaultModel`/`theme`/…) while **preserving** keys pi or the user write (e.g. `packages`)
  - `models.json` — only **custom** (non-built-in) providers: qwen, doubao
  - `APPEND_SYSTEM.md` — global agent instructions (mirrors codex `AGENTS.md`)
- **tmux-state extension** — pi pane busy/idle via `~/.local/bin/tmux-ai-agent-state` (pi has no native hooks); `tmux-ai-agent-state` now recognizes `pi`
- **MCP via `pi-mcp-adapter`** (pi has no native MCP) — installed by `run_onchange_after_13`; servers in `~/.pi/agent/mcp.json` (context7/tavily/postgres/serena/deepwiki), all `lazy` for fast startup
- `.chezmoiignore` — ignore pi runtime/secret state (auth.json, sessions, npm, …)
- `treefmt` — don't prettier-format chezmoi `modify_` scripts (bash, not their target type)

## Verification

- pi 0.78.1 installs; built-in registry + custom qwen/doubao resolve
- extensions auto-discover & load; adapter installs and loads; startup ~1.6s, clean exit
- settings `modify_` merge is idempotent (adapter `packages` + managed keys coexist across re-apply)
- shellcheck clean; pre-commit (treefmt / typos / gitleaks / template render+check) all pass

## Notes

- Auth is left to the user (`/login`); no credentials touched.
- Live tmux pane status + actual MCP tool calls require an interactive session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)