### PR TITLE
revert(supacode): remove supacode cask

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -22,7 +22,6 @@ homebrew:
   casks:
     shared:
       - codex-app # OpenAI Codex desktop app for managing coding agents
-      - supacode # native macOS coding-agents command center (git worktrees + Ghostty + gh CLI); requires macOS >= 26
       - displaylink # USB dock/adapter multi-monitor driver; needs reboot + manual Screen Recording grant
       - dockdoor
       - visual-studio-code


### PR DESCRIPTION
Reverts #691 — supacode is not needed.

- App already uninstalled locally (`brew uninstall --cask supacode`).
- Removes `supacode` from `homebrew.casks.shared` so nix-darwin (`cleanup="zap"`) does not reinstall it on the next `darwin-rebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)