### PR TITLE
chore(aqua): update pinned packages (2026-06-24)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.32.1
+  - name: signalridge/slipway@v0.33.0
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
@@ -25,14 +25,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.186
+  - name: anthropics/claude-code@v2.1.187
   - name: openai/codex@rust-v0.142.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.6.12
+  - name: jdx/mise@v2026.6.13
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -96,7 +96,7 @@ packages:
   - name: ClementTsang/bottom@0.14.1
   - name: dalance/procs@v0.14.11
   - name: sharkdp/hexyl@v0.17.0
-  - name: mr-karan/doggo@v1.1.7
+  - name: mr-karan/doggo@v1.2.0
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0
   - name: sxyazi/yazi@v26.5.6


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.