### PR TITLE
chore(versions): update pinned versions (2026-06-08)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -7,12 +7,12 @@ versions:
   aquaInstaller: v4.0.4
   aquaInstallerSha256: acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28
   aquaVersion: v2.59.1
-  nixIndexDb: 2026-05-31-064259
+  nixIndexDb: 2026-06-07-065317
   paperlib: 3.1.12
   claudeWshobsonAgentsRev: cf6059d030bf4fe96623ae2e596d2f31e35fedc0
   claudeWshobsonAgentsSha256: dbd646528a72a795df3a0394eadd3f590e4588a052a6a8553b939fdfef4b3b8e
-  claudeAnthropicsSkillsRev: da20c92503b2e8ff1cf28ca81a0df4673debdbf7
-  claudeAnthropicsSkillsSha256: 586e3fccffbf1d033c76f14deb9b3ebb7cdf91960b9b72cee9038c3c21c57b79
+  claudeAnthropicsSkillsRev: c30d329f5814647c1e2f071020c1e8c1c9893ef1
+  claudeAnthropicsSkillsSha256: d24f2f4616ed3404347bb1c449f26dedca64676a7511a7939143428f0a412648
   claudeBaoyuSkillsRev: ce84174bf7af6a178ae2c980f1bdcce4f1c3f7de
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
@@ -27,7 +27,7 @@ versions:
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: 145a923cce95c2cef20643302e8811363fa2e51d
   microsoftSkillsRev: 619745888df8014bc963929896f9a279c6d12641
-  sickn33AntigravitySkillsRev: 9d486d0899e0c4474939861469ac43339f128344
+  sickn33AntigravitySkillsRev: d89c349f775bff02124a1bbd345450115c1c8705
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d
@@ -40,6 +40,6 @@ versions:
   dpearsonSwiftSkillsRev: 8112d1004918fc698e936e38ddf14d4a7301b982
   effectiveTypescriptRev: d754db2077d71ae1e2b57bf50ae7bc565067a2e0
   bobmatnycMpmSkillsRev: 613bfff57467be1191a32e40ba60ed1ee7ce289f
-  humanizerEnRev: a2ace14a88a6746f64f1f53ed8272d6788828038
+  humanizerEnRev: 9600f2b7241cb4eed6ad803abee5ea01d67fe8e4
   humanizerJaRev: 1b850cfe8529f7836025b2edd15b3d64447f8fb6
   quAiWeiRev: da121a748e23d39f4e4052058d9721c66a54f134


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.1` |
| nix-index-database | `2026-06-07-065317` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `504191c59a67888cae225ea54fe03aa502ef0319` |
| getsentry/skills | `493bb49084f6a8add1eaefb85a952e999f362415` |
| trailofbits/skills | `d5fe2e6a7896236c3102fd5477e833623ad70298` |
| cloudflare/skills | `c5b7b06b073fa0b4abbd63964630f97d81da69c4` |
| vercel-labs/agent-skills | `4ec6f84b61cd3c931046c3e6e398f3ae7de372f7` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `145a923cce95c2cef20643302e8811363fa2e51d` |
| microsoft/skills | `619745888df8014bc963929896f9a279c6d12641` |
| sickn33/antigravity-awesome-skills | `d89c349f775bff02124a1bbd345450115c1c8705` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |