### PR TITLE
fix(aqua): repair doggo registry metadata

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -97,6 +97,7 @@ packages:
   - name: dalance/procs@v0.14.11
   - name: sharkdp/hexyl@v0.17.0
   - name: mr-karan/doggo@v1.2.0
+    registry: third-party
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0
   - name: sxyazi/yazi@v26.5.6

--- a/private_dot_config/aquaproj-aqua/registry.yaml
+++ b/private_dot_config/aquaproj-aqua/registry.yaml
@@ -57,3 +57,26 @@ packages:
     supported_envs:
       - darwin
       - linux
+  - type: github_release
+    repo_owner: mr-karan
+    repo_name: doggo
+    description: ":dog: Command-line DNS Client for Humans. Written in Golang"
+    asset: "doggo-{{.OS}}-{{.Arch}}.{{.Format}}"
+    format: tar.gz
+    files:
+      - name: doggo
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    checksum:
+      type: github_release
+      asset: "doggo_{{trimV .Version}}_checksums.txt"
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip
+        replacements: {}
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64


### PR DESCRIPTION
## Summary

- route `mr-karan/doggo@v1.2.0` through the local aqua registry
- add doggo metadata for the new upstream asset naming scheme (`doggo-darwin-aarch64.tar.gz`)

## Type of Change

- [x] `fix` - Bug fix
- [ ] `feat` - New feature or functionality
- [ ] `refactor` - Code refactoring (no functional change)
- [ ] `docs` - Documentation only
- [ ] `chore` - Maintenance, dependencies, CI/CD
- [ ] `perf` - Performance improvement

## Changes

- Keeps the doggo version pin unchanged at `v1.2.0`.
- Uses the existing `third-party` aqua registry policy path instead of waiting for the standard registry metadata to catch up.
- Maps aqua arm64 to upstream aarch64 asset names.

## Testing

- [ ] `chezmoi apply --dry-run` passes
- [x] Pre-commit hooks pass locally
- [x] Tested on: macOS

Commands run:

- `bash tests/test_toolchain_bootstrap.sh`
- `AQUA_CONFIG=private_dot_config/aquaproj-aqua/aqua.yaml AQUA_GLOBAL_CONFIG=private_dot_config/aquaproj-aqua/aqua.yaml AQUA_POLICY_CONFIG=private_dot_config/aquaproj-aqua/aqua-policy.yaml aqua exec -- doggo --version`
- `AQUA_CONFIG=private_dot_config/aquaproj-aqua/aqua.yaml AQUA_GLOBAL_CONFIG=private_dot_config/aquaproj-aqua/aqua.yaml AQUA_POLICY_CONFIG=private_dot_config/aquaproj-aqua/aqua-policy.yaml aqua install`

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or sensitive data included
- [x] Templates render correctly (check CI Lint job)
- [ ] Nix flake checks pass (if nix-config changes)