### PR TITLE
feat(ai): add krill provider; align ccm menu with cxm

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -78,6 +78,20 @@ claude:
       disable_nonessential_traffic: true
       models:
         - ark-code-latest
+    # Krill (gpt-5.5 served on an Anthropic-compatible endpoint): https://api.krill-ai.com
+    krill:
+      base_url: https://api.krill-ai.com/codex
+      timeout_ms: 300000
+      disable_nonessential_traffic: true
+      # Drop the attribution header and experimental betas the proxy rejects,
+      # and advertise gpt-5.5's reasoning/effort capabilities to Claude Code.
+      attribution_header: "0"
+      disable_experimental_betas: true
+      supported_capabilities: thinking,adaptive_thinking,temperature,effort,max_effort
+      subagent_model: gpt-5.5
+      effort_level: max
+      models:
+        - gpt-5.5
   # ===== Account Configurations =====
   # Format: provider or provider@account
   # Fields: model, small_model, haiku_model, sonnet_model, opus_model, timeout_ms
@@ -116,6 +130,16 @@ claude:
       haiku_model: kimi-k2.5
       sonnet_model: kimi-k2.5
       opus_model: kimi-k2.5
+    # gpt-5.5 via krill; attribution/betas/capabilities inherit from the provider.
+    krill@private:
+      provider: krill
+      model: gpt-5.5
+      small_model: gpt-5.5
+      haiku_model: gpt-5.5
+      sonnet_model: gpt-5.5
+      opus_model: gpt-5.5
+      subagent_model: gpt-5.5
+      effort_level: max
   # ==========================================================================
   # Claude Code Plugins (downloaded via .chezmoiexternal.toml.tmpl)
   # All skills are hardcoded in .chezmoiexternal.toml.tmpl

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -59,6 +59,38 @@
 {{- if $effortLevel }}
     "CLAUDE_CODE_EFFORT_LEVEL": "{{ $effortLevel }}",
 {{- end }}
+{{- /* attribution_header: account -> provider (proxies that reject the header set "0") */ -}}
+{{- $attributionHeader := "" -}}
+{{- if and $account (hasKey $account "attribution_header") -}}
+{{-   $attributionHeader = $account.attribution_header -}}
+{{- else if and $provider (hasKey $provider "attribution_header") -}}
+{{-   $attributionHeader = $provider.attribution_header -}}
+{{- end -}}
+{{- if ne (toString $attributionHeader) "" }}
+    "CLAUDE_CODE_ATTRIBUTION_HEADER": "{{ $attributionHeader }}",
+{{- end }}
+{{- /* disable_experimental_betas: account -> provider */ -}}
+{{- $disableBetas := false -}}
+{{- if and $account (hasKey $account "disable_experimental_betas") -}}
+{{-   $disableBetas = $account.disable_experimental_betas -}}
+{{- else if and $provider (hasKey $provider "disable_experimental_betas") -}}
+{{-   $disableBetas = $provider.disable_experimental_betas -}}
+{{- end -}}
+{{- if $disableBetas }}
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+{{- end }}
+{{- /* supported_capabilities: account -> provider; applied to opus/sonnet/haiku default models */ -}}
+{{- $supportedCaps := "" -}}
+{{- if and $account (hasKey $account "supported_capabilities") -}}
+{{-   $supportedCaps = $account.supported_capabilities -}}
+{{- else if and $provider (hasKey $provider "supported_capabilities") -}}
+{{-   $supportedCaps = $provider.supported_capabilities -}}
+{{- end -}}
+{{- if $supportedCaps }}
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES": "{{ $supportedCaps }}",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES": "{{ $supportedCaps }}",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES": "{{ $supportedCaps }}",
+{{- end }}
 {{- /* disable_nonessential_traffic: account -> provider -> defaults */ -}}
 {{- $disableTraffic := false -}}
 {{- if and $account (hasKey $account "disable_nonessential_traffic") -}}

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -149,6 +149,12 @@ base_url = "https://open.bigmodel.cn/api/paas/v4"
 name = "Kimi"
 base_url = "https://api.moonshot.ai/v1"
 
