### PR TITLE
feat(shell): autostart tmux only in real Ghostty.app

### DIFF
--- a/dot_custom/exports.sh.tmpl
+++ b/dot_custom/exports.sh.tmpl
@@ -96,9 +96,9 @@ export ZSH_TMUX_CONFIG="$HOME/.config/tmux/tmux.conf"
 # additionally pin __CFBundleIdentifier to Ghostty's bundle id. When that var is
 # unset (e.g. Linux), we fall back to TERM_PROGRAM alone. Non-TTY/nested/managed
 # environments always get a plain shell to prevent startup loops.
-if [[ "$TERM_PROGRAM" == "ghostty" ]] \
-    && [[ "${__CFBundleIdentifier:-com.mitchellh.ghostty}" == "com.mitchellh.ghostty" ]] \
-    && [[ -z "$TMUX" ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
+if [[ "$TERM_PROGRAM" == "ghostty" ]] &&
+    [[ "${__CFBundleIdentifier:-com.mitchellh.ghostty}" == "com.mitchellh.ghostty" ]] &&
+    [[ -z "$TMUX" ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
     export ZSH_TMUX_AUTOSTART=true
     export ZSH_TMUX_AUTOCONNECT=true
 else

--- a/dot_custom/exports.sh.tmpl
+++ b/dot_custom/exports.sh.tmpl
@@ -91,14 +91,19 @@ export CARAPACE_BRIDGES="${CARAPACE_BRIDGES:-zsh,fish,bash,inshellisense}"
 # Must be set before sheldon loads the plugin
 # ─────────────────────────────────────────────────────────────
 export ZSH_TMUX_CONFIG="$HOME/.config/tmux/tmux.conf"
-# Disable tmux autostart in non-TTY/nested/managed environments.
-# This prevents startup loops for tool-driven shells.
-if [[ "$TERM_PROGRAM" == "vscode" ]] || [[ -n "$TMUX" ]] || [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
-    export ZSH_TMUX_AUTOSTART=false
-    export ZSH_TMUX_AUTOCONNECT=false
-else
+# Only autostart tmux inside the real Ghostty.app. Other terminals that embed
+# the Ghostty core (e.g. muxy) also report TERM_PROGRAM=ghostty, so on macOS we
+# additionally pin __CFBundleIdentifier to Ghostty's bundle id. When that var is
+# unset (e.g. Linux), we fall back to TERM_PROGRAM alone. Non-TTY/nested/managed
+# environments always get a plain shell to prevent startup loops.
+if [[ "$TERM_PROGRAM" == "ghostty" ]] \
+    && [[ "${__CFBundleIdentifier:-com.mitchellh.ghostty}" == "com.mitchellh.ghostty" ]] \
+    && [[ -z "$TMUX" ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
     export ZSH_TMUX_AUTOSTART=true
     export ZSH_TMUX_AUTOCONNECT=true
+else
+    export ZSH_TMUX_AUTOSTART=false
+    export ZSH_TMUX_AUTOCONNECT=false
 fi
 export ZSH_TMUX_AUTOQUIT=false
 # TMux session name based on aerospace workspace


### PR DESCRIPTION
## What

Restrict tmux autostart so it only fires inside the real Ghostty.app.

## Why

The previous logic enabled `ZSH_TMUX_AUTOSTART` in every interactive TTY except VS Code and nested/non-TTY shells, so **every** terminal launched straight into tmux. Terminals that embed the Ghostty core (e.g. **muxy**) also report `TERM_PROGRAM=ghostty`, so keying on that var alone wasn't enough to exclude them.

## How

`dot_custom/exports.sh.tmpl` now autostarts tmux only when **all** hold:

- `TERM_PROGRAM == "ghostty"`
- `__CFBundleIdentifier == "com.mitchellh.ghostty"` — pins to the real Ghostty.app on macOS. muxy's bundle id is `com.muxy.app`, so it's excluded. The check falls back to `TERM_PROGRAM` alone when the var is unset (e.g. Linux).
- interactive TTY (`-t 0`, `-t 1`) and not already inside tmux (`-z "$TMUX"`)

Every other terminal (muxy, iTerm, Apple Terminal, VS Code, tool-driven/non-TTY shells) gets a plain shell.

## Verify

- Ghostty.app → enters tmux ✅
- Muxy → plain shell ✅
- Other terminals / non-TTY → plain shell ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)