### PR TITLE
fix(ai): harden provider key management

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -27,14 +27,18 @@ claude:
         - claude-sonnet-4-6
         - claude-sonnet-4-5-20250929
         - claude-haiku-4-5-20251001
-    # DeepSeek: https://api-docs.deepseek.com/guides/anthropic_api
+    # DeepSeek Claude Code: https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code
     deepseek:
       base_url: https://api.deepseek.com/anthropic
       timeout_ms: 300000
       disable_nonessential_traffic: true
+      default_model: deepseek-v4-pro[1m]
+      # User preference: run Claude Code subagents on pro instead of the documented flash default.
+      subagent_model: deepseek-v4-pro[1m]
+      effort_level: max
       models:
-        - deepseek-chat
-        - deepseek-reasoner
+        - deepseek-v4-pro[1m]
+        - deepseek-v4-flash
     # Kimi K2 (Moonshot): https://github.com/MoonshotAI/kimi-cli/blob/main/docs/en/configuration/providers.md
     kimi:
       base_url: https://api.kimi.com/coding
@@ -91,6 +95,15 @@ claude:
       small_model: claude-haiku-4-5-20251001
     # Third-party accounts (format: provider@label)
     # Add your own: deepseek@work, kimi@personal, etc.
+    deepseek@private:
+      provider: deepseek
+      model: deepseek-v4-pro[1m]
+      small_model: deepseek-v4-flash
+      haiku_model: deepseek-v4-flash
+      sonnet_model: deepseek-v4-pro[1m]
+      opus_model: deepseek-v4-pro[1m]
+      subagent_model: deepseek-v4-pro[1m]
+      effort_level: max
     doubao@private:
       model: kimi-k2.5
       small_model: kimi-k2.5

--- a/docs/claude-provider.md
+++ b/docs/claude-provider.md
@@ -91,7 +91,10 @@ claude:
       models: [claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001]
     deepseek:
       base_url: https://api.deepseek.com/anthropic
-      models: [deepseek-chat, deepseek-reasoner]
+      models: ["deepseek-v4-pro[1m]", deepseek-v4-flash]
+      default_model: deepseek-v4-pro[1m]
+      subagent_model: deepseek-v4-pro[1m]
+      effort_level: max
     kimi:
       base_url: https://api.kimi.com/coding
       models: [kimi-k2.5, kimi-k2]
@@ -107,6 +110,15 @@ claude:
       small_model: claude-haiku-4-5-20251001
 
     # Third-party accounts (format: provider@label)
+    deepseek@private:
+      provider: deepseek
+      model: deepseek-v4-pro[1m]
+      small_model: deepseek-v4-flash
+      haiku_model: deepseek-v4-flash
+      sonnet_model: deepseek-v4-pro[1m]
+      opus_model: deepseek-v4-pro[1m]
+      subagent_model: deepseek-v4-pro[1m]
+      effort_level: max
     kimi@private:
       model: kimi-k2.5
       small_model: kimi-k2.5
@@ -118,14 +130,16 @@ claude:
 
 ## Environment Variable Mapping
 
-| Account Field  | Environment Variable             |
-| -------------- | -------------------------------- |
-| `model`        | `ANTHROPIC_MODEL`                |
-| `small_model`  | `ANTHROPIC_SMALL_FAST_MODEL`     |
-| `haiku_model`  | `ANTHROPIC_DEFAULT_HAIKU_MODEL`  |
-| `sonnet_model` | `ANTHROPIC_DEFAULT_SONNET_MODEL` |
-| `opus_model`   | `ANTHROPIC_DEFAULT_OPUS_MODEL`   |
-| `timeout_ms`   | `API_TIMEOUT_MS`                 |
+| Account Field    | Environment Variable             |
+| ---------------- | -------------------------------- |
+| `model`          | `ANTHROPIC_MODEL`                |
+| `small_model`    | `ANTHROPIC_SMALL_FAST_MODEL`     |
+| `haiku_model`    | `ANTHROPIC_DEFAULT_HAIKU_MODEL`  |
+| `sonnet_model`   | `ANTHROPIC_DEFAULT_SONNET_MODEL` |
+| `opus_model`     | `ANTHROPIC_DEFAULT_OPUS_MODEL`   |
+| `subagent_model` | `CLAUDE_CODE_SUBAGENT_MODEL`     |
+| `effort_level`   | `CLAUDE_CODE_EFFORT_LEVEL`       |
+| `timeout_ms`     | `API_TIMEOUT_MS`                 |
 
 ## Data Storage
 
@@ -188,8 +202,14 @@ claude-manage switch kimi@private
 ```yaml
 accounts:
   deepseek@work:
-    model: deepseek-reasoner
-    small_model: deepseek-chat
+    provider: deepseek
+    model: deepseek-v4-pro[1m]
+    small_model: deepseek-v4-flash
+    haiku_model: deepseek-v4-flash
+    sonnet_model: deepseek-v4-pro[1m]
+    opus_model: deepseek-v4-pro[1m]
+    subagent_model: deepseek-v4-pro[1m]
+    effort_level: max
     timeout_ms: 300000
 ```
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -39,6 +39,26 @@
 {{- if and $account (hasKey $account "opus_model") }}
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "{{ $account.opus_model }}",
 {{- end }}
+{{- /* subagent_model: account -> provider */ -}}
+{{- $subagentModel := "" -}}
+{{- if and $account (hasKey $account "subagent_model") -}}
+{{-   $subagentModel = $account.subagent_model -}}
+{{- else if and $provider (hasKey $provider "subagent_model") -}}
+{{-   $subagentModel = $provider.subagent_model -}}
+{{- end -}}
+{{- if $subagentModel }}
+    "CLAUDE_CODE_SUBAGENT_MODEL": "{{ $subagentModel }}",
+{{- end }}
+{{- /* effort_level: account -> provider */ -}}
+{{- $effortLevel := "" -}}
+{{- if and $account (hasKey $account "effort_level") -}}
+{{-   $effortLevel = $account.effort_level -}}
+{{- else if and $provider (hasKey $provider "effort_level") -}}
+{{-   $effortLevel = $provider.effort_level -}}
+{{- end -}}
+{{- if $effortLevel }}
+    "CLAUDE_CODE_EFFORT_LEVEL": "{{ $effortLevel }}",
+{{- end }}
 {{- /* disable_nonessential_traffic: account -> provider -> defaults */ -}}
 {{- $disableTraffic := false -}}
 {{- if and $account (hasKey $account "disable_nonessential_traffic") -}}

