### PR TITLE
fix(claude): repair block-main-edits PreToolUse ask schema

### DIFF
--- a/dot_claude/hooks/executable_block-main-edits.sh
+++ b/dot_claude/hooks/executable_block-main-edits.sh
@@ -60,5 +60,11 @@ done
 msg="ASK MAIN-EDIT: Editing '${file_path}' on protected branch '${branch}'.
 Next: git checkout -b fix/<topic> (or set CLAUDE_ALLOW_PROTECTED_BRANCH_EDITS=1)."
 
-jq -n --arg reason "$msg" '{decision:"ask", reason:$reason}'
+jq -n --arg reason "$msg" '{
+    hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: $reason
+    }
+}'
 exit 0


### PR DESCRIPTION
## Problem

The global PreToolUse hook `~/.claude/hooks/block-main-edits.sh` (source: `dot_claude/hooks/executable_block-main-edits.sh`) emitted:

```sh
jq -n --arg reason "$msg" '{decision:"ask", reason:$reason}'
```

`"ask"` is **not** a valid value for the PreToolUse top-level `decision` field (legacy enum is only `approve`/`block`). Claude Code rejects the output with `(root): Invalid input`. Because that validation failure is **non-blocking**, CC prints the error and falls through to the normal permission flow — so the intended *"confirm before editing on a protected branch"* gate **never actually fired**. It degraded into pure noise (observed 3× when writing 3 memory files while on `main`).

## Fix

Emit the modern hook schema, which is where the `ask` semantic now lives:

```sh
jq -n --arg reason "$msg" '{
    hookSpecificOutput: {
        hookEventName: "PreToolUse",
        permissionDecision: "ask",
        permissionDecisionReason: $reason
    }
}'
```

Verified against the official hooks docs (`permissionDecision` ∈ `allow`/`deny`/`ask`).

## Verification

- `bash -n` syntax check passes; pre-commit Shellcheck passes.
- Running the hook with CWD on `main` + a non-allowlisted file path now emits well-formed JSON matching `hookSpecificOutput.permissionDecision == "ask"`.
- Allowlisted paths (`README.md`, `CHANGELOG.md`, `.claude/*`, `docs/*`) still exit silently with code 0.

After merge: `chezmoi apply` propagates to `~/.claude/hooks/block-main-edits.sh`, and protected-branch edits will genuinely prompt for confirmation instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)