### PR TITLE
feat(supacode): add supacode cask

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -22,6 +22,7 @@ homebrew:
   casks:
     shared:
       - codex-app # OpenAI Codex desktop app for managing coding agents
+      - supacode # native macOS coding-agents command center (git worktrees + Ghostty + gh CLI); requires macOS >= 26
       - displaylink # USB dock/adapter multi-monitor driver; needs reboot + manual Screen Recording grant
       - dockdoor
       - visual-studio-code


### PR DESCRIPTION
Adds **supacode** ([supabitapp/supacode](https://github.com/supabitapp/supacode)) — a native macOS "coding-agents command center" for running terminal agents across multiple git worktrees (Ghostty-backed terminal, `gh` CLI integration, per-repo automation).

- Channel: **Homebrew cask** (GUI app `supacode.app`) — added to `homebrew.casks.shared` next to `codex-app`/`muxy`, installed declaratively via the nix-darwin homebrew module.
- Requires **macOS ≥ 26** (Tahoe). Current machine is 26.5.1 ✓.
- `auto_updates` cask (the app self-updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)