### PR TITLE
fix(ai): disambiguate manager case patterns

### DIFF
--- a/dot_local/bin/lib/ai/claude
+++ b/dot_local/bin/lib/ai/claude
@@ -97,10 +97,10 @@ fzf_pick_account() {
     local result raw
     if ! raw=$({
         case "$list_type" in
-            token) build_account_list_with_token ;;
-            token-known) build_account_list_with_token known ;;
-            plain) printf '%s\n' "${ACCOUNTS[@]}" ;;
-            *)     build_account_list_with_status ;;
+            (token) build_account_list_with_token ;;
+            (token-known) build_account_list_with_token known ;;
+            (plain) printf '%s\n' "${ACCOUNTS[@]}" ;;
+            (*)     build_account_list_with_status ;;
         esac
         echo -e "${YELLOW}Back${NC}"
     } | fzf --ansi \

--- a/dot_local/bin/lib/ai/codex
+++ b/dot_local/bin/lib/ai/codex
@@ -98,9 +98,9 @@ fzf_pick_account() {
     local result raw
     if ! raw=$({
         case "$list_type" in
-            token) build_account_list_with_token ;;
-            plain) printf '%s\n' "${ACCOUNTS[@]}" ;;
-            *)     build_account_list_with_status ;;
+            (token) build_account_list_with_token ;;
+            (plain) printf '%s\n' "${ACCOUNTS[@]}" ;;
+            (*)     build_account_list_with_status ;;
         esac
         echo -e "${YELLOW}Back${NC}"
     } | fzf --ansi \


### PR DESCRIPTION
## Summary

- Disambiguate Bash `case` patterns inside the Claude and Codex account picker command substitutions.
- Preserve the existing account picker behavior while fixing the parse errors surfaced by `ccm` and `cxm`.

## Root Cause

Bash can parse an unparenthesized `case` arm such as `token)` inside `$(...)` as the end of command substitution. Using the explicit `(token)` pattern form removes that ambiguity.

## Validation

- `bash -n dot_local/bin/lib/ai/claude`
- `bash -n dot_local/bin/lib/ai/codex`
- `bash -n ~/.local/bin/lib/ai/claude`
- `bash -n ~/.local/bin/lib/ai/codex`
- `zsh -lic 'ccm list >/dev/null'`
- `zsh -lic 'cxm list >/dev/null'`
- `git diff --check`
- pre-commit hooks during `git commit`