+[model_providers.krill]
+name = "krill"
+base_url = "https://api.krill-ai.com/codex/v1"
+requires_openai_auth = true
+wire_api = "responses"
+
 [model_providers.minimax]
 name = "Minimax"
 base_url = "https://api.minimax.io/v1"

--- a/dot_local/bin/executable_claude-manage
+++ b/dot_local/bin/executable_claude-manage
@@ -61,9 +61,6 @@ switch         Change default account
 create-account Create account (and optional API key)
 update-account Update account (and optional API key)
 remove-account Remove account (and optional API key)
-add-key        Add API key for a configured account
-update-key     Rotate API key for an account
-delete-key     Delete API key for an account
 test           Test connectivity
 list           Show all accounts
 doctor         Run account diagnostics
@@ -82,9 +79,6 @@ MENU
                     create-account) echo "Create account (and optional API key)." ;;
                     update-account) echo "Update account (and optional API key)." ;;
                     remove-account) echo "Remove account (and optional API key)." ;;
-                    add-key)        echo "Add API key for a configured account." ;;
-                    update-key)     echo "Rotate API key for an account." ;;
-                    delete-key)     echo "Delete API key for an account." ;;
                     test)           echo "Test API connectivity." ;;
                     list)           echo "Show all accounts." ;;
                     doctor)         echo "Run account diagnostics." ;;
@@ -111,9 +105,6 @@ MENU
             create-account) cmd_create_account || rc=$? ;;
             update-account) cmd_update_account || rc=$? ;;
             remove-account) cmd_remove_account || rc=$? ;;
-            add-key)        cmd_add_key || rc=$? ;;
-            update-key)     cmd_update_key || rc=$? ;;
-            delete-key)     cmd_delete_key || rc=$? ;;
             test)           cmd_test || rc=$? ;;
             list)           cmd_list || rc=$? ;;
             doctor)         cmd_doctor || rc=$? ;;