--- a/dot_local/bin/executable_claude-manage
+++ b/dot_local/bin/executable_claude-manage
@@ -61,6 +61,9 @@ switch         Change default account
 create-account Create account (and optional API key)
 update-account Update account (and optional API key)
 remove-account Remove account (and optional API key)
+add-key        Add API key for a configured account
+update-key     Rotate API key for an account
+delete-key     Delete API key for an account
 test           Test connectivity
 list           Show all accounts
 doctor         Run account diagnostics
@@ -79,6 +82,9 @@ MENU
                     create-account) echo "Create account (and optional API key)." ;;
                     update-account) echo "Update account (and optional API key)." ;;
                     remove-account) echo "Remove account (and optional API key)." ;;
+                    add-key)        echo "Add API key for a configured account." ;;
+                    update-key)     echo "Rotate API key for an account." ;;
+                    delete-key)     echo "Delete API key for an account." ;;
                     test)           echo "Test API connectivity." ;;
                     list)           echo "Show all accounts." ;;
                     doctor)         echo "Run account diagnostics." ;;
@@ -105,6 +111,9 @@ MENU
             create-account) cmd_create_account || rc=$? ;;
             update-account) cmd_update_account || rc=$? ;;
             remove-account) cmd_remove_account || rc=$? ;;
+            add-key)        cmd_add_key || rc=$? ;;
+            update-key)     cmd_update_key || rc=$? ;;
+            delete-key)     cmd_delete_key || rc=$? ;;
             test)           cmd_test || rc=$? ;;
             list)           cmd_list || rc=$? ;;
             doctor)         cmd_doctor || rc=$? ;;
