### PR TITLE
feat(nvim): optimize LazyVim configuration

### DIFF
--- a/private_dot_config/nvim/lazy-lock.json
+++ b/private_dot_config/nvim/lazy-lock.json
@@ -1,11 +1,15 @@
 {
   "LazyVim": {
     "branch": "main",
-    "commit": "c64a61734fc9d45470a72603395c02137802bc6f"
+    "commit": "c10948c50b18fae7f256433afdef09e432410480"
+  },
+  "SchemaStore.nvim": {
+    "branch": "main",
+    "commit": "322751401046ae2dbbe32eeb31992a5d4fcc8d92"
   },
   "blink.cmp": {
     "branch": "main",
-    "commit": "b19413d214068f316c78978b08264ed1c41830ec"
+    "commit": "78336bc89ee5365633bcf754d93df01678b5c08f"
   },
   "bufferline.nvim": {
     "branch": "main",
@@ -13,11 +17,31 @@
   },
   "catppuccin": {
     "branch": "main",
-    "commit": "6efc53e42cfc97700f19043105bf73ba83c4ae7d"
+    "commit": "e068ab5f8261f23f6f71ffd8791ae40315b77b9c"
+  },
+  "chezmoi.nvim": {
+    "branch": "main",
+    "commit": "4167bbec76f693f481a5243f1be521ff0ccf1a6d"
+  },
+  "chezmoi.vim": {
+    "branch": "main",
+    "commit": "7a498ea65f658993237fb0469001bdf71f68cf94"
+  },
+  "codecompanion.nvim": {
+    "branch": "main",
+    "commit": "635f001598d811c6ea256bc863b3d503c3a88d43"
   },
   "conform.nvim": {
     "branch": "master",
-    "commit": "8314f4c9e205e7f30b62147069729f9a1227d8bf"
+    "commit": "619363c30309d29ffa631e67c8183f2a72caa373"
+  },
+  "crates.nvim": {
+    "branch": "main",
+    "commit": "694357861ec9ebf12475ddcdd04ea45a0923c32d"
+  },
+  "dracula": {
+    "branch": "main",
+    "commit": "ae752c13e95fb7c5f58da4b5123cb804ea7568ee"
   },
   "flash.nvim": {
     "branch": "main",
@@ -25,15 +49,19 @@
   },
   "friendly-snippets": {
     "branch": "main",
-    "commit": "572f5660cf05f8cd8834e096d7b4c921ba18e175"
+    "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9"
   },
   "gitsigns.nvim": {
     "branch": "main",
-    "commit": "dfac404ac94b0eb1461bd7da32279e16950dfd67"
+    "commit": "2038c666bd9d8a0b7349a0b6ee00dc83104b9ecf"
   },
   "grug-far.nvim": {
     "branch": "main",
-    "commit": "794f03c97afc7f4b03fb6ec5111be507df1850cf"
+    "commit": "c69859c1d5427ab5fc7ed12380ab521b4e336691"
+  },
+  "inc-rename.nvim": {
+    "branch": "main",
+    "commit": "0074b551a17338ccdcd299bd86687cc651bcb33d"
   },
   "lazy.nvim": {
     "branch": "main",
@@ -41,31 +69,59 @@
   },
   "lazydev.nvim": {
     "branch": "main",
-    "commit": "5231c62aa83c2f8dc8e7ba957aa77098cda1257d"
+    "commit": "ff2cbcba459b637ec3fd165a2be59b7bbaeedf0d"
   },
   "lualine.nvim": {
     "branch": "master",
-    "commit": "47f91c416daef12db467145e16bed5bbfe00add8"
+    "commit": "221ce6b2d999187044529f49da6554a92f740a96"
+  },
+  "markdown-preview.nvim": {
+    "branch": "master",
+    "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee"
   },
   "mason-lspconfig.nvim": {
     "branch": "main",
-    "commit": "4cfe411526a7a99c18281135e8b4765ae6330d15"
+    "commit": "21c5b3ebeaa0412e28096bb0701434c51c1fbf76"
+  },
+  "mason-nvim-dap.nvim": {
+    "branch": "main",
+    "commit": "9a10e096703966335bd5c46c8c875d5b0690dade"
   },
   "mason.nvim": {
     "branch": "main",
-    "commit": "4d92d33d50f1768eed4b37ca3517dca13d293b90"
+    "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d"
   },
   "mini.ai": {
     "branch": "main",
-    "commit": "bfb26d9072670c3aaefab0f53024b2f3729c8083"
+    "commit": "d73c36349aa7b0bab5f77ad71701a1d42211a1df"
+  },
+  "mini.hipatterns": {
+    "branch": "main",
+    "commit": "607d604e650cdf21d71f863d040c496a1d0cb320"
   },
   "mini.icons": {
     "branch": "main",
-    "commit": "efc85e42262cd0c9e1fdbf806c25cb0be6de115c"
+    "commit": "e56797f90192d81f1fda02e662fc3e8e3d775027"
   },
   "mini.pairs": {
     "branch": "main",
-    "commit": "d5a29b6254dad07757832db505ea5aeab9aad43a"
+    "commit": "db0fac0a25884183650352ccf92b362a41ed2e9c"
+  },
+  "mini.surround": {
+    "branch": "main",
+    "commit": "a2f644f3759edd3d3f8b6a6d55378408bfe6d290"
+  },
+  "neotest": {
+    "branch": "master",
+    "commit": "ad991822b7076b1d940b33a9d6d0d30416d5df81"
+  },
+  "neotest-golang": {
+    "branch": "main",
+    "commit": "542cbaf37f1233a2723ccd64ce8ed7e3acbd192b"
+  },
+  "neotest-python": {
+    "branch": "master",
+    "commit": "e6df4f1892f6137f58135917db24d1655937d831"
   },
   "noice.nvim": {
     "branch": "main",
@@ -75,25 +131,49 @@
     "branch": "main",
     "commit": "de740991c12411b663994b2860f1a4fd0937c130"
   },
+  "nvim-dap": {
+    "branch": "master",
+    "commit": "9e848e09a697ee95302a3ef2dd43fd6eb709e570"
+  },
+  "nvim-dap-go": {
+    "branch": "main",
+    "commit": "b4421153ead5d726603b02743ea40cf26a51ed5f"
+  },
+  "nvim-dap-python": {
+    "branch": "master",
+    "commit": "1808458eba2b18f178f990e01376941a42c7f93b"
+  },
+  "nvim-dap-ui": {
+    "branch": "master",
+    "commit": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49"
+  },
+  "nvim-dap-virtual-text": {
+    "branch": "master",
+    "commit": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6"
+  },
   "nvim-lint": {
     "branch": "master",
-    "commit": "ca6ea12daf0a4d92dc24c5c9ae22a1f0418ade37"
+    "commit": "01c9842c089069ab497430159312b2c8868a4590"
   },
   "nvim-lspconfig": {
     "branch": "master",
-    "commit": "0b38bc74487e73489624d61396af7805af9cc75f"
+    "commit": "bfcc0171a43f22afa61d927ffe9fcb6cb85dc99e"
+  },
+  "nvim-nio": {
+    "branch": "master",
+    "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662"
   },
   "nvim-treesitter": {
     "branch": "main",
-    "commit": "b033ab331ca0bccbd93c3c2b4f886fdfc09abec0"
+    "commit": "4916d6592ede8c07973490d9322f187e07dfefac"
   },
   "nvim-treesitter-textobjects": {
     "branch": "main",
-    "commit": "28a3494c075ef0f353314f627546537e43c09592"
+    "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e"
   },
   "nvim-ts-autotag": {
     "branch": "main",
-    "commit": "c4ca798ab95b316a768d51eaaaee48f64a4a46bc"
+    "commit": "88c1453db4ba7dd24131086fe51fdf74e587d275"
   },
   "persistence.nvim": {
     "branch": "main",
@@ -101,11 +181,19 @@
   },
   "plenary.nvim": {
     "branch": "master",
-    "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509"
+    "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b"
+  },
+  "render-markdown.nvim": {
+    "branch": "main",
+    "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a"
+  },
+  "rustaceanvim": {
+    "branch": "main",
+    "commit": "1f2f0cef1656a1d20011287137615a9c1ea69baf"
   },
   "snacks.nvim": {
     "branch": "main",
-    "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b"
+    "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2"
   },
   "todo-comments.nvim": {
     "branch": "main",
@@ -113,7 +201,7 @@
   },
   "tokyonight.nvim": {
     "branch": "main",
-    "commit": "5da1b76e64daf4c5d410f06bcb6b9cb640da7dfd"
+    "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6"
   },
   "trouble.nvim": {
     "branch": "main",
@@ -122,6 +210,10 @@
   "ts-comments.nvim": {
     "branch": "main",
     "commit": "123a9fb12e7229342f807ec9e6de478b1102b041"
+  },
+  "venv-selector.nvim": {
+    "branch": "main",
+    "commit": "cc4bb3975de8835291f9bb45889e96c6b2795fc4"
   },
   "which-key.nvim": {
     "branch": "main",

--- a/private_dot_config/nvim/lazyvim.json
+++ b/private_dot_config/nvim/lazyvim.json
@@ -1,5 +1,24 @@
 {
-  "extras": [],
+  "extras": [
+    "lazyvim.plugins.extras.coding.mini-surround",
+    "lazyvim.plugins.extras.dap.core",
+    "lazyvim.plugins.extras.editor.inc-rename",
+    "lazyvim.plugins.extras.formatting.prettier",
+    "lazyvim.plugins.extras.lang.docker",
+    "lazyvim.plugins.extras.lang.git",
+    "lazyvim.plugins.extras.lang.go",
+    "lazyvim.plugins.extras.lang.json",
+    "lazyvim.plugins.extras.lang.markdown",
+    "lazyvim.plugins.extras.lang.nix",
+    "lazyvim.plugins.extras.lang.python",
+    "lazyvim.plugins.extras.lang.rust",
+    "lazyvim.plugins.extras.lang.toml",
+    "lazyvim.plugins.extras.lang.yaml",
+    "lazyvim.plugins.extras.test.core",
+    "lazyvim.plugins.extras.util.chezmoi",
+    "lazyvim.plugins.extras.util.dot",
+    "lazyvim.plugins.extras.util.mini-hipatterns"
+  ],
   "install_version": 8,
   "news": {
     "NEWS.md": "11866"

--- a/private_dot_config/nvim/lua/config/autocmds.lua
+++ b/private_dot_config/nvim/lua/config/autocmds.lua
@@ -6,3 +6,23 @@
 --
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
+
+local group = vim.api.nvim_create_augroup("local_dotfiles", { clear = true })
+
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+  group = group,
+  pattern = { "*.tmpl", "*.chezmoitmpl" },
+  callback = function(event)
+    vim.b[event.buf].autoformat = false
+  end,
+  desc = "Keep formatters from rewriting chezmoi templates",
+})
+
+vim.api.nvim_create_autocmd("FileType", {
+  group = group,
+  pattern = { "gitcommit", "markdown" },
+  callback = function(event)
+    vim.bo[event.buf].textwidth = 100
+  end,
+  desc = "Use a practical prose width for docs and commits",
+})

--- a/private_dot_config/nvim/lua/config/keymaps.lua
+++ b/private_dot_config/nvim/lua/config/keymaps.lua
@@ -1,3 +1,10 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
+
+local map = vim.keymap.set
+
+map("n", "<leader>uA", function()
+  vim.b.autoformat = not LazyVim.format.enabled(0)
+  vim.notify("Buffer autoformat " .. (vim.b.autoformat and "enabled" or "disabled"))
+end, { desc = "Toggle Buffer Autoformat" })

--- a/private_dot_config/nvim/lua/config/options.lua
+++ b/private_dot_config/nvim/lua/config/options.lua
@@ -1,3 +1,13 @@
 -- Options are automatically loaded before lazy.nvim startup
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- Add any additional options here
+
+vim.g.lazyvim_picker = "snacks"
+vim.g.lazyvim_python_lsp = "pyright"
+vim.g.lazyvim_python_ruff = "ruff"
+vim.g.lazyvim_rust_diagnostics = "rust-analyzer"
+
+vim.opt.scrolloff = 8
+vim.opt.sidescrolloff = 8
+vim.opt.splitkeep = "screen"
+vim.opt.smoothscroll = true

--- a/private_dot_config/nvim/lua/plugins/ai.lua
+++ b/private_dot_config/nvim/lua/plugins/ai.lua
@@ -38,12 +38,10 @@ return {
           })
         end,
       },
-      strategies = {
-        chat = { adapter = "anthropic" },
-        inline = { adapter = "anthropic" },
-        cmd = { adapter = "anthropic" },
-      },
       display = {
+        action_palette = {
+          provider = "snacks",
+        },
         chat = {
           show_settings = false,
           show_token_count = true,
@@ -56,8 +54,14 @@ return {
           provider = "default",
         },
       },
+      interactions = {
+        chat = { adapter = "anthropic" },
+        inline = { adapter = "anthropic" },
+        cmd = { adapter = "anthropic" },
+      },
       opts = {
         log_level = "ERROR",
+        language = "Chinese",
         send_code = true,
       },
     },

--- a/private_dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/private_dot_config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,16 @@
+return {
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "dracula",
+    },
+  },
+  {
+    "Mofiqul/dracula.nvim",
+    name = "dracula",
+    opts = {
+      terminal_colors = true,
+      italic_comment = true,
+    },
+  },
+}

