### PR TITLE
chore(aqua): update pinned packages (2026-06-10)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.15.0
+  - name: signalridge/slipway@v0.17.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.