### PR TITLE
feat: add Vial keyboard configurator

### DIFF
--- a/.chezmoidata/aerospace.yaml
+++ b/.chezmoidata/aerospace.yaml
@@ -15,6 +15,8 @@ aerospace:
         comment: Keka
       - id: com.hegenberg.KeyboardCleanTool
         comment: KeyboardCleanTool
+      - id: com.vial.Vial
+        comment: Vial
       - id: org.pqrs.Karabiner-Elements.Settings
         comment: Karabiner Elements
       - id: org.pqrs.Karabiner-EventViewer

--- a/.chezmoidata/hammerspoon.yaml
+++ b/.chezmoidata/hammerspoon.yaml
@@ -25,6 +25,8 @@ hammerspoon:
         ime: en
       - app: Karabiner-EventViewer
         ime: en
+      - app: Vial
+        ime: en
       - app: AeroSpace
         ime: en
       - app: Raycast

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -29,6 +29,7 @@ homebrew:
       - karabiner-elements
       - keka
       - keyboardcleantool
+      - vial
       - ghostty
       - muxy # macOS-first terminal (SwiftUI + libghostty) for AI-agent workflows
       - mockoon


### PR DESCRIPTION
## Summary

- Add the `vial` Homebrew cask to the shared app list.
- Configure AeroSpace to float Vial windows.
- Configure Hammerspoon IME auto-switching so Vial uses English input.

## Context

Vial is a real-time configurator for compatible keyboards. Homebrew currently provides it as the `vial` cask, but marks it as deprecated because it does not pass macOS Gatekeeper checks and notes that it will be disabled on 2026-09-01. The app is Intel-only on macOS and requires Rosetta 2; Rosetta is available on this machine.

## Validation

- `git diff --check`
- `chezmoi --source /Users/yixianlu/.local/share/chezmoi/.worktrees/wt-install-vial execute-template < nix-config/modules/apps.nix.tmpl | nix-instantiate --parse - >/dev/null`
- Rendered Aerospace config includes `com.vial.Vial`
- Rendered Hammerspoon IME config includes `{ "Vial", "en" }`
- `chezmoi --source /Users/yixianlu/.local/share/chezmoi/.worktrees/wt-install-vial diff "$HOME/nix-config/modules/apps.nix" "$HOME/.config/aerospace/aerospace.toml" "$HOME/.config/hammerspoon/ime.lua"`
- `brew list --cask vial` and `/Applications/Vial.app` both confirmed the local install
- pre-commit hooks from `git commit`, including YAML check, treefmt, gitleaks, typos, and template validation

## Notes

Vial is already installed locally from Homebrew as version 0.7.5. AeroSpace was reloaded after applying the generated config; Hammerspoon was not running, so the IME rule will take effect on its next launch or reload.