--- a/private_dot_config/nvim/lua/plugins/dotfiles.lua
+++ b/private_dot_config/nvim/lua/plugins/dotfiles.lua
@@ -1,0 +1,77 @@
+local function executable(name)
+  return vim.fn.executable(name) == 1
+end
+
+local function has_file(ctx, names)
+  return vim.fs.find(names, { path = ctx.filename, upward = true })[1] ~= nil
+end
+
+return {
+  {
+    "xvzc/chezmoi.nvim",
+    optional = true,
+    init = function()
+      local source = vim.fn.expand("~/.local/share/chezmoi")
+      local worktrees = source .. "/.worktrees/"
+
+      vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+        group = vim.api.nvim_create_augroup("local_chezmoi_watch", { clear = true }),
+        pattern = { source .. "/*" },
+        callback = function(event)
+          local path = vim.api.nvim_buf_get_name(event.buf)
+          if path:sub(1, #worktrees) == worktrees then
+            return
+          end
+
+          vim.schedule(function()
+            require("chezmoi.commands.__edit").watch(event.buf)
+          end)
+        end,
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters_by_ft = {
+        bash = { "shfmt" },
+        sh = { "shfmt" },
+      },
+      formatters = {
+        shfmt = {
+          prepend_args = { "-i", "4" },
+        },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    opts = function(_, opts)
+      opts.linters_by_ft = opts.linters_by_ft or {}
+      opts.linters_by_ft.lua = vim.list_extend(opts.linters_by_ft.lua or {}, { "selene" })
+      opts.linters_by_ft.yaml = vim.list_extend(opts.linters_by_ft.yaml or {}, { "actionlint" })
+
+      opts.linters = opts.linters or {}
+      opts.linters.selene = {
+        condition = function(ctx)
+          return executable("selene") and has_file(ctx, { "selene.toml" })
+        end,
+      }
+      opts.linters.actionlint = {
+        condition = function(ctx)
+          return executable("actionlint") and ctx.filename:match("/%.github/workflows/.*%.ya?ml$") ~= nil
+        end,
+      }
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        bashls = {
+          filetypes = { "sh", "bash" },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

- Enable a focused set of LazyVim extras for dotfiles work, language support, DAP, tests, formatting, and mini utilities.
- Align Neovim with the repo-wide Dracula theme used by Ghostty, Starship, bat, fzf, delta, lazygit, yazi, borders, and Herdr.
- Add dotfiles-specific Neovim behavior for chezmoi templates, shell formatting, conditional linting, and CodeCompanion's current interactions API.

## Why

The previous Neovim setup was still close to the LazyVim starter defaults and did not match the rest of this dotfiles theme stack. The change keeps LazyVim as the base while making the managed Neovim config more complete for this repo's daily workflow.

## Impact

- `nvim` now starts with the Dracula colorscheme.
- Chezmoi templates are protected from automatic formatter rewrites.
- Go, Rust, Python, Markdown, Nix, Docker, Git, JSON, YAML, and TOML workflows get their corresponding LazyVim extras and pinned plugins.
- CodeCompanion continues using Anthropic, now through the current `interactions` configuration surface.

## Validation

- `stylua --check private_dot_config/nvim/lua`
- `jq . private_dot_config/nvim/lazyvim.json`
- `git diff --check`
- `nvim --headless` assertion for `colors=dracula` and loaded LazyVim extras
- `nvim --headless` assertion that chezmoi template buffers set `vim.b.autoformat = false`
- `chezmoi diff --source /Users/yixianlu/.local/share/chezmoi/.worktrees/wt-neovim-optimization --refresh-externals=never --no-pager --recursive /Users/yixianlu/.config/nvim`
- pre-commit hooks during commit, including treefmt, Selene, typos, and gitleaks