### PR TITLE
fix(claude): judge block-main-edits by edited file, not CWD

### DIFF
--- a/dot_claude/hooks/executable_block-main-edits.sh
+++ b/dot_claude/hooks/executable_block-main-edits.sh
@@ -25,14 +25,30 @@ if [[ "$tool" != "Write" && "$tool" != "Edit" && "$tool" != "MultiEdit" ]]; then
     exit 0
 fi
 
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""' 2>/dev/null || echo "")
+
+# Judge the branch by where the *edited file* lives, not the hook's CWD.
+# CC always runs from the primary checkout (usually main), so a CWD-based
+# check flags every edit as "main" even when the file is in a feature
+# worktree under .worktrees/<branch>. Resolve the file's own directory and
+# ask git there: a linked worktree reports its own branch, not main.
+if [[ -n "$file_path" ]]; then
+    target_dir=$(dirname -- "$file_path")
+else
+    target_dir="."
+fi
+# New-file writes target a path that doesn't exist yet; walk up to the
+# nearest existing ancestor so git can resolve the containing worktree.
+while [[ "$target_dir" != "/" && "$target_dir" != "." && ! -d "$target_dir" ]]; do
+    target_dir=$(dirname -- "$target_dir")
+done
+
+if ! git -C "$target_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     exit 0
 fi
 
-branch=$(git branch --show-current 2>/dev/null || echo "")
+branch=$(git -C "$target_dir" branch --show-current 2>/dev/null || echo "")
 [[ -n "$branch" ]] || exit 0
-
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""' 2>/dev/null || echo "")
 
 protected=false
 case "$branch" in


### PR DESCRIPTION
## Problem

`block-main-edits.sh` decided the branch with `git branch --show-current` run in the **hook's process CWD**. Claude Code always runs from the primary checkout (usually `main`), so *every* `Write`/`Edit`/`MultiEdit` was flagged as a protected-branch edit — even when:

- the file lived in a feature worktree under `.worktrees/<branch>` (the common case — CWD on `main` ≠ editing `main`), or
- the file was outside the repo entirely (e.g. `~/.claude` memory files — the original "3× noise" case from #699).

## Fix

Resolve the branch from the **directory of the file being edited** (`git -C <file_dir>`) instead of the CWD:

- a linked worktree reports its own branch → not flagged;
- a path outside any work tree short-circuits to `exit 0`;
- new-file writes walk up to the nearest existing ancestor so git can resolve the containing worktree.

Net effect: the confirm prompt fires only when the edited file truly lives on a protected branch; worktree and out-of-repo edits pass silently.

## Verification

- ✅ edit a file physically in the main checkout → ASK (protection preserved)
- ✅ edit a file in a feature worktree → silent (exit 0)
- ✅ new file inside a worktree → silent (walk-up resolves the worktree)
- ✅ new file at main checkout root → ASK
- ✅ `~/.claude` memory file (outside any repo) → silent
- pre-commit clean (shellcheck / treefmt / typos / gitleaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)