@@ -128,7 +137,7 @@ MENU
 cmd_switch() {
     local input="${1:-}"
     if [[ -z "$input" ]]; then
-        if input=$(fzf_pick_account "Switch Account"); then
+        if input=$(fzf_pick_account "Switch Account" "token-known"); then
             :
         else
             local rc=$?
@@ -139,17 +148,24 @@ cmd_switch() {
         fi
     fi
 
-    if ! is_runtime_account "$input"; then
+    if ! is_known_account "$input"; then
         log_error "Unknown account '$input'"
         return 1
     fi
 
-    local provider
+    local provider parsed acct_name
     provider=$(get_provider "$input")
+    parsed=$(parse_provider_account "$input")
+    acct_name="${parsed#*|}"
 
     if is_third_party "$provider" && ! claude-token --check "$input" 2>/dev/null; then
-        log_error "No API token for $input"
-        echo "Run: claude-manage update-account $input" >&2
+        if key_exists "$provider" "$acct_name"; then
+            log_error "API token entry for $input is empty or unreadable"
+            echo "Run: claude-manage update-key $input" >&2
+        else
+            log_error "No API token for $input"
+            echo "Run: claude-manage add-key $input" >&2
+        fi
         return 1
     fi
 
@@ -307,7 +323,7 @@ cmd_create_account() {
             store_api_key "$provider" "$account_name" "$api_key"
             log_success "API key saved"
         else
-            log_info "Skipped API key (run: claude-manage update-account $full_name)"
+            log_info "Skipped API key (run: claude-manage add-key $full_name)"
         fi
     fi
 
@@ -337,7 +353,7 @@ cmd_update_account() {
         fi
     fi
 
-    is_runtime_account "$input" || { log_error "Unknown account '$input'"; return 1; }
+    is_configured_account "$input" || { log_error "Unknown configured account '$input'"; return 1; }
 
     log_info "Edit Account: $input"
     echo ""
@@ -367,6 +383,35 @@ cmd_update_account() {
     if is_third_party_account "$input"; then
         ensure_third_party_account_models "$input"
         log_info "Ensured third-party model fields (fill missing only)"
+
+        local provider parsed acct_name
+        provider=$(get_provider "$input")
+        parsed=$(parse_provider_account "$input")
+        acct_name="${parsed#*|}"
+        if ! key_exists "$provider" "$acct_name"; then
+            echo ""
+            printf "API Key (leave empty to skip): "
+            read -rs api_key
+            echo ""
+            if [[ -n "$api_key" ]]; then
+                store_api_key "$provider" "$acct_name" "$api_key"
+                log_success "API key saved"
+            else
+                log_info "Skipped API key (run: claude-manage add-key $input)"
+            fi
+        else
+            echo ""
+            printf "Rotate API key? [y/N]: "
+            read -r rotate_key
+            if [[ "$rotate_key" == "y" || "$rotate_key" == "Y" ]]; then
+                printf "New API Key: "
+                read -rs api_key
+                echo ""
+                [[ -z "$api_key" ]] && { log_error "API key required"; return 1; }
+                store_api_key "$provider" "$acct_name" "$api_key"
+                log_success "API key updated"
+            fi
+        fi
     fi
 
     echo ""
@@ -396,7 +441,7 @@ cmd_remove_account() {
         fi
     fi
 
-    is_runtime_account "$input" || { log_error "Unknown account '$input'"; return 1; }
+    is_known_account "$input" || { log_error "Unknown account '$input'"; return 1; }
 
     local has_profile=0
     if ACCOUNT_NAME="$input" yq -e '.claude.accounts[strenv(ACCOUNT_NAME)] // empty' "$CLAUDE_YAML" >/dev/null 2>&1; then
@@ -485,8 +530,16 @@ cmd_add_key() {
     parsed=$(parse_provider_account "$input")
     acct_name="${parsed#*|}"
 
+    is_known_account "$input" || { log_error "Unknown account '$input'"; return 1; }
     is_third_party "$provider" || { log_warn "Native OAuth, no key needed"; return 0; }
-    key_exists "$provider" "$acct_name" && { log_error "Key already exists. Use update-key."; return 1; }
+    if key_exists "$provider" "$acct_name"; then
+        if claude-token --check "$input" 2>/dev/null; then
+            log_error "Key already exists. Use update-key."
+        else
+            log_error "Key entry already exists but is empty or unreadable. Use update-key."
+        fi
+        return 1
+    fi
 
     log_info "Adding API key for $input"
     printf "API Key: "
@@ -528,7 +581,7 @@ cmd_update_key() {
     acct_name="${parsed#*|}"
 
     is_third_party "$provider" || { log_warn "Native OAuth, no key needed"; return 0; }
-    key_exists "$provider" "$acct_name" || { log_error "No key exists. Use update-account."; return 1; }
+    key_exists "$provider" "$acct_name" || { log_error "No key exists. Use add-key."; return 1; }
 
     log_info "Updating API key for $input"
     printf "New API Key: "
@@ -584,7 +637,7 @@ cmd_delete_key() {
 cmd_test() {
     local input="${1:-}"
     if [[ -z "$input" ]]; then
-        if input=$(fzf_pick_account "Test Connectivity"); then
+        if input=$(fzf_pick_account "Test Connectivity" "token-known"); then
             :
         else
             local rc=$?
@@ -595,7 +648,7 @@ cmd_test() {
         fi
     fi
 
-    is_runtime_account "$input" || { log_error "Unknown account '$input'"; return 1; }
+    is_known_account "$input" || { log_error "Unknown account '$input'"; return 1; }
 
     local provider config base_url
     provider=$(get_provider "$input")
@@ -617,14 +670,24 @@ cmd_test() {
     parsed=$(parse_provider_account "$input")
     acct_name="${parsed#*|}"
 
-    key_exists "$provider" "$acct_name" || {
-        log_fail "No API key"
+    if ! claude-token --check "$input" 2>/dev/null; then
+        if key_exists "$provider" "$acct_name"; then
+            log_fail "API key entry is empty or unreadable"
+            echo "  Run: claude-manage update-key $input"
+        else
+            log_fail "No API key"
+            echo "  Run: claude-manage add-key $input"
+        fi
         return 1
-    }
+    fi
     log_success "Key found"
 
     local token
-    token=$(claude-token "$input" 2>/dev/null) || { log_fail "Failed to decrypt"; return 1; }
+    token=$(claude-token "$input" 2>/dev/null) || {
+        log_fail "Failed to read API key"
+        echo "  Run: claude-manage update-key $input"
+        return 1
+    }
 
     echo "  Testing API..."
     local model response http_code
@@ -691,7 +754,7 @@ EOF
 
 # List accounts
 list_claude_accounts() {
-    list_runtime_accounts
+    list_known_accounts
 }
 
 cmd_list() {
@@ -711,8 +774,10 @@ cmd_list() {
             local parsed acct_name
             parsed=$(parse_provider_account "$account")
             acct_name="${parsed#*|}"
-            if key_exists "$provider" "$acct_name"; then
+            if claude-token --check "$account" 2>/dev/null; then
                 echo -e "  ${GREEN}${STATUS_OK}${NC} $account"
+            else
+                echo -e "  ${RED}${STATUS_ERROR}${NC} $account (no key)"
             fi
         else
             echo -e "  ${GREEN}${STATUS_NATIVE}${NC} $account (native)"

--- a/dot_local/bin/executable_claude-token
+++ b/dot_local/bin/executable_claude-token
@@ -63,14 +63,29 @@ get_account_config() {
         ($c.defaults // {}) as $defaults |
         ($c.providers[$provider] // {}) as $provider_cfg |
         ($c.accounts[$account] // {}) as $account_cfg |
+        ([
+            $account_cfg.model,
+            $account_cfg.small_model,
+            $account_cfg.haiku_model,
+            $account_cfg.sonnet_model,
+            $account_cfg.opus_model,
+            $account_cfg.subagent_model
+        ] | map(select(. != null and . != ""))) as $account_models |
         {
             base_url: $provider_cfg.base_url,
-            models: $provider_cfg.models,
+            models: (if ($account_models | length) > 0 then
+                reduce $account_models[] as $m ([]; if index($m) then . else . + [$m] end)
+            else
+                $provider_cfg.models
+            end),
+            default_model: $provider_cfg.default_model,
             model: $account_cfg.model,
             small_model: $account_cfg.small_model,
             haiku_model: $account_cfg.haiku_model,
             sonnet_model: $account_cfg.sonnet_model,
             opus_model: $account_cfg.opus_model,
+            subagent_model: ($account_cfg.subagent_model // $provider_cfg.subagent_model),
+            effort_level: ($account_cfg.effort_level // $provider_cfg.effort_level),
             timeout_ms: ($account_cfg.timeout_ms // $provider_cfg.timeout_ms // $defaults.timeout_ms),
             disable_nonessential_traffic: ($account_cfg.disable_nonessential_traffic // $provider_cfg.disable_nonessential_traffic // $defaults.disable_nonessential_traffic)
         } | with_entries(select(.value != null))
@@ -162,7 +177,7 @@ EOF
         check)
             # Silent check, exit code only
             if is_third_party "$provider"; then
-                key_exists "$provider" "$account"
+                get_api_key "$provider" "$account" >/dev/null
             else
                 # Native Anthropic providers don't need tokens
                 exit 0
@@ -188,7 +203,7 @@ EOF
                     display_name="${parsed%%|*}@$account"
                 fi
                 log_error "API token not found for '$display_name'"
-                echo "Run: claude-manage update-account $display_name" >&2
+                echo "Run: claude-manage add-key $display_name" >&2
                 exit 1
             fi
 

--- a/dot_local/bin/executable_claude-with
+++ b/dot_local/bin/executable_claude-with
@@ -81,9 +81,11 @@ launch_claude() {
     small_model=$(echo "$config" | jq -r '.small_model // empty')
 
     # Session isolation: clean up environment to prevent shell pollution
-    # Unset any existing ANTHROPIC_* variables that could interfere
+    # Unset any existing routing variables that could interfere
     unset ANTHROPIC_API_KEY
     unset ANTHROPIC_AUTH_TOKEN
+    unset CLAUDE_CODE_SUBAGENT_MODEL
+    unset CLAUDE_CODE_EFFORT_LEVEL
 
     # Always set override account to ensure claude-token uses the correct provider
     # This works for both native Anthropic (OAuth) and third-party (API key)
@@ -95,7 +97,7 @@ launch_claude() {
         # Verify token exists before launching
         if ! claude-token --check "$account" 2>/dev/null; then
             log_error "No API token for $account"
-            echo -e "Run: ${YELLOW}claude-manage update-account $account${NC}" >&2
+            echo -e "Run: ${YELLOW}claude-manage add-key $account${NC}" >&2
             return 1
         fi
         export ANTHROPIC_BASE_URL="$base_url"
@@ -109,11 +111,13 @@ launch_claude() {
     [[ -n "$small_model" ]] && export ANTHROPIC_SMALL_FAST_MODEL="$small_model"
 
     # Optional settings
-    local timeout haiku sonnet opus disable_traffic
+    local timeout haiku sonnet opus subagent effort_level disable_traffic
     timeout=$(echo "$config" | jq -r '.timeout_ms // empty')
     haiku=$(echo "$config" | jq -r '.haiku_model // empty')
     sonnet=$(echo "$config" | jq -r '.sonnet_model // empty')
     opus=$(echo "$config" | jq -r '.opus_model // empty')
+    subagent=$(echo "$config" | jq -r '.subagent_model // empty')
+    effort_level=$(echo "$config" | jq -r '.effort_level // empty')
     disable_traffic=$(echo "$config" | jq -r '.disable_nonessential_traffic // empty')
 
     [[ -n "$timeout" ]] && export API_TIMEOUT_MS="$timeout"
@@ -121,6 +125,8 @@ launch_claude() {
     [[ -n "$haiku" ]] && export ANTHROPIC_DEFAULT_HAIKU_MODEL="$haiku"
     [[ -n "$sonnet" ]] && export ANTHROPIC_DEFAULT_SONNET_MODEL="$sonnet"
     [[ -n "$opus" ]] && export ANTHROPIC_DEFAULT_OPUS_MODEL="$opus"
+    [[ -n "$subagent" ]] && export CLAUDE_CODE_SUBAGENT_MODEL="$subagent"
+    [[ -n "$effort_level" ]] && export CLAUDE_CODE_EFFORT_LEVEL="$effort_level"
 
     # Status
     echo -e "${GREEN}Launching claude with ${CYAN}$account${NC}"
@@ -155,7 +161,9 @@ launch_claude() {
             .ANTHROPIC_SMALL_FAST_MODEL,
             .ANTHROPIC_DEFAULT_HAIKU_MODEL,
             .ANTHROPIC_DEFAULT_SONNET_MODEL,
-            .ANTHROPIC_DEFAULT_OPUS_MODEL
+            .ANTHROPIC_DEFAULT_OPUS_MODEL,
+            .CLAUDE_CODE_SUBAGENT_MODEL,
+            .CLAUDE_CODE_EFFORT_LEVEL
         ))
     ' "$HOME/.claude/settings.json" 2>/dev/null || echo '{}')
 
@@ -168,6 +176,8 @@ launch_claude() {
         --arg haiku "${haiku:-}" \
         --arg sonnet "${sonnet:-}" \
         --arg opus "${opus:-}" \
+        --arg subagent "${subagent:-}" \
+        --arg effort_level "${effort_level:-}" \
         --arg disable_traffic "${disable_traffic:-}" \
         '(
             $base
@@ -182,6 +192,8 @@ launch_claude() {
                         ANTHROPIC_DEFAULT_HAIKU_MODEL: $haiku,
                         ANTHROPIC_DEFAULT_SONNET_MODEL: $sonnet,
                         ANTHROPIC_DEFAULT_OPUS_MODEL: $opus,
+                        CLAUDE_CODE_SUBAGENT_MODEL: $subagent,
+                        CLAUDE_CODE_EFFORT_LEVEL: $effort_level,
                         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: (if $disable_traffic == "true" then "1" else "" end)
                     }
                 )

--- a/dot_local/bin/executable_codex-manage
+++ b/dot_local/bin/executable_codex-manage
@@ -167,13 +167,19 @@ cmd_switch() {
         return 1
     fi
 
-    local provider
+    local provider parsed acct_name
     provider=$(get_provider "$input")
+    parsed=$(parse_provider_account "$input")
+    acct_name="${parsed#*|}"
 
     if is_third_party "$provider"; then
         if require_cmd gopass >/dev/null 2>&1; then
             if ! codex-token --check "$input" 2>/dev/null; then
-                log_warn "No API token for $input (continuing without auth update)"
+                if key_exists "$provider" "$acct_name"; then
+                    log_warn "API token entry for $input is empty or unreadable (continuing without auth update; run: codex-manage update-key $input)"
+                else
+                    log_warn "No API token for $input (continuing without auth update; run: codex-manage add-key $input)"
+                fi
             fi
         else
             log_warn "gopass not found (continuing without auth update)"
@@ -189,9 +195,6 @@ cmd_switch() {
     if is_third_party "$provider"; then
         if require_cmd gopass >/dev/null 2>&1 && codex-token --check "$input" 2>/dev/null; then
             backup_codex_auth_openai || return 1
-            local parsed acct_name
-            parsed=$(parse_provider_account "$input")
-            acct_name="${parsed#*|}"
             local api_key
             api_key=$(get_api_key "$provider" "$acct_name") || {
                 log_warn "Failed to retrieve API key (skipping auth.json update)"
@@ -399,7 +402,14 @@ cmd_add_key() {
     acct_name="${parsed#*|}"
 
     is_third_party "$provider" || { log_warn "Native provider, no key needed"; return 0; }
-    key_exists "$provider" "$acct_name" && { log_error "Key already exists. Use update-key."; return 1; }
+    if key_exists "$provider" "$acct_name"; then
+        if codex-token --check "$input" 2>/dev/null; then
+            log_error "Key already exists. Use update-key."
+        else
+            log_error "Key entry already exists but is empty or unreadable. Use update-key."
+        fi
+        return 1
+    fi
 
     log_info "Adding API key for $input"
     printf "API Key: "
@@ -532,14 +542,24 @@ cmd_test() {
     parsed=$(parse_provider_account "$input")
     acct_name="${parsed#*|}"
 
-    key_exists "$provider" "$acct_name" || {
-        log_fail "No API key"
+    if ! codex-token --check "$input" 2>/dev/null; then
+        if key_exists "$provider" "$acct_name"; then
+            log_fail "API key entry is empty or unreadable"
+            echo "  Run: codex-manage update-key $input"
+        else
+            log_fail "No API key"
+            echo "  Run: codex-manage add-key $input"
+        fi
         return 1
-    }
+    fi
     log_success "Key found"
 
     local token
-    token=$(get_api_key "$provider" "$acct_name") || { log_fail "Failed to decrypt"; return 1; }
+    token=$(get_api_key "$provider" "$acct_name") || {
+        log_fail "Failed to read API key"
+        echo "  Run: codex-manage update-key $input"
+        return 1
+    }
 
     echo "  Testing API..."
 
@@ -668,8 +688,10 @@ cmd_list() {
             local parsed acct_name
             parsed=$(parse_provider_account "$account")
             acct_name="${parsed#*|}"
-            if key_exists "$provider" "$acct_name"; then
+            if codex-token --check "$account" 2>/dev/null; then
                 echo -e "  ${GREEN}${STATUS_OK}${NC} $account"
+            else
+                echo -e "  ${RED}${STATUS_ERROR}${NC} $account (no key)"
             fi
         else
             echo -e "  ${GREEN}${STATUS_NATIVE}${NC} $account (native)"

--- a/dot_local/bin/executable_codex-token
+++ b/dot_local/bin/executable_codex-token
@@ -111,7 +111,7 @@ fi
 
 # Check mode: just verify key exists
 if $CHECK_ONLY; then
-    if key_exists "$PROVIDER" "$ACCT_NAME"; then
+    if get_api_key "$PROVIDER" "$ACCT_NAME" >/dev/null; then
         exit 0
     else
         exit 1

--- a/dot_local/bin/lib/ai/claude
+++ b/dot_local/bin/lib/ai/claude
@@ -35,6 +35,7 @@ build_account_list_with_status() {
 
 # Build account list with token status
 build_account_list_with_token() {
+    local source="${1:-runtime}"
     local account
     while IFS= read -r account; do
         [[ -z "$account" ]] && continue
@@ -49,7 +50,13 @@ build_account_list_with_token() {
         else
             echo -e "${CYAN}○${NC} $account"
         fi
-    done < <(list_runtime_accounts)
+    done < <(
+        if [[ "$source" == "known" ]]; then
+            list_known_accounts
+        else
+            list_runtime_accounts
+        fi
+    )
 }
 
 # Common preview script for account selection
@@ -65,6 +72,8 @@ ACCOUNT_PREVIEW='
     claude-token --config "$account" 2>/dev/null | jq -r "
         \"Model:     \(.model // \"default\")\",
         \"Small:     \(.small_model // \"default\")\",
+        \"Subagent:  \(.subagent_model // \"default\")\",
+        \"Effort:    \(.effort_level // \"default\")\",
         \"Base URL:  \(.base_url // \"Anthropic (native)\")\"
     " 2>/dev/null || echo "Config not available"
     echo ""
@@ -72,7 +81,7 @@ ACCOUNT_PREVIEW='
         echo -e "\033[0;32m✓ Token ready\033[0m"
     else
         if claude-token --config "$account" 2>/dev/null | jq -e ".base_url // empty" >/dev/null 2>&1; then
-            echo -e "\033[0;31m✗ No token (run: claude-manage update-account $account)\033[0m"
+            echo -e "\033[0;31m✗ No token (run: claude-manage add-key $account)\033[0m"
         else
             echo -e "\033[0;36m○ Native OAuth\033[0m"
         fi
@@ -90,6 +99,7 @@ fzf_pick_account() {
     if ! raw=$({
         case "$list_type" in
             token) build_account_list_with_token ;;
+            token-known) build_account_list_with_token known ;;
             plain) printf '%s\n' "${ACCOUNTS[@]}" ;;
             *)     build_account_list_with_status ;;
         esac

--- a/dot_local/bin/lib/ai/codex
+++ b/dot_local/bin/lib/ai/codex
@@ -45,7 +45,7 @@ build_account_list_with_token() {
             local parsed acct_name
             parsed=$(parse_provider_account "$account")
             acct_name="${parsed#*|}"
-            if key_exists "$provider" "$acct_name"; then
+            if codex-token --check "$account" 2>/dev/null; then
                 echo -e "${GREEN}✓${NC} $account"
             else
                 echo -e "${RED}✗${NC} $account"

--- a/dot_local/bin/lib/ai/core.tmpl
+++ b/dot_local/bin/lib/ai/core.tmpl
@@ -97,7 +97,7 @@ load_codex_runtime_config() {
 
     current_account="openai"
     if command -v chezmoi &>/dev/null && command -v jq &>/dev/null; then
-        current_account=$(chezmoi data --format json 2>/dev/null | jq -r '.codexProviderAccount // "openai"' 2>/dev/null)
+        current_account=$(chezmoi data --format json 2>/dev/null | jq -r '.codexProviderAccount // "openai"' 2>/dev/null || true)
         [[ -z "$current_account" || "$current_account" == "null" ]] && current_account="openai"
     fi
 
@@ -223,6 +223,31 @@ list_runtime_accounts() {
     fi
 }
 
+list_known_accounts() {
+    local -a accounts=()
+    local account
+
+    for account in "${ACCOUNTS[@]}"; do
+        [[ -n "$account" ]] && accounts+=("$account")
+    done
+
+    while IFS= read -r account; do
+        [[ -n "$account" ]] && accounts+=("$account")
+    done < <(list_gopass_third_party_accounts)
+
+    local dedup=() a
+    for a in "${accounts[@]}"; do
+        [[ -z "$a" ]] && continue
+        if [[ " ${dedup[*]-} " != *" $a "* ]]; then
+            dedup+=("$a")
+        fi
+    done
+
+    if [[ ${#dedup[@]} -gt 0 ]]; then
+        printf '%s\n' "${dedup[@]}"
+    fi
+}
+
 is_runtime_account() {
     local target="$1"
     local account
@@ -230,6 +255,25 @@ is_runtime_account() {
         [[ -z "$account" ]] && continue
         [[ "$account" == "$target" ]] && return 0
     done < <(list_runtime_accounts)
+    return 1
+}
+
+is_configured_account() {
+    local target="$1"
+    local account
+    for account in "${ACCOUNTS[@]}"; do
+        [[ "$account" == "$target" ]] && return 0
+    done
+    return 1
+}
+
+is_known_account() {
+    local target="$1"
+    local account
+    while IFS= read -r account; do
+        [[ -z "$account" ]] && continue
+        [[ "$account" == "$target" ]] && return 0
+    done < <(list_known_accounts)
     return 1
 }
 
@@ -384,7 +428,7 @@ get_provider_default_model() {
     chezmoi data --format json 2>/dev/null | jq -r \
         --arg tool "$AI_TOOL_CONTEXT" \
         --arg provider "$provider" \
-        '.[$tool].providers[$provider].models[0] // empty' 2>/dev/null
+        '.[$tool].providers[$provider].default_model // .[$tool].providers[$provider].models[0] // empty' 2>/dev/null
 }
 
 is_third_party_account() {
@@ -394,7 +438,9 @@ is_third_party_account() {
     is_third_party "$provider"
 }
 
-# Build list of accounts with existing keys
+# Build list of third-party accounts that can be selected for key rotation.
+# Includes configured accounts and entries present in gopass, even when the
+# existing entry is empty or unreadable.
 build_accounts_with_keys() {
     local acct
     while IFS= read -r acct; do
@@ -402,12 +448,10 @@ build_accounts_with_keys() {
         local prov
         prov=$(get_provider "$acct")
         if is_third_party "$prov"; then
-            local parsed acct_name
-            parsed=$(parse_provider_account "$acct")
-            acct_name="${parsed#*|}"
-            key_exists "$prov" "$acct_name" && echo "$acct"
+            echo "$acct"
         fi
-    done < <(list_runtime_accounts)
+    done < <(list_known_accounts)
+    return 0
 }
 
 # Discover third-party accounts that actually exist in gopass.
@@ -415,7 +459,7 @@ build_accounts_with_keys() {
 list_gopass_third_party_accounts() {
     require_cmd gopass >/dev/null 2>&1 || return 0
 
-    local prefix path provider label account key_value
+    local prefix path provider label account
     local -a accounts=()
 
     while IFS= read -r prefix; do
@@ -431,8 +475,7 @@ list_gopass_third_party_accounts() {
             validate_account_name "$label" || continue
             is_third_party "$provider" || continue
 
-            key_value=$(gopass_show_secret "$path" 3 2>/dev/null || true)
-            [[ -n "$key_value" ]] || continue
+            gopass_has_secret "$path" 3 || continue
 
             if [[ "$label" == "default" ]]; then
                 account="$provider"
@@ -454,29 +497,13 @@ list_gopass_third_party_accounts() {
 # ===== String Utilities =====
 
 # Split a CLI arg string into newline-delimited args.
-# Prefers python3/zsh for shell-like parsing; falls back to whitespace.
+# Prefers zsh for shell-like parsing; falls back to whitespace.
 split_cli_args() {
     local input="$1"
     [[ -z "$input" ]] && return 0
 
-    if command -v python3 &>/dev/null; then
-        python3 - "$input" <<'PY'
-import shlex
-import sys
-
-s = sys.argv[1]
-try:
-    parts = shlex.split(s)
-except ValueError:
-    parts = s.split()
-for p in parts:
-    print(p)
-PY
-        return 0
-    fi
-
     if command -v zsh &>/dev/null; then
-        zsh -c 'print -rl -- ${(z)1}' -- "$input"
+        zsh -c 'print -rl -- ${(Q)${(z)1}}' -- "$input"
         return 0
     fi
 
@@ -538,7 +565,7 @@ store_api_key() {
     local key_value="$3"
     local target
     target=$(api_key_path "$provider" "$account") || return 1
-    printf '%s' "$key_value" | gopass_exec_with_timeout 5 insert -f "$target"
+    printf '%s\n' "$key_value" | gopass_exec_with_timeout 5 insert -f -m "$target"
 }
 
 delete_api_key() {

--- a/dot_local/bin/lib/common
+++ b/dot_local/bin/lib/common
@@ -157,7 +157,35 @@ gopass_exec_with_timeout() {
 gopass_show_secret() {
     local secret_path="$1"
     local timeout_sec="${2:-3}"
-    gopass_exec_with_timeout "$timeout_sec" show -o "$secret_path"
+    local output line value
+
+    if output=$(gopass_exec_with_timeout "$timeout_sec" show -o "$secret_path" 2>/dev/null); then
+        if [[ -n "$output" ]]; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+    fi
+
+    if ! output=$(gopass_exec_with_timeout "$timeout_sec" show --unsafe --noparsing "$secret_path" 2>/dev/null); then
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        [[ -z "$line" ]] && continue
+
+        if [[ "$line" =~ ^[[:space:]]*(api[_-]?key|token|key)[[:space:]]*[:=][[:space:]]*(.+)$ ]]; then
+            value="${BASH_REMATCH[2]}"
+            [[ -n "$value" ]] || continue
+            printf '%s\n' "$value"
+            return 0
+        fi
+
+        printf '%s\n' "$line"
+        return 0
+    done <<< "$output"
+
+    return 1
 }
 
 gopass_has_secret() {
@@ -212,25 +240,30 @@ run_with_timeout() {
         return $?
     fi
 
-    if command -v python3 &>/dev/null; then
-        python3 - "$timeout_sec" "$@" <<'PY'
-import subprocess
-import sys
+    local cmd_pid rc elapsed_ticks max_ticks
 
-timeout = float(sys.argv[1])
-cmd = sys.argv[2:]
+    "$@" &
+    cmd_pid=$!
 
-try:
-    completed = subprocess.run(cmd, timeout=timeout)
-    sys.exit(completed.returncode)
-except subprocess.TimeoutExpired:
-    sys.exit(124)
-PY
-        return $?
-    fi
+    elapsed_ticks=0
+    max_ticks=$((timeout_sec * 10))
+    [[ "$max_ticks" -lt 1 ]] && max_ticks=1
 
-    # Fallback without timeout if no timeout backend is available.
-    "$@"
+    while kill -0 "$cmd_pid" 2>/dev/null; do
+        if [[ "$elapsed_ticks" -ge "$max_ticks" ]]; then
+            kill -TERM "$cmd_pid" 2>/dev/null || true
+            sleep 1
+            kill -KILL "$cmd_pid" 2>/dev/null || true
+            wait "$cmd_pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 0.1
+        elapsed_ticks=$((elapsed_ticks + 1))
+    done
+
+    wait "$cmd_pid"
+    rc=$?
+    return "$rc"
 }
 
 # ===== File Operations =====

--- a/tests/test_codex_config_rendering.sh
+++ b/tests/test_codex_config_rendering.sh
@@ -48,6 +48,7 @@ assert_file_not_contains() {
 MODIFY_SCRIPT="$TMP_ROOT/modify_config.sh"
 RENDERED="$TMP_ROOT/config.toml"
 CLAUDE_SETTINGS="$TMP_ROOT/settings.json"
+DEEPSEEK_CLAUDE_SETTINGS="$TMP_ROOT/settings-deepseek.json"
 chezmoi execute-template --source "$ROOT" <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$MODIFY_SCRIPT"
 bash "$MODIFY_SCRIPT" </dev/null >"$RENDERED"
 chezmoi execute-template --source "$ROOT" <"$ROOT/dot_claude/settings.json.tmpl" >"$CLAUDE_SETTINGS"
@@ -69,6 +70,17 @@ assert_file_contains "$CLAUDE_SETTINGS" '"SessionEnd"'
 assert_file_contains "$CLAUDE_SETTINGS" '"Stop"'
 assert_file_contains "$CLAUDE_SETTINGS" 'tmux-ai-agent-state claude idle'
 assert_file_not_contains "$CLAUDE_SETTINGS" '"SubagentStop"'
+
+chezmoi execute-template --source "$ROOT" \
+    --override-data '{"claudeProviderAccount":"deepseek@private"}' \
+    <"$ROOT/dot_claude/settings.json.tmpl" >"$DEEPSEEK_CLAUDE_SETTINGS"
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_MODEL": "deepseek-v4-pro[1m]"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-pro[1m]"'
+assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"CLAUDE_CODE_EFFORT_LEVEL": "max"'
 
 cat >"$TMP_ROOT/existing-config.toml" <<'EOF'
 model = "old-model"

--- a/tests/test_manage_list_logic.sh
+++ b/tests/test_manage_list_logic.sh
@@ -21,6 +21,8 @@ cleanup() {
 trap cleanup EXIT
 
 export HOME="$TMP_ROOT/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+unset AQUA_CONFIG AQUA_GLOBAL_CONFIG
 mkdir -p "$HOME/.config/chezmoi" "$HOME/.codex"
 cat >"$HOME/.config/chezmoi/chezmoi.toml" <<'EOF'
 [data]
@@ -99,13 +101,17 @@ case "$cmd" in
         case "$target" in
             codex)
                 echo "codex/deepseek/private/api_key"
+                echo "codex/kimi/private/api_key"
                 exit 0
                 ;;
             claude)
+                echo "claude/deepseek/private/api_key"
                 echo "claude/qwen/beta/api_key"
                 exit 0
                 ;;
             codex/deepseek/private/api_key|\
+            codex/kimi/private/api_key|\
+            claude/deepseek/private/api_key|\
             claude/qwen/beta/api_key)
                 exit 0
                 ;;
@@ -115,14 +121,33 @@ case "$cmd" in
         esac
         ;;
     show)
-        target="${1:-}"
-        if [[ "$target" == "-o" ]]; then
-            target="${2:-}"
-        fi
+        target=""
+        password_only=0
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -o|--password)
+                    password_only=1
+                    ;;
+                -u|--unsafe|-f|--force|--noparsing|-n)
+                    ;;
+                *)
+                    target="$1"
+                    ;;
+            esac
+            shift || true
+        done
         case "$target" in
             codex/deepseek/private/api_key|\
+            claude/deepseek/private/api_key|\
             claude/qwen/beta/api_key)
                 echo "test-key"
+                exit 0
+                ;;
+            claude/kimi/private/api_key)
+                if [[ "$password_only" -eq 1 ]]; then
+                    exit 11
+                fi
+                echo "api_key: body-key"
                 exit 0
                 ;;
             *)
@@ -131,11 +156,27 @@ case "$cmd" in
         esac
         ;;
     insert)
-        if [[ "${1:-}" == "-f" ]]; then
-            printf '%s\n' "${2:-}" >>"${GOPASS_INSERT_LOG:?}"
-            exit 0
-        fi
-        exit 1
+        force=0
+        multiline=0
+        target=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -f|--force)
+                    force=1
+                    ;;
+                -m|--multiline)
+                    multiline=1
+                    ;;
+                *)
+                    target="$1"
+                    ;;
+            esac
+            shift || true
+        done
+        [[ "$force" -eq 1 && "$multiline" -eq 1 && -n "$target" ]] || exit 1
+        secret="$(cat)"
+        printf '%s|%s\n' "$target" "$secret" >>"${GOPASS_INSERT_LOG:?}"
+        exit 0
         ;;
     rm)
         exit 0
@@ -150,7 +191,12 @@ cat >"$STUB/codex-token" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}" in
-    --check) exit 0 ;;
+    --check)
+        case "${2:-}" in
+            deepseek@private) exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
     --config)
         echo '{"provider":"deepseek","model":"deepseek-chat","base_url":"https://api.deepseek.com"}'
         exit 0
@@ -166,7 +212,12 @@ cat >"$STUB/claude-token" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}" in
-    --check) exit 0 ;;
+    --check)
+        case "${2:-}" in
+            deepseek@private|qwen@beta) exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
     --config)
         echo '{"provider":"qwen","model":"qwen3-coder-plus","base_url":"https://dashscope.aliyuncs.com/apps/anthropic"}'
         exit 0
@@ -275,30 +326,40 @@ assert_equals() {
 codex_list="$(PATH="$BASE_PATH" "$BIN/codex-manage" list | strip_ansi)"
 claude_list="$(PATH="$BASE_PATH" "$BIN/claude-manage" list | strip_ansi)"
 
-# codex-manage list: native + valid third-party for codex path only.
+# codex-manage list: native + codex gopass accounts; unreadable entries are
+# visible as no-key instead of being mistaken for valid keys.
 assert_contains "$codex_list" "openai (native)"
 assert_contains "$codex_list" "deepseek@private"
-assert_not_contains "$codex_list" "kimi"
+assert_contains "$codex_list" "kimi@private (no key)"
 assert_not_contains "$codex_list" "qwen@beta"
-assert_not_contains "$codex_list" "(no key)"
 
-# claude-manage list: native accounts + valid third-party for claude path only.
+# claude-manage list: native accounts + known configured accounts + valid
+# third-party keys discovered from the claude gopass prefix.
 assert_contains "$claude_list" "anthropic (native)"
 assert_contains "$claude_list" "opus (native)"
 assert_contains "$claude_list" "haiku (native)"
+assert_contains "$claude_list" "deepseek@private"
 assert_contains "$claude_list" "qwen@beta"
+assert_contains "$claude_list" "doubao@private (no key)"
+assert_contains "$claude_list" "kimi@private (no key)"
 assert_not_contains "$claude_list" "qwen@private"
-assert_not_contains "$claude_list" "kimi"
-assert_not_contains "$claude_list" "deepseek"
-assert_not_contains "$claude_list" "doubao@private"
-assert_not_contains "$claude_list" "(no key)"
 
 # list-visible runtime accounts must be operable for switch.
 PATH="$BASE_PATH" "$BIN/codex-manage" switch deepseek@private >/dev/null
+PATH="$BASE_PATH" "$BIN/claude-manage" switch deepseek@private >/dev/null
 PATH="$BASE_PATH" "$BIN/claude-manage" switch qwen@beta >/dev/null
+
+# Configured accounts without keys should be recognized, then fail with the
+# key-specific remediation instead of "Unknown account".
+claude_no_key_switch="$(PATH="$BASE_PATH" "$BIN/claude-manage" switch doubao@private 2>&1 || true)"
+assert_contains "$claude_no_key_switch" "No API token for doubao@private"
 
 # list-visible runtime accounts must be operable for test.
 PATH="$BASE_PATH" "$BIN/codex-manage" test deepseek@private >/dev/null
+codex_no_key_test="$(PATH="$BASE_PATH" "$BIN/codex-manage" test kimi@private 2>&1 || true)"
+assert_contains "$codex_no_key_test" "API key entry is empty or unreadable"
+assert_contains "$codex_no_key_test" "codex-manage update-key kimi@private"
+PATH="$BASE_PATH" "$BIN/claude-manage" test deepseek@private >/dev/null
 PATH="$BASE_PATH" "$BIN/claude-manage" test qwen@beta >/dev/null
 
 # claude-manage test should report network error gracefully when curl fails.
@@ -307,6 +368,7 @@ assert_contains "$claude_fail_output" "Network error"
 
 # list-visible runtime accounts must be operable for launcher entrypoints.
 PATH="$BASE_PATH" "$BIN/codex-with" deepseek@private --version >/dev/null
+PATH="$BASE_PATH" "$BIN/claude-with" deepseek@private --version >/dev/null
 PATH="$BASE_PATH" "$BIN/claude-with" qwen@beta --version >/dev/null
 
 # doctor: parity diagnostics should be available in both tools.
@@ -353,8 +415,18 @@ claude_candidates="$(
 assert_equals "$codex_candidates" $'codex/kimi/private/api_key'
 assert_equals "$claude_candidates" $'claude/kimi/private/api_key'
 
+# gopass body-only entries are accepted as API keys when the password field is empty.
+claude_body_key="$(
+    PATH="$BASE_PATH" bash -c "source '$BIN/lib/ai/claude'; get_api_key kimi private"
+)"
+assert_equals "$claude_body_key" "body-key"
+
 # Store operations always write to tool-specific canonical path.
 PATH="$BASE_PATH" bash -c "source '$BIN/lib/ai/codex'; store_api_key deepseek alpha sk-test"
-assert_equals "$(tail -n1 "$INSERT_LOG")" "codex/deepseek/alpha/api_key"
+assert_equals "$(tail -n1 "$INSERT_LOG")" "codex/deepseek/alpha/api_key|sk-test"
+
+# Configured Claude accounts without keys are still manageable by explicit add-key.
+printf 'sk-doubao\n' | PATH="$BASE_PATH" "$BIN/claude-manage" add-key doubao@private >/dev/null
+assert_equals "$(tail -n1 "$INSERT_LOG")" "claude/doubao/private/api_key|sk-doubao"
 
 echo "test_manage_list_logic: OK"


### PR DESCRIPTION
## Summary

- Configure DeepSeek Claude Code for the current DeepSeek Anthropic endpoint/model set, including `deepseek-v4-pro[1m]` for main and subagent usage.
- Harden Claude and Codex provider key handling so account discovery no longer treats a gopass path alone as a usable key.
- Fix API key writes through gopass, remove the Python timeout/splitting fallback, preserve stdin through timeout wrappers, and surface clear `update-key` remediation when an entry is empty or unreadable.
- Make Codex `list`, `test`, and token status paths use the same readable-key checks as Claude.

## Root Cause

The previous flow mixed two meanings of key existence: “a gopass entry path exists” and “a non-empty readable API key exists.” That let `list`, `test`, and account selection show third-party providers as configured even when the stored entry was empty or unreadable. On systems without `timeout`/`gtimeout`, the shell timeout fallback also consumed stdin before `gopass insert -m`, which could create empty key entries.

## Validation

- `bash tests/test_manage_list_logic.sh`
- `bash tests/test_codex_config_rendering.sh`
- `bash -n dot_local/bin/executable_codex-manage dot_local/bin/executable_claude-manage dot_local/bin/executable_codex-token dot_local/bin/executable_claude-token dot_local/bin/lib/common`
- `git diff --check`
- Commit hooks: treefmt, shellcheck, typo check, gitleaks, template validation
- Installed-script smoke checks for readable-key behavior, no Python fallback references, stdin-preserving timeout behavior, and Claude/Codex account listing