### PR TITLE
chore(versions): update pinned versions (2026-06-19)

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -17,7 +17,7 @@ versions:
   uiUxProMaxSkillRev: b7e3af80f6e331f6fb456667b82b12cade7c9d35
   uiUxProMaxSkillSha256: 7c51fb0ab28651f620e873632d0109f364942c54c9e77a8819a1e2cedec424ea
   openaiSkillsRev: 972cb867affac58fda9afa76bb1a19b399a278cf
-  huggingfaceSkillsRev: c68f1b08d9eb3af22cdc1d3fb60e9cdb78522556
+  huggingfaceSkillsRev: ce5f615271cade006271fa7822c8ce2d984c4eda
   getsentrySkillsRev: b39c7c4b6056f0579b340b7c5c4e811e400368e8
   trailofbitsSkillsRev: c070b9b5881183ea5f6e320ff06c46688becb13e
   cloudflareSkillsRev: ffcc622bf112eccc49c4b433faa5dd28e9ede2ea
@@ -25,9 +25,9 @@ versions:
   vercelLabsNextSkillsRev: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
   vercelLabsAgentBrowserRev: 6323df571ffd17d14e60ec19fcb56cc1caf498ab
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
-  expoSkillsRev: b76270a44ce60fd2f1e664d92177e88211722c45
-  microsoftSkillsRev: 69e4442a24174cf097ea310332ef549f78cfeef0
-  sickn33AntigravitySkillsRev: 6042393e48713b48952566cf2d4e3e28d4e50159
+  expoSkillsRev: b553ae4e1755bec11eac21517fe63040c7e07f2c
+  microsoftSkillsRev: 12184914d53b81e8d7fe3780d52b58d910b549ec
+  sickn33AntigravitySkillsRev: 943cecf333abf8c89684f1247f9aa87a5c0783c3
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: ca7af700a3d8888e63bb819f6f118e2aec42c2db
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d


### PR DESCRIPTION
Automated version update for pinned dependencies.

| Package | Version |
|---------|---------|
| nix-installer | `v3.21.1` |
| nix | `v2.34.7` |
| aqua-installer | `v4.0.4` |
| aqua-installer sha256 | `acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28` |
| aqua | `v2.60.1` |
| nix-index-database | `2026-06-14-070944` |
| paperlib | `3.1.12` |
| openai/skills | `972cb867affac58fda9afa76bb1a19b399a278cf` |
| huggingface/skills | `ce5f615271cade006271fa7822c8ce2d984c4eda` |
| getsentry/skills | `b39c7c4b6056f0579b340b7c5c4e811e400368e8` |
| trailofbits/skills | `c070b9b5881183ea5f6e320ff06c46688becb13e` |
| cloudflare/skills | `ffcc622bf112eccc49c4b433faa5dd28e9ede2ea` |
| vercel-labs/agent-skills | `f8a72b9603728bb92a217a879b7e62e43ad76c81` |
| vercel-labs/next-skills | `dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9` |
| supabase/agent-skills | `1356046015476711a769601079262b5635929427` |
| expo/skills | `b553ae4e1755bec11eac21517fe63040c7e07f2c` |
| microsoft/skills | `12184914d53b81e8d7fe3780d52b58d910b549ec` |
| sickn33/antigravity-awesome-skills | `943cecf333abf8c89684f1247f9aa87a5c0783c3` |
| signalridge/zig-development-playbook-skill | `72cab69050cc84793603ea7a9d82de367cdd104c` |
| signalridge/rust-development-playbook-skill | `eea186a4c35edecd47058c62b44cf8643fc7cc07` |
| humanizer-en | `9600f2b7241cb4eed6ad803abee5ea01d67fe8e4` |
| humanizer-zh | `91f3d394db8419c20d67ebe22a96cf8fee0a404b` |
| humanizer-ja | `1b850cfe8529f7836025b2edd15b3d64447f8fb6` |