### PR TITLE
chore(aqua): update pinned packages (2026-06-18)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,14 +7,14 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.26.0
+  - name: signalridge/slipway@v0.28.0
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
-  - name: asciinema/asciinema@v3.2.0
+  - name: asciinema/asciinema@v3.2.1
   - name: atuinsh/atuin@v18.16.1
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -23,14 +23,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.178
-  - name: openai/codex@rust-v0.140.0
+  - name: anthropics/claude-code@v2.1.181
+  - name: openai/codex@rust-v0.141.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.6.10
+  - name: jdx/mise@v2026.6.11
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -42,7 +42,7 @@ packages:
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.73.1
   - name: gopasspw/gopass@v1.16.1
-  - name: cli/cli@v2.94.0
+  - name: cli/cli@v2.95.0
   - name: dlvhdr/gh-dash@v4.24.1
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
@@ -53,7 +53,7 @@ packages:
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
   - name: ast-grep/ast-grep@0.43.0
-  - name: casey/just@1.52.0
+  - name: casey/just@1.53.0
   - name: jesseduffield/lazygit@v0.62.2
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.3
@@ -81,7 +81,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.15.17
-  - name: astral-sh/ty@0.0.49
+  - name: astral-sh/ty@0.0.50
   - name: j178/prek@v0.4.5
   - name: golang.org/x/tools/gopls@v0.22.0
   - name: golangci/golangci-lint@v2.12.2
@@ -102,7 +102,7 @@ packages:
   - name: ajeetdsouza/zoxide@v0.9.9
   - name: derailed/k9s@v0.51.0
   - name: kubernetes/kubernetes/kubectl@v1.36.2
-  - name: helm/helm@v4.2.1
+  - name: helm/helm@v4.2.2
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.6.0
   - name: ahmetb/kubectx@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.