### PR TITLE
fix(homebrew): install cursor cli

### DIFF
--- a/.chezmoidata/hammerspoon.yaml
+++ b/.chezmoidata/hammerspoon.yaml
@@ -32,8 +32,6 @@ hammerspoon:
     work:
       - app: DBeaver
         ime: en
-      - app: Cursor
-        ime: en
       - app: Obsidian
         ime: jp
       # Browsers/Communication -> Japanese for work

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -50,7 +50,7 @@ homebrew:
     work:
       - dbeaver-community
       - obsidian
-      - cursor
+      - cursor-cli
       - gcloud-cli
       - keepingyouawake # menu-bar utility to keep the Mac awake
     private:


### PR DESCRIPTION
## Summary
- replace the Cursor Homebrew cask with cursor-cli
- remove the stale Cursor GUI app IME rule from Hammerspoon data

## Verification
- git diff --check
- chezmoi execute-template < nix-config/modules/apps.nix.tmpl | rg -n '"cursor-cli"|"cursor"'
- chezmoi execute-template < private_dot_config/hammerspoon/ime.lua.tmpl | rg -n 'Cursor|DBeaver|Obsidian'