### PR TITLE
fix: select platform scripts via chezmoi ignore

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -50,7 +50,9 @@ Library/
 .config/hammerspoon/
 {{- else }}
 # Linux-only: systemd --user units have no meaning on macOS (launchd is used
-# there via Library/LaunchAgents). Exclude them from the macOS target.
+# there via Library/LaunchAgents). Exclude the script and units from the macOS
+# target so the Linux-only script is not rendered or executed during apply.
+.chezmoiscripts/15_load-systemd-user-units.sh
 .config/systemd/
 {{- end }}
 

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -40,6 +40,7 @@ nix-config/modules/host-users.nix
 .chezmoiscripts/02_init.sh
 .chezmoiscripts/09_install-paperlib.sh
 .chezmoiscripts/10_update_homebrew_packages.sh
+.chezmoiscripts/13_load-launch-agents.sh
 
 # macOS-only GUI apps (target paths)
 Library/

--- a/.chezmoiscripts/run_onchange_after_09_install-paperlib.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09_install-paperlib.sh.tmpl
@@ -4,11 +4,6 @@
 
 set -euo pipefail
 
-{{- if or (ne .chezmoi.os "darwin") .headless }}
-echo ":: [09] Paperlib install skipped (macOS GUI profile only)"
-exit 0
-{{- end }}
-
 echo ":: [09] Installing Paperlib"
 
 VERSION="{{ .versions.paperlib }}"

--- a/.chezmoiscripts/run_onchange_after_13_load-launch-agents.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_13_load-launch-agents.sh.tmpl
@@ -60,6 +60,4 @@ mkdir -p "${HOME}/Library/Logs"
 reload_launch_agent "com.signalridge.qmk-hid-host"
 reload_launch_agent "com.signalridge.mcp-reaper"
 reload_launch_agent "com.signalridge.mcp-context7"
-{{ else -}}
-echo ":: [13] macOS LaunchAgents skipped (macOS GUI profile only)"
 {{ end -}}

--- a/.chezmoiscripts/run_onchange_after_15_load-systemd-user-units.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_15_load-systemd-user-units.sh.tmpl
@@ -42,6 +42,4 @@ systemctl --user enable --now mcp-reaper.timer
 systemctl --user try-restart mcp-reaper.timer || true
 
 echo "    enabled mcp-context7.service + mcp-reaper.timer"
-{{ else -}}
-echo ":: [15] systemd --user MCP units skipped (Linux only)"
 {{ end -}}