--- a/dot_local/bin/executable_claude-token
+++ b/dot_local/bin/executable_claude-token
@@ -86,6 +86,9 @@ get_account_config() {
             opus_model: $account_cfg.opus_model,
             subagent_model: ($account_cfg.subagent_model // $provider_cfg.subagent_model),
             effort_level: ($account_cfg.effort_level // $provider_cfg.effort_level),
+            attribution_header: ($account_cfg.attribution_header // $provider_cfg.attribution_header),
+            disable_experimental_betas: ($account_cfg.disable_experimental_betas // $provider_cfg.disable_experimental_betas),
+            supported_capabilities: ($account_cfg.supported_capabilities // $provider_cfg.supported_capabilities),
             timeout_ms: ($account_cfg.timeout_ms // $provider_cfg.timeout_ms // $defaults.timeout_ms),
             disable_nonessential_traffic: ($account_cfg.disable_nonessential_traffic // $provider_cfg.disable_nonessential_traffic // $defaults.disable_nonessential_traffic)
         } | with_entries(select(.value != null))

--- a/dot_local/bin/executable_claude-with
+++ b/dot_local/bin/executable_claude-with
@@ -86,6 +86,11 @@ launch_claude() {
     unset ANTHROPIC_AUTH_TOKEN
     unset CLAUDE_CODE_SUBAGENT_MODEL
     unset CLAUDE_CODE_EFFORT_LEVEL
+    unset CLAUDE_CODE_ATTRIBUTION_HEADER
+    unset CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS
+    unset ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES
+    unset ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES
+    unset ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES
 
     # Always set override account to ensure claude-token uses the correct provider
     # This works for both native Anthropic (OAuth) and third-party (API key)
@@ -112,6 +117,7 @@ launch_claude() {
 
     # Optional settings
     local timeout haiku sonnet opus subagent effort_level disable_traffic
+    local attribution disable_betas supported_caps
     timeout=$(echo "$config" | jq -r '.timeout_ms // empty')
     haiku=$(echo "$config" | jq -r '.haiku_model // empty')
     sonnet=$(echo "$config" | jq -r '.sonnet_model // empty')
@@ -119,6 +125,9 @@ launch_claude() {
     subagent=$(echo "$config" | jq -r '.subagent_model // empty')
     effort_level=$(echo "$config" | jq -r '.effort_level // empty')
     disable_traffic=$(echo "$config" | jq -r '.disable_nonessential_traffic // empty')
+    attribution=$(echo "$config" | jq -r '.attribution_header // empty')
+    disable_betas=$(echo "$config" | jq -r '.disable_experimental_betas // empty')
+    supported_caps=$(echo "$config" | jq -r '.supported_capabilities // empty')
 
     [[ -n "$timeout" ]] && export API_TIMEOUT_MS="$timeout"
     [[ "$disable_traffic" == "true" ]] && export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
@@ -127,6 +136,13 @@ launch_claude() {
     [[ -n "$opus" ]] && export ANTHROPIC_DEFAULT_OPUS_MODEL="$opus"
     [[ -n "$subagent" ]] && export CLAUDE_CODE_SUBAGENT_MODEL="$subagent"
     [[ -n "$effort_level" ]] && export CLAUDE_CODE_EFFORT_LEVEL="$effort_level"
+    [[ -n "$attribution" ]] && export CLAUDE_CODE_ATTRIBUTION_HEADER="$attribution"
+    [[ "$disable_betas" == "true" ]] && export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS="1"
+    if [[ -n "$supported_caps" ]]; then
+        export ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES="$supported_caps"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES="$supported_caps"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES="$supported_caps"
+    fi
 
     # Status
     echo -e "${GREEN}Launching claude with ${CYAN}$account${NC}"
@@ -163,7 +179,12 @@ launch_claude() {
             .ANTHROPIC_DEFAULT_SONNET_MODEL,
             .ANTHROPIC_DEFAULT_OPUS_MODEL,
             .CLAUDE_CODE_SUBAGENT_MODEL,
-            .CLAUDE_CODE_EFFORT_LEVEL
+            .CLAUDE_CODE_EFFORT_LEVEL,
+            .CLAUDE_CODE_ATTRIBUTION_HEADER,
+            .CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS,
+            .ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES,
+            .ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES,
+            .ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES
         ))
     ' "$HOME/.claude/settings.json" 2>/dev/null || echo '{}')
 
@@ -179,6 +200,9 @@ launch_claude() {
         --arg subagent "${subagent:-}" \
         --arg effort_level "${effort_level:-}" \
         --arg disable_traffic "${disable_traffic:-}" \
+        --arg attribution "${attribution:-}" \
+        --arg disable_betas "${disable_betas:-}" \
+        --arg supported_caps "${supported_caps:-}" \
         '(
             $base
             * {
@@ -194,7 +218,12 @@ launch_claude() {
                         ANTHROPIC_DEFAULT_OPUS_MODEL: $opus,
                         CLAUDE_CODE_SUBAGENT_MODEL: $subagent,
                         CLAUDE_CODE_EFFORT_LEVEL: $effort_level,
-                        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: (if $disable_traffic == "true" then "1" else "" end)
+                        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: (if $disable_traffic == "true" then "1" else "" end),
+                        CLAUDE_CODE_ATTRIBUTION_HEADER: $attribution,
+                        CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: (if $disable_betas == "true" then "1" else "" end),
+                        ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES: $supported_caps,
+                        ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES: $supported_caps,
+                        ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES: $supported_caps
                     }
                 )
             }

--- a/tests/test_codex_config_rendering.sh
+++ b/tests/test_codex_config_rendering.sh
@@ -64,6 +64,11 @@ assert_file_contains "$RENDERED" 'tmux-ai-agent-state codex idle'
 assert_file_not_contains "$RENDERED" '[[hooks.SubagentStop]]'
 assert_file_not_contains "$RENDERED" 'async = true'
 
+assert_file_contains "$RENDERED" '[model_providers.krill]'
+assert_file_contains "$RENDERED" 'base_url = "https://api.krill-ai.com/codex/v1"'
+assert_file_contains "$RENDERED" 'requires_openai_auth = true'
+assert_file_contains "$RENDERED" 'wire_api = "responses"'
+
 assert_file_contains "$CLAUDE_SETTINGS" '"UserPromptSubmit"'
 assert_file_contains "$CLAUDE_SETTINGS" 'tmux-ai-agent-state claude busy'
 assert_file_contains "$CLAUDE_SETTINGS" '"SessionEnd"'
@@ -81,6 +86,24 @@ assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_SONNET_MODE
 assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash"'
 assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-pro[1m]"'
 assert_file_contains "$DEEPSEEK_CLAUDE_SETTINGS" '"CLAUDE_CODE_EFFORT_LEVEL": "max"'
+
+KRILL_CLAUDE_SETTINGS="$TMP_ROOT/settings-krill.json"
+chezmoi execute-template --source "$ROOT" \
+    --override-data '{"claudeProviderAccount":"krill@private"}' \
+    <"$ROOT/dot_claude/settings.json.tmpl" >"$KRILL_CLAUDE_SETTINGS"
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"ANTHROPIC_BASE_URL": "https://api.krill-ai.com/codex"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"ANTHROPIC_MODEL": "gpt-5.5"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES": "thinking,adaptive_thinking,temperature,effort,max_effort"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES": "thinking,adaptive_thinking,temperature,effort,max_effort"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES": "thinking,adaptive_thinking,temperature,effort,max_effort"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"CLAUDE_CODE_SUBAGENT_MODEL": "gpt-5.5"'
+assert_file_contains "$KRILL_CLAUDE_SETTINGS" '"CLAUDE_CODE_EFFORT_LEVEL": "max"'
+
+# Native Anthropic default must not leak krill-only env keys.
+assert_file_not_contains "$CLAUDE_SETTINGS" 'CLAUDE_CODE_ATTRIBUTION_HEADER'
+assert_file_not_contains "$CLAUDE_SETTINGS" 'SUPPORTED_CAPABILITIES'
 
 cat >"$TMP_ROOT/existing-config.toml" <<'EOF'
 model = "old-model"


### PR DESCRIPTION
## Summary
- Add the **krill** provider (gpt-5.5 served on an Anthropic-compatible endpoint) as a **switchable option** for both Codex and Claude. Defaults stay `anthropic`/`openai`.
- Align `claude-manage` (ccm)'s interactive menu with `codex-manage` (cxm).

## Provider wiring
- **Codex** — `dot_codex/modify_config.toml.tmpl`: `[model_providers.krill]` (responses wire API).
- **Claude** — `krill` provider + `krill@private` account in `.chezmoidata/claude.yaml`; new generic `attribution_header` / `disable_experimental_betas` / `supported_capabilities` fields wired through `settings.json.tmpl` and the `claude-with` / `claude-token` launchers, with strip-on-switch so the keys don't leak when switching back to Anthropic.

## ccm/cxm menu
- Removed the standalone `add-key` / `update-key` / `delete-key` items from ccm's fzf menu (redundant with `update-account`), matching cxm. Still available as CLI subcommands.

## Usage
```bash
chezmoi apply
claude-manage add-key krill@private   # store key in gopass
claude-with krill@private             # Claude on gpt-5.5 via krill
codex-with krill@private              # Codex via krill
```

## Notes
- The Codex block uses `requires_openai_auth = true` as in krill's docs; this routes auth through `~/.codex/auth.json` rather than the gopass key. A follow-up could switch to `env_key = "KRILL_API_KEY"` for deterministic, gopass-based auth that keeps the ChatGPT login intact for the real `openai` provider.

## Test plan
- `tests/test_codex_config_rendering.sh` extended with krill render + leak-check assertions — passing.
- pre-commit (shellcheck, treefmt, gitleaks, template render+check) — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)