### PR TITLE
feat(claude): drop directory segment from status line

### DIFF
--- a/dot_claude/executable_statusline-command.sh
+++ b/dot_claude/executable_statusline-command.sh
@@ -24,17 +24,12 @@ effort=$(echo "$input" | jq -r '.effort.level // ""')
 # yellow #f1fa8c  → \e[38;5;228m
 # reset
 RST='\e[0m'
-CYAN='\e[38;5;117m'
 PINK='\e[38;5;212m'
 PURPLE='\e[38;5;141m'
 GREEN='\e[38;5;84m'
 ORANGE='\e[38;5;215m'
 YELLOW='\e[38;5;228m'
 BOLD='\e[1m'
-
-# ── Directory: shorten $HOME to ~ ─────────────────────────────────────────────
-home="${HOME:-/root}"
-short_cwd="${cwd/#$home/\~}"
 
 # ── Git branch via git (more accurate than repo field alone) ─────────────────
 git_branch=""
@@ -44,9 +39,6 @@ fi
 
 # ── Build output ──────────────────────────────────────────────────────────────
 out=""
-
-#  directory (bold cyan)
-out+="${BOLD}${CYAN}${short_cwd}${RST}"
 
 #  git branch (bold pink with  symbol)
 if [[ -n "$git_branch" ]]; then


### PR DESCRIPTION
## What

Removes the current-directory segment from the Claude Code status line in the chezmoi source (`dot_claude/executable_statusline-command.sh`), keeping all other segments.

## Changes
- Drop the `short_cwd` computation block (`home` / `short_cwd`).
- Drop the directory output line and its comment.
- Drop the now-unused `CYAN` colour variable.
- `cwd` is retained — still used by `git -C "$cwd" branch --show-current`.

Remaining segments: git branch, worktree, repo, model, effort, context usage.

Mirrors the already-applied change to the live `~/.claude/statusline-command.sh`.

## Verification
- Pre-commit hooks pass (Shellcheck, treefmt, etc.).
- Smoke test with sample JSON renders branch/model/ctx and no directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)