### PR TITLE
chore(versions): update pinned versions (2026-06-09)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -18,14 +18,14 @@ versions:
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
   openaiSkillsRev: a8924c2a35cfa290458852c4fad17c9133054c2e
   huggingfaceSkillsRev: d7223848c3895fbd447faf2aec73e0a6cdd7fdcd
-  getsentrySkillsRev: 493bb49084f6a8add1eaefb85a952e999f362415
+  getsentrySkillsRev: b39c7c4b6056f0579b340b7c5c4e811e400368e8
   trailofbitsSkillsRev: d5fe2e6a7896236c3102fd5477e833623ad70298
   cloudflareSkillsRev: c5b7b06b073fa0b4abbd63964630f97d81da69c4
   vercelLabsAgentSkillsRev: 4ec6f84b61cd3c931046c3e6e398f3ae7de372f7
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
   vercelLabsAgentBrowserRev: 328ce8a98560ac7bac8fa81f53a718822550b94e
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
-  expoSkillsRev: 145a923cce95c2cef20643302e8811363fa2e51d
+  expoSkillsRev: c38860242118df93d4ec4381a34f4144fff61928
   microsoftSkillsRev: 619745888df8014bc963929896f9a279c6d12641
   sickn33AntigravitySkillsRev: afc403de16917b418c301b690970047b2109542f
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.0` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.59.1` |
| nix-index-database | `2026-06-07-065317` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `d7223848c3895fbd447faf2aec73e0a6cdd7fdcd` |
| getsentry/skills | `b39c7c4b6056f0579b340b7c5c4e811e400368e8` |
| trailofbits/skills | `d5fe2e6a7896236c3102fd5477e833623ad70298` |
| cloudflare/skills | `c5b7b06b073fa0b4abbd63964630f97d81da69c4` |
| vercel-labs/agent-skills | `4ec6f84b61cd3c931046c3e6e398f3ae7de372f7` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `c38860242118df93d4ec4381a34f4144fff61928` |
| microsoft/skills | `619745888df8014bc963929896f9a279c6d12641` |
| sickn33/antigravity-awesome-skills | `afc403de16917b418c301b690970047b2109542f` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |