### PR TITLE
feat(claude): sync claude + codex status lines into chezmoi source

### DIFF
--- a/dot_claude/executable_statusline-command.sh
+++ b/dot_claude/executable_statusline-command.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Claude Code status line — Dracula-themed, mirroring the Starship prompt style.
+# Receives JSON on stdin.
+
+input=$(cat)
+
+# ── Extract fields ────────────────────────────────────────────────────────────
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+branch=$(echo "$input" | jq -r '
+  if .workspace.repo then
+    .workspace.repo.owner + "/" + .workspace.repo.name
+  else "" end')
+worktree=$(echo "$input" | jq -r '.workspace.git_worktree // ""')
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+effort=$(echo "$input" | jq -r '.effort.level // ""')
+
+# ── Dracula ANSI colours (256-colour approximations) ─────────────────────────
+# cyan   #8be9fd  → \e[38;5;117m
+# pink   #ff79c6  → \e[38;5;212m
+# purple #bd93f9  → \e[38;5;141m
+# green  #50fa7b  → \e[38;5;84m
+# orange #ffb86c  → \e[38;5;215m
+# yellow #f1fa8c  → \e[38;5;228m
+# reset
+RST='\e[0m'
+CYAN='\e[38;5;117m'
+PINK='\e[38;5;212m'
+PURPLE='\e[38;5;141m'
+GREEN='\e[38;5;84m'
+ORANGE='\e[38;5;215m'
+YELLOW='\e[38;5;228m'
+BOLD='\e[1m'
+
+# ── Directory: shorten $HOME to ~ ─────────────────────────────────────────────
+home="${HOME:-/root}"
+short_cwd="${cwd/#$home/\~}"
+
+# ── Git branch via git (more accurate than repo field alone) ─────────────────
+git_branch=""
+if git_branch_raw=$(git -C "$cwd" branch --show-current 2>/dev/null); then
+    git_branch="$git_branch_raw"
+fi
+
+# ── Build output ──────────────────────────────────────────────────────────────
+out=""
+
+#  directory (bold cyan)
+out+="${BOLD}${CYAN}${short_cwd}${RST}"
+
+#  git branch (bold pink with  symbol)
+if [[ -n "$git_branch" ]]; then
+    out+="  ${BOLD}${PINK} ${git_branch}${RST}"
+fi
+
+#  worktree indicator (bold purple), mirrors starship right_format custom.worktree
+if [[ -n "$worktree" ]]; then
+    out+="  ${BOLD}${PURPLE}wt:${worktree}${RST}"
+fi
+
+#  repo (owner/name) when present and no local branch info is enough
+if [[ -z "$git_branch" && -n "$branch" ]]; then
+    out+="  ${BOLD}${PINK} ${branch}${RST}"
+fi
+
+#  model (green)
+if [[ -n "$model" ]]; then
+    out+="  ${BOLD}${GREEN}${model}${RST}"
+fi
+
+#  effort level when set and not default
+if [[ -n "$effort" && "$effort" != "medium" ]]; then
+    out+="  ${BOLD}${ORANGE}effort:${effort}${RST}"
+fi
+
+#  context usage (yellow) — only after first API response
+if [[ -n "$used_pct" ]]; then
+    printf_pct=$(printf '%.0f' "$used_pct")
+    out+="  ${BOLD}${YELLOW}ctx:${printf_pct}%${RST}"
+fi
+
+printf "%b\n" "$out"

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -256,6 +256,10 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash $HOME/.claude/statusline-command.sh"
+  },
   "skipDangerousModePermissionPrompt": true,
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh"

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -115,6 +115,9 @@ max_bytes = 104857600
 notifications = true
 animations = true
 show_tooltips = true
+# Built-in status line segments (declarative — no external script, unlike Claude Code's).
+status_line = ["model-with-reasoning", "git-branch", "pull-request-number", "branch-changes", "run-state", "permissions", "approval-mode", "context-used", "weekly-limit", "context-window-size"]
+status_line_use_colors = true
 
 # =============================================================================
 # Lifecycle Hooks


### PR DESCRIPTION
## What

Persist both agents' status lines in the **chezmoi source** so they survive `chezmoi apply` and reproduce on other machines. Previously they only existed as live `~/` files (or would be dropped on the next apply).

| Agent | Change | Why it was needed |
|---|---|---|
| **claude** | New `dot_claude/executable_statusline-command.sh` (Dracula-themed, mirrors the Starship prompt) + `statusLine` block in `settings.json.tmpl` | The `statusline-setup` agent wrote only the live `~/.claude/` files; the script was untracked and the settings edit would be clobbered by the template on next apply. |
| **codex** | Add `tui.status_line` + `status_line_use_colors` to `dot_codex/modify_config.toml.tmpl` | codex's status line is a built-in declarative segment list. The `modify_` script only preserves `[projects.*]` and `[hooks.state]`, so the live `status_line` would be **dropped** on the next apply. |

## Verification

- `chezmoi cat ~/.claude/settings.json | jq .statusLine` → renders the command block.
- `chezmoi cat ~/.codex/config.toml` → `[tui]` now contains `status_line`.
- `chezmoi diff` for both files shows **no content drift** for the status lines (only expected mode/NUX-state noise).

## Notes

- The claude script is invoked via `bash`, so the `executable_` bit is convention, not a hard requirement.
- No secrets touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)