### PR TITLE
chore(versions): update pinned versions (2026-06-16)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -26,7 +26,7 @@ versions:
   vercelLabsAgentBrowserRev: 2c7991c9eccca1c9db6eee1a26a713414778de5a
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: b76270a44ce60fd2f1e664d92177e88211722c45
-  microsoftSkillsRev: 6ac37ba803104a074d2bace9b105e1ec9d0706b6
+  microsoftSkillsRev: 7fbdf7950d08ffc453efb6da0798abcc669b56fb
   sickn33AntigravitySkillsRev: 39660b6b4b9eee6dc2accbc4a22b89605d995662
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.1` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.60.1` |
| nix-index-database | `2026-06-14-070944` |
| paperlib | `3.1.12` |
| openai/skills | `a8924c2a35cfa290458852c4fad17c9133054c2e` |
| huggingface/skills | `c68f1b08d9eb3af22cdc1d3fb60e9cdb78522556` |
| getsentry/skills | `b39c7c4b6056f0579b340b7c5c4e811e400368e8` |
| trailofbits/skills | `c070b9b5881183ea5f6e320ff06c46688becb13e` |
| cloudflare/skills | `8ff55f2a574f498bbf89675279d92b7a61f4d521` |
| vercel-labs/agent-skills | `f8a72b9603728bb92a217a879b7e62e43ad76c81` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `b76270a44ce60fd2f1e664d92177e88211722c45` |
| microsoft/skills | `7fbdf7950d08ffc453efb6da0798abcc669b56fb` |
| sickn33/antigravity-awesome-skills | `39660b6b4b9eee6dc2accbc4a22b89605d995662` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |