### PR TITLE
chore(versions): update pinned versions (2026-06-11)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -17,7 +17,7 @@ versions:
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
   openaiSkillsRev: a8924c2a35cfa290458852c4fad17c9133054c2e
-  huggingfaceSkillsRev: d7223848c3895fbd447faf2aec73e0a6cdd7fdcd
+  huggingfaceSkillsRev: 7bf59b7f85b79c74207b10d5e425934514e8b089
   getsentrySkillsRev: b39c7c4b6056f0579b340b7c5c4e811e400368e8
   trailofbitsSkillsRev: c070b9b5881183ea5f6e320ff06c46688becb13e
   cloudflareSkillsRev: c5b7b06b073fa0b4abbd63964630f97d81da69c4
@@ -27,7 +27,7 @@ versions:
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: 1a5693e0acc95a0829ff1656b4426fee2f2c1167
   microsoftSkillsRev: dee7bef5a24cfd8e313a60c4039cfbdbd0118c6c
-  sickn33AntigravitySkillsRev: 13c8a69fb89d5296a9ee5f0ea7e422b08d9c9fe0
+  sickn33AntigravitySkillsRev: 4da6d2a312f54a5c12fe26e7792df6635f534df6
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.1` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.60.0` |
| nix-index-database | `2026-06-07-065317` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `7bf59b7f85b79c74207b10d5e425934514e8b089` |
| getsentry/skills | `b39c7c4b6056f0579b340b7c5c4e811e400368e8` |
| trailofbits/skills | `c070b9b5881183ea5f6e320ff06c46688becb13e` |
| cloudflare/skills | `c5b7b06b073fa0b4abbd63964630f97d81da69c4` |
| vercel-labs/agent-skills | `f8a72b9603728bb92a217a879b7e62e43ad76c81` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `1a5693e0acc95a0829ff1656b4426fee2f2c1167` |
| microsoft/skills | `dee7bef5a24cfd8e313a60c4039cfbdbd0118c6c` |
| sickn33/antigravity-awesome-skills | `4da6d2a312f54a5c12fe26e7792df6635f534df6` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |