### PR TITLE
chore(versions): update pinned versions (2026-06-13)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -23,11 +23,11 @@ versions:
   cloudflareSkillsRev: 12520fd63a1e958be217a93f48ce1f04bc9055f3
   vercelLabsAgentSkillsRev: f8a72b9603728bb92a217a879b7e62e43ad76c81
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
-  vercelLabsAgentBrowserRev: 5185339ca3fdab9848e11b8ec676eecfdec3733f
+  vercelLabsAgentBrowserRev: 2c7991c9eccca1c9db6eee1a26a713414778de5a
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: 39d50f0caeacec8a17588534bb32aa962c677a3d
   microsoftSkillsRev: dee7bef5a24cfd8e313a60c4039cfbdbd0118c6c
-  sickn33AntigravitySkillsRev: cb7f9b7851bad345a9d0f3909f7ef804619701c2
+  sickn33AntigravitySkillsRev: 3a407b3c2bf310dd330da4fc801b9f87d2d8b4d1
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.1` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.60.0` |
| nix-index-database | `2026-06-07-065317` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `c68f1b08d9eb3af22cdc1d3fb60e9cdb78522556` |
| getsentry/skills | `b39c7c4b6056f0579b340b7c5c4e811e400368e8` |
| trailofbits/skills | `c070b9b5881183ea5f6e320ff06c46688becb13e` |
| cloudflare/skills | `12520fd63a1e958be217a93f48ce1f04bc9055f3` |
| vercel-labs/agent-skills | `f8a72b9603728bb92a217a879b7e62e43ad76c81` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `39d50f0caeacec8a17588534bb32aa962c677a3d` |
| microsoft/skills | `dee7bef5a24cfd8e313a60c4039cfbdbd0118c6c` |
| sickn33/antigravity-awesome-skills | `3a407b3c2bf310dd330da4fc801b9f87d2d8b4d1` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |