### PR TITLE
fix: configure Homebrew tap trust

### DIFF
--- a/nix-config/modules/apps.nix.tmpl
+++ b/nix-config/modules/apps.nix.tmpl
@@ -30,6 +30,11 @@
     onActivation = {
       autoUpdate = false; # Disabled: auto-update resets brew bundle state, breaking mas detection (Homebrew 5.1+)
       upgrade = true; # Upgrade outdated casks and formulae (mas upgrade still fails due to root requirement on macOS 15.4+)
+      extraEnv = {
+        # nix-darwin activation runs under sudo and does not inherit dot_zshenv.
+        # Keep Homebrew trust lookup on the managed XDG config path.
+        XDG_CONFIG_HOME = "{{ .chezmoi.homeDir }}/.config";
+      };
       # 'zap': uninstalls all formulae(and related files) not listed in the generated Brewfile
       cleanup = "zap";
     };

--- a/private_dot_config/homebrew/private_trust.json
+++ b/private_dot_config/homebrew/private_trust.json
@@ -1,0 +1,4 @@
+{
+  "trustedformulae": ["felixkratz/formulae/borders"],
+  "trustedtaps": ["felixkratz/formulae", "muxy-app/tap", "nikitabobko/tap"]
+}


### PR DESCRIPTION
## Summary

- Preserve `XDG_CONFIG_HOME` for nix-darwin's Homebrew activation so `brew bundle` reads the managed Homebrew trust file.
- Add a chezmoi-managed private Homebrew trust file for the non-official taps currently used by the Brewfile.

## Root Cause

`brew trust` stored entries under `~/.config/homebrew/trust.json` because interactive shells export `XDG_CONFIG_HOME`. nix-darwin runs the Homebrew activation under sudo and did not inherit that variable, so Homebrew looked in its fallback trust location and refused non-official tap contents such as `felixkratz/formulae/borders` and `muxy-app/tap/muxy`.

## Validation

- `jq empty private_dot_config/homebrew/private_trust.json`
- `chezmoi execute-template < nix-config/modules/apps.nix.tmpl | nix-instantiate --parse - >/dev/null`
- `git diff --cached --check`
- pre-commit hooks from `git commit`, including treefmt, gitleaks, typos, and template validation
- `XDG_CONFIG_HOME="$HOME/.config" brew trust --json v1` reports the configured third-party taps as trusted

## Notes

This PR intentionally leaves `homebrew.onActivation.cleanup = "zap"` unchanged, so Homebrew may still print its upstream `--cleanup` deprecation warning during activation.