### PR TITLE
perf(ci): drop Nix store cache restores

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - name: Restore Nix cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('nix-config/**/*.nix', 'nix-config/**/*.tmpl', 'nix-config/.flake-*.lock', '.github/workflows/*.yml', '.pre-commit-config.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-          gc-max-store-size-macos: 2G
       - name: Install test dependencies
         run: |
           nix profile install nixpkgs#chezmoi nixpkgs#jq

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -32,13 +32,6 @@ jobs:
           installMasApps = false
           EOF
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - name: Restore Nix cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('nix-config/**/*.nix', 'nix-config/**/*.tmpl', 'nix-config/.flake-*.lock', '.github/workflows/*.yml', '.pre-commit-config.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-          gc-max-store-size-macos: 2G
       - name: Install chezmoi
         run: nix profile install nixpkgs#chezmoi
       - name: Update flake.lock


### PR DESCRIPTION
## Summary

- Remove `nix-community/cache-nix-action` from `update-flake-lock.yml`.
- Remove the remaining Nix store restore from `tests.yml`.
- Keep workflows relying on the Nix binary cache configured by `DeterminateSystems/nix-installer-action`.

## Why

The investigated `Update (darwin)` job spent most of its runtime restoring the GitHub Actions Nix store cache. The cache download completed quickly, but tar/zstd extraction into `/nix/store` on the macOS runner took roughly 8 to 11 minutes across recent runs. These workflows only install a small set of tools or update/check lock files, so restoring the whole store costs more than using the public binary cache.

## Validation

- `rg "cache-nix-action|Restore Nix cache|nix-community/cache|gc-max-store-size|restore-prefixes-first-match|primary-key: nix-" .github/workflows` returned no matches.
- `git diff --cached --check` passed before commit.
- Parsed all workflow YAML files with Ruby `YAML.load_file`.
- `actionlint` passed.