### PR TITLE
chore(brew): drop dead azure/functions tap (func via CDN) + add displaylink cask

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -4,8 +4,7 @@ homebrew:
       - nikitabobko/tap
       - FelixKratz/formulae
       - muxy-app/tap # muxy cask source
-    work:
-      - azure/functions
+    work: [] # azure/functions removed — repo GitHub-staff-disabled 2026-06-05 (untappable); func now installed from Azure CDN via run_onchange_after_14
     private: []
   brews:
     shared:
@@ -17,7 +16,7 @@ homebrew:
       - awscli
       - aws-sam-cli
       - azure-cli
-      - azure/functions/azure-functions-core-tools@4
+      # azure-functions-core-tools@4 — installed from Azure CDN by run_onchange_after_14 (tap is GitHub-staff-disabled)
     private:
       - mas # Required for masApps installation
   casks:

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -22,6 +22,7 @@ homebrew:
   casks:
     shared:
       - codex-app # OpenAI Codex desktop app for managing coding agents
+      - displaylink # USB dock/adapter multi-monitor driver; needs reboot + manual Screen Recording grant
       - dockdoor
       - visual-studio-code
       - hammerspoon

--- a/.chezmoiscripts/run_onchange_after_14_azure-functions-core-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_14_azure-functions-core-tools.sh.tmpl
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+{{ if .work -}}
+# Azure Functions Core Tools (`func`) — work machines only.
+#
+# Installed directly from Microsoft's public CDN, NOT Homebrew or npm:
+#   - The official tap `azure/functions` (github.com/azure/homebrew-functions)
+#     and the source repo were disabled by GitHub staff (ToS block, 2026-06-05);
+#     `brew tap` hangs on an auth prompt and cannot succeed even when logged in.
+#   - The npm package fetches the same CDN binary but couples the install to a
+#     specific mise-managed node version and its postinstall download is flaky.
+# This CDN zip is the identical binary brew/npm ship, fetched reliably (resumable
+# curl) into a versioned dir and symlinked onto PATH.
+#
+# To upgrade: bump VERSION and BUILD_ID together (changing them re-triggers this
+# run_onchange script). Both values come from the npm package metadata:
+#   npm view azure-functions-core-tools@4 version consolidatedBuildId
+VERSION="4.12.0"
+BUILD_ID="281211" # consolidatedBuildId; CDN path uses 4.0.<BUILD_ID>
+
+echo ":: [14] Azure Functions Core Tools (func) ${VERSION}"
+
+install_root="${XDG_DATA_HOME:-$HOME/.local/share}/azure-functions-core-tools"
+target_dir="${install_root}/${VERSION}"
+bin_dir="$HOME/.local/bin"
+func_link="${bin_dir}/func"
+
+mkdir -p "$bin_dir"
+
+# Idempotent: already at the target version → just ensure the symlink is correct.
+if [[ -x "${target_dir}/func" ]] \
+    && current="$("${target_dir}/func" --version 2>/dev/null)" \
+    && [[ "$current" == "$VERSION" ]]; then
+    ln -sfn "${target_dir}/func" "$func_link"
+    echo "    Already installed (${VERSION})"
+    exit 0
+fi
+
+# Map platform → Azure CDN release identifier.
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64) rid="osx-arm64" ;;
+    Darwin-x86_64) rid="osx-x64" ;;
+    Linux-aarch64 | Linux-arm64) rid="linux-arm64" ;;
+    Linux-x86_64) rid="linux-x64" ;;
+    *)
+        echo "    Skipped (unsupported platform $(uname -s)-$(uname -m))"
+        exit 0
+        ;;
+esac
+
+url="https://cdn.functions.azure.com/public/4.0.${BUILD_ID}/Azure.Functions.Cli.${rid}.${VERSION}.zip"
+echo "    Downloading ${rid} ${VERSION} from Azure CDN (~600MB)..."
+
+tmp_zip="$(mktemp -t func.XXXXXX.zip)"
+trap 'rm -f "$tmp_zip"' EXIT
+if ! curl -fL --retry 5 --retry-delay 2 -C - -o "$tmp_zip" "$url"; then
+    echo "    Error: download failed (${url})" >&2
+    exit 1
+fi
+
+# Extract into a versioned dir so the binary and its sibling .NET assemblies stay
+# together, then (re)point the PATH symlink at it.
+rm -rf "$target_dir"
+mkdir -p "$target_dir"
+unzip -oq "$tmp_zip" -d "$target_dir"
+chmod +x "${target_dir}/func" 2>/dev/null || true
+chmod +x "${target_dir}/gozip" 2>/dev/null || true
+ln -sfn "${target_dir}/func" "$func_link"
+
+# Prune older versions (~1.5GB each once extracted).
+find "$install_root" -mindepth 1 -maxdepth 1 -type d ! -name "$VERSION" -exec rm -rf {} + 2>/dev/null || true
+
+echo "    Installed func ${VERSION} -> ${func_link}"
+"$func_link" --version
+{{- else -}}
+# func is a work-only tool; nothing to do on a non-work machine.
+:
+{{- end }}


### PR DESCRIPTION
Two unrelated Homebrew config changes, each in its own commit.

---

## 1. Replace the dead `azure/functions` tap with a CDN installer

### Problem
The `azure/functions` Homebrew tap (`github.com/azure/homebrew-functions`) and its source repo were **disabled by GitHub staff** (ToS block, `2026-06-05`). Consequences:

- `brew bundle` during `darwin-rebuild` **hangs interactively** on `Username for 'https://github.com':` while trying to tap it.
- The git endpoint returns **HTTP 403 "Access to this repository has been disabled by GitHub staff"** even with valid credentials — verified via Basic auth + the `gh` credential helper. **Logging in does not help.**
- `azure-functions-core-tools@4` has no homebrew-core equivalent, so the tap was its only brew source.

### Fix
- Remove the untappable `azure/functions` tap and the `azure-functions-core-tools@4` brew entry from `.chezmoidata/homebrew.yaml` (both annotated with the reason + pointer to the new script).
- Add `run_onchange_after_14_azure-functions-core-tools.sh.tmpl` — a **work-only** (`{{ if .work }}`) installer that pulls `func` straight from Microsoft's public CDN (`cdn.functions.azure.com`), the **same binary** brew/npm ship.

| Path | Status |
|------|--------|
| brew (official) | ❌ tap GitHub-staff-disabled; hangs `darwin-rebuild`, 403 even authed |
| npm package | ⚠️ works but couples to mise-managed node version; flaky ~600MB postinstall |
| **Azure CDN (this PR)** | ✅ same binary, resumable curl, version-pinned, no GitHub/brew/node coupling |

Script: detects platform → CDN release id; resumable `curl --retry`; extracts to `~/.local/share/azure-functions-core-tools/<version>`; symlinks `func` into `~/.local/bin` (.NET DLL resolution through the symlink verified); idempotent (skips the ~600MB download when already current); prunes old versions. Upgrade = bump `VERSION` + `BUILD_ID` (from `npm view azure-functions-core-tools@4 version consolidatedBuildId`).

**Verification:** `chezmoi execute-template` render + `bash -n` OK; valid YAML with `taps.work=[]` and zero `azure/functions` refs; `func --version` via the PATH symlink → `4.12.0`; re-run hits the idempotent fast path.

---

## 2. Add `displaylink` cask (shared)

DisplayLink USB Graphics driver for multi-monitor docks/adapters, added to `casks.shared` (all machines). Installs from homebrew-cask core — **no special tap**.

⚠️ Post-install is **not** fully automatable: requires a **reboot** and a manual **Screen Recording** permission grant for DisplayLink Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)