--- a/tests/test_chezmoiignore.sh
+++ b/tests/test_chezmoiignore.sh
@@ -10,6 +10,8 @@ command -v chezmoi >/dev/null 2>&1 || {
 
 out="$(chezmoi ignored --source "$ROOT" --override-data '{"useEncryption":false,"headless":false}')"
 headless_out="$(chezmoi ignored --source "$ROOT" --override-data '{"useEncryption":true,"headless":true}')"
+managed_scripts="$(chezmoi managed --source "$ROOT" --include=scripts)"
+chezmoi_os="$(chezmoi execute-template --source "$ROOT" '{{ .chezmoi.os }}')"
 
 require_line() {
     local expected="$1"
@@ -46,6 +48,26 @@ require_any_line() {
     exit 1
 }
 
+require_managed_script() {
+    local expected="$1"
+    if ! printf '%s\n' "$managed_scripts" | grep -qxF "$expected"; then
+        echo "expected managed script not found: $expected" >&2
+        echo "--- managed scripts ---" >&2
+        printf '%s\n' "$managed_scripts" >&2
+        exit 1
+    fi
+}
+
+forbid_managed_script() {
+    local unexpected="$1"
+    if printf '%s\n' "$managed_scripts" | grep -qxF "$unexpected"; then
+        echo "unexpected managed script found: $unexpected" >&2
+        echo "--- managed scripts ---" >&2
+        printf '%s\n' "$managed_scripts" >&2
+        exit 1
+    fi
+}
+
 # Always ignored (repo-only content).
 require_line "docs"
 require_line "tests"
@@ -56,6 +78,14 @@ require_line ".chezmoiscripts/01_setup-encryption-key.sh"
 require_line ".chezmoiscripts/06_setup-gopass.sh"
 # Chezmoi may report source entries as either target-style or template/encrypted names.
 require_any_line ".ssh/config" ".ssh/config.tmpl.age"
+
+if [[ "$chezmoi_os" == "darwin" ]]; then
+    require_line ".chezmoiscripts/15_load-systemd-user-units.sh"
+    forbid_managed_script ".chezmoiscripts/15_load-systemd-user-units.sh"
+else
+    forbid_line ".chezmoiscripts/15_load-systemd-user-units.sh"
+    require_managed_script ".chezmoiscripts/15_load-systemd-user-units.sh"
+fi
 
 out="$headless_out"
 require_line ".chezmoiscripts/09_install-paperlib.sh"

--- a/tests/test_chezmoiignore.sh
+++ b/tests/test_chezmoiignore.sh
@@ -8,10 +8,17 @@ command -v chezmoi >/dev/null 2>&1 || {
     exit 0
 }
 
-out="$(chezmoi ignored --source "$ROOT" --override-data '{"useEncryption":false,"headless":false}')"
-headless_out="$(chezmoi ignored --source "$ROOT" --override-data '{"useEncryption":true,"headless":true}')"
-managed_scripts="$(chezmoi managed --source "$ROOT" --include=scripts)"
-chezmoi_os="$(chezmoi execute-template --source "$ROOT" '{{ .chezmoi.os }}')"
+default_data='{"useEncryption":false,"headless":false}'
+headless_data='{"useEncryption":true,"headless":true}'
+darwin_data='{"chezmoi":{"os":"darwin"},"useEncryption":false,"headless":false}'
+linux_data='{"chezmoi":{"os":"linux"},"useEncryption":false,"headless":false}'
+
+out="$(chezmoi ignored --source "$ROOT" --override-data "$default_data")"
+headless_out="$(chezmoi ignored --source "$ROOT" --override-data "$headless_data")"
+darwin_out="$(chezmoi ignored --source "$ROOT" --override-data "$darwin_data")"
+darwin_managed_scripts="$(chezmoi managed --source "$ROOT" --include=scripts --override-data "$darwin_data")"
+linux_out="$(chezmoi ignored --source "$ROOT" --override-data "$linux_data")"
+linux_managed_scripts="$(chezmoi managed --source "$ROOT" --include=scripts --override-data "$linux_data")"
 
 require_line() {
     local expected="$1"
@@ -48,22 +55,26 @@ require_any_line() {
     exit 1
 }
 
-require_managed_script() {
-    local expected="$1"
-    if ! printf '%s\n' "$managed_scripts" | grep -qxF "$expected"; then
-        echo "expected managed script not found: $expected" >&2
-        echo "--- managed scripts ---" >&2
-        printf '%s\n' "$managed_scripts" >&2
+require_entry_in() {
+    local haystack="$1"
+    local expected="$2"
+    local label="$3"
+    if ! printf '%s\n' "$haystack" | grep -qxF "$expected"; then
+        echo "expected entry not found in $label: $expected" >&2
+        echo "--- $label ---" >&2
+        printf '%s\n' "$haystack" >&2
         exit 1
     fi
 }
 
-forbid_managed_script() {
-    local unexpected="$1"
-    if printf '%s\n' "$managed_scripts" | grep -qxF "$unexpected"; then
-        echo "unexpected managed script found: $unexpected" >&2
-        echo "--- managed scripts ---" >&2
-        printf '%s\n' "$managed_scripts" >&2
+forbid_entry_in() {
+    local haystack="$1"
+    local unexpected="$2"
+    local label="$3"
+    if printf '%s\n' "$haystack" | grep -qxF "$unexpected"; then
+        echo "unexpected entry found in $label: $unexpected" >&2
+        echo "--- $label ---" >&2
+        printf '%s\n' "$haystack" >&2
         exit 1
     fi
 }
@@ -79,13 +90,25 @@ require_line ".chezmoiscripts/06_setup-gopass.sh"
 # Chezmoi may report source entries as either target-style or template/encrypted names.
 require_any_line ".ssh/config" ".ssh/config.tmpl.age"
 
-if [[ "$chezmoi_os" == "darwin" ]]; then
-    require_line ".chezmoiscripts/15_load-systemd-user-units.sh"
-    forbid_managed_script ".chezmoiscripts/15_load-systemd-user-units.sh"
-else
-    forbid_line ".chezmoiscripts/15_load-systemd-user-units.sh"
-    require_managed_script ".chezmoiscripts/15_load-systemd-user-units.sh"
-fi
+# Platform-specific scripts should be selected by .chezmoiignore, not by
+# rendering/running scripts that only print a platform skip message.
+forbid_entry_in "$darwin_out" ".chezmoiscripts/09_install-paperlib.sh" "darwin ignored"
+forbid_entry_in "$darwin_out" ".chezmoiscripts/13_load-launch-agents.sh" "darwin ignored"
+require_entry_in "$darwin_out" ".chezmoiscripts/15_load-systemd-user-units.sh" "darwin ignored"
+require_entry_in "$darwin_managed_scripts" ".chezmoiscripts/09_install-paperlib.sh" "darwin managed scripts"
+require_entry_in "$darwin_managed_scripts" ".chezmoiscripts/13_load-launch-agents.sh" "darwin managed scripts"
+forbid_entry_in "$darwin_managed_scripts" ".chezmoiscripts/15_load-systemd-user-units.sh" "darwin managed scripts"
+
+require_entry_in "$linux_out" ".chezmoiscripts/02_init.sh" "linux ignored"
+require_entry_in "$linux_out" ".chezmoiscripts/09_install-paperlib.sh" "linux ignored"
+require_entry_in "$linux_out" ".chezmoiscripts/10_update_homebrew_packages.sh" "linux ignored"
+require_entry_in "$linux_out" ".chezmoiscripts/13_load-launch-agents.sh" "linux ignored"
+forbid_entry_in "$linux_out" ".chezmoiscripts/15_load-systemd-user-units.sh" "linux ignored"
+forbid_entry_in "$linux_managed_scripts" ".chezmoiscripts/02_init.sh" "linux managed scripts"
+forbid_entry_in "$linux_managed_scripts" ".chezmoiscripts/09_install-paperlib.sh" "linux managed scripts"
+forbid_entry_in "$linux_managed_scripts" ".chezmoiscripts/10_update_homebrew_packages.sh" "linux managed scripts"
+forbid_entry_in "$linux_managed_scripts" ".chezmoiscripts/13_load-launch-agents.sh" "linux managed scripts"
+require_entry_in "$linux_managed_scripts" ".chezmoiscripts/15_load-systemd-user-units.sh" "linux managed scripts"
 
 out="$headless_out"
 require_line ".chezmoiscripts/09_install-paperlib.sh"


### PR DESCRIPTION
## Summary

- Ignore macOS-only scripts through `.chezmoiignore` on Linux, including `13_load-launch-agents`.
- Ignore the Linux-only systemd script through `.chezmoiignore` on macOS.
- Remove platform-only `skipped` output branches from the Paperlib and LaunchAgent scripts.
- Extend `test_chezmoiignore.sh` to validate Darwin and Linux managed-script sets explicitly.

## Why

PR #733 left platform selection partly inside script templates. That meant `chezmoi apply` could still render and execute a script just to print a platform skip message, for example the Linux-only systemd script on macOS. Platform and GUI selection should happen in chezmoi ignore/rendering rules so non-applicable scripts never enter the managed script set.

## Validation

- `bash tests/test_chezmoiignore.sh`
- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$(mktemp -d) bash tests/test_chezmoiignore.sh`
- `bash tests/test_toolchain_bootstrap.sh`
- Rendered every `.chezmoiscripts/*` template under default, Darwin, and Linux data and checked the result with `bash -n`
- `git diff --check`
- pre-commit hooks during commit, including template validation, Shellcheck, Typos, Gitleaks, and treefmt

## Notes

A local full `bash tests/run.sh` gets past `test_chezmoiignore` and then fails later in `test_keys_manage_nonmenu.sh` on macOS `/bin/bash` 3.x because the generated helper uses `local -A`. That is outside this PRs platform-script rendering fix; GitHub Bootstrap tests run on Linux with a newer bash.