### PR TITLE
fix(homebrew): trust aerospace cask

### DIFF
--- a/private_dot_config/homebrew/private_trust.json
+++ b/private_dot_config/homebrew/private_trust.json
@@ -1,4 +1,5 @@
 {
   "trustedformulae": ["felixkratz/formulae/borders"],
-  "trustedtaps": ["felixkratz/formulae", "muxy-app/tap", "nikitabobko/tap"]
+  "trustedtaps": ["felixkratz/formulae", "muxy-app/tap", "nikitabobko/tap"],
+  "trustedcasks": ["nikitabobko/tap/aerospace"]
 }


### PR DESCRIPTION
## Summary
- sync managed Homebrew trust.json with the current trusted Aerospace cask entry
- keep the file formatted the way Homebrew wrote the target trust file

## Verification
- jq empty private_dot_config/homebrew/private_trust.json
- chezmoi diff /Users/yixianlu/.config/homebrew/trust.json
- git diff --check