### PR TITLE
feat(aqua): install qmk-hid-host and run it as a launchd agent

### DIFF
--- a/.chezmoiscripts/run_onchange_after_15_load-qmk-hid-host-agent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_15_load-qmk-hid-host-agent.sh.tmpl
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# (Re)load the qmk-hid-host LaunchAgent. Re-runs whenever the plist changes.
+# plist sha256: {{ include "private_Library/LaunchAgents/com.signalridge.qmk-hid-host.plist.tmpl" | sha256sum }}
+{{ if eq .chezmoi.os "darwin" -}}
+label="com.signalridge.qmk-hid-host"
+plist="${HOME}/Library/LaunchAgents/${label}.plist"
+domain="gui/$(id -u)"
+
+echo ":: [15] (re)loading ${label} LaunchAgent"
+
+if [[ ! -f "$plist" ]]; then
+    echo "    plist not found at $plist, skipping"
+    exit 0
+fi
+
+mkdir -p "${HOME}/Library/Logs"
+
+# bootout the running instance (ignore if not loaded), then bootstrap + start
+launchctl bootout "${domain}/${label}" 2>/dev/null || true
+launchctl bootstrap "$domain" "$plist"
+launchctl enable "${domain}/${label}"
+launchctl kickstart -k "${domain}/${label}"
+echo "    loaded ${label}"
+{{ else -}}
+echo ":: [15] qmk-hid-host LaunchAgent skipped (macOS only)"
+{{ end -}}

--- a/private_Library/LaunchAgents/com.signalridge.qmk-hid-host.plist.tmpl
+++ b/private_Library/LaunchAgents/com.signalridge.qmk-hid-host.plist.tmpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.signalridge.qmk-hid-host</string>
+
+    <!-- Runs the aqua-managed binary. Launch args replace the JSON config:
+         configure your keyboard here (find product id with `qmk-hid-host -p`). -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua/bin/qmk-hid-host</string>
+        <string>--product-id</string>
+        <string>0x1988</string>
+        <string>--layout</string>
+        <string>en</string>
+    </array>
+
+    <!-- aqua bin is an aqua-proxy shim; it needs these to resolve the real
+         binary version since launchd does not source the shell profile. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{ .chezmoi.homeDir }}</string>
+        <key>PATH</key>
+        <string>{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>AQUA_GLOBAL_CONFIG</key>
+        <string>{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml</string>
+        <key>AQUA_POLICY_CONFIG</key>
+        <string>{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua-policy.yaml</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/qmk-hid-host.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/qmk-hid-host.log</string>
+</dict>
+</plist>

--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -9,6 +9,8 @@ packages:
   # ----- third-party registry (see registry.yaml) -----
   - name: signalridge/slipway@v0.21.0
     registry: third-party
+  - name: signalridge/qmk-hid-host@v2026.06.14.1
+    registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1

--- a/private_dot_config/aquaproj-aqua/registry.yaml
+++ b/private_dot_config/aquaproj-aqua/registry.yaml
@@ -20,3 +20,23 @@ packages:
       - darwin
       - linux
       - windows
+  - type: github_release
+    repo_owner: signalridge
+    repo_name: qmk-hid-host
+    description: Host component for communicating with QMK keyboards using Raw HID
+    format: raw
+    files:
+      - name: qmk-hid-host
+    # release assets are raw, per-platform binaries: qmk-hid-host-macos-arm64,
+    # qmk-hid-host-linux-x86_64, qmk-hid-host-windows.exe
+    asset: "qmk-hid-host-{{.OS}}-{{.Arch}}"
+    replacements:
+      darwin: macos
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        asset: "qmk-hid-host-windows.exe"
+    supported_envs:
+      - darwin/arm64
+      - linux/amd64
+      - windows/amd64


### PR DESCRIPTION
## What
Install `qmk-hid-host` (QMK Raw HID host for the MOTE-V3 keyboard) via aqua and run it as a persistent **launchd** agent on macOS — all managed by chezmoi.

## Changes
- `private_dot_config/aquaproj-aqua/registry.yaml` — add `signalridge/qmk-hid-host` (`github_release`, raw per-platform assets), mirroring the slipway entry
- `private_dot_config/aquaproj-aqua/aqua.yaml` — pin `signalridge/qmk-hid-host@v2026.06.14.1`
- `private_Library/LaunchAgents/com.signalridge.qmk-hid-host.plist.tmpl` — LaunchAgent: launch args `--product-id 0x1988 --layout en`, `RunAtLoad` + `KeepAlive`, aqua env so the aqua-proxy shim resolves under launchd, logs to `~/Library/Logs/qmk-hid-host.log`
- `.chezmoiscripts/run_onchange_after_15_load-qmk-hid-host-agent.sh.tmpl` — (re)load the agent on `chezmoi apply` (macOS only)

## Notes
- Linux/Windows skip the plist via the existing non-darwin `Library/` ignore in `.chezmoiignore`.
- Vial and qmk-hid-host cannot both hold the keyboard's Raw HID at once; quit Vial for the host to connect (it auto-reconnects via the KeepAlive + reconnect loop).
- Configure a different keyboard by editing the launch args in the plist template; `chezmoi apply` reloads the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)