### PR TITLE
chore(brew): add keepingyouawake cask

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -51,6 +51,7 @@ homebrew:
       - obsidian
       - cursor
       - gcloud-cli
+      - keepingyouawake # menu-bar utility to keep the Mac awake
     private:
       - cherry-studio # Multi-model AI desktop client
       - adguard


### PR DESCRIPTION
## Summary
- Add `keepingyouawake` Homebrew cask — a menu-bar utility to keep the Mac awake.

## Test plan
- N/A (declarative package list change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)