### PR TITLE
fix(homebrew): strip quarantine from cursor-cli native modules

### DIFF
--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -50,6 +50,11 @@ homebrew:
     work:
       - dbeaver-community
       - obsidian
+      # cursor-cli ships Anysphere-signed native .node modules. macOS/MDM tags the
+      # freshly-installed files with com.apple.quarantine, so Gatekeeper blocks
+      # dlopen ("library load disallowed by system policy") and cursor-agent crashes.
+      # Homebrew 6 dropped quarantine handling (no no_quarantine arg), so the fix is
+      # stripping the flag post-install: run_after_13_cursor-cli-dequarantine.sh.
       - cursor-cli
       - gcloud-cli
       - keepingyouawake # menu-bar utility to keep the Mac awake

--- a/.chezmoiscripts/run_after_13_cursor-cli-dequarantine.sh
+++ b/.chezmoiscripts/run_after_13_cursor-cli-dequarantine.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# cursor-cli ships Anysphere-signed native modules (merkle-tree-napi.*.node etc).
+# On (re)install macOS/MDM tags the extracted files with com.apple.quarantine;
+# Gatekeeper then refuses to dlopen them ("code signature ... not valid for use
+# in process: library load disallowed by system policy") and `cursor-agent`
+# crashes at startup. Homebrew 6 removed quarantine handling (no --no-quarantine
+# / no_quarantine arg), so the reliable fix is to strip the flag after install.
+#
+# Runs after the brew-related scripts (02 darwin-rebuild install, 10 brew upgrade)
+# on every apply; idempotent and a no-op when nothing is quarantined or off-macOS.
+
+[[ "$(uname -s)" == "Darwin" ]] || exit 0
+
+echo ":: [13] De-quarantining cursor-cli native modules"
+
+stripped=0
+for prefix in /opt/homebrew /usr/local; do
+    for pkg in "$prefix"/Caskroom/cursor-cli/*/dist-package; do
+        [[ -d "$pkg" ]] || continue
+        if xattr -dr com.apple.quarantine "$pkg" 2>/dev/null; then
+            stripped=1
+        fi
+    done
+done
+
+if [[ "$stripped" -eq 1 ]]; then
+    echo "    Stripped com.apple.quarantine from cursor-cli"
+else
+    echo "    Skipped (cursor-cli not installed)"
+fi


### PR DESCRIPTION
## Problem

`cursor-agent` crashes at startup:

```
Failed to load native binding for darwin/arm64 (expected: ./merkle-tree-napi.darwin-arm64.node)
dlopen(.../merkle-tree-napi.darwin-arm64.node): code signature ... not valid for
use in process: library load disallowed by system policy
```

## Root cause

- cursor-cli ships native `.node` modules signed by `Developer ID Application: Anysphere Incorporated (DCNK4UB866)`. The binaries and the download are fine (bundled `node` even carries `com.apple.security.cs.disable-library-validation`, so it is **not** a library-validation problem).
- On (re)install, macOS/MDM tags the extracted files with `com.apple.quarantine`; Gatekeeper then refuses to `dlopen` the quarantined native module.
- **Homebrew 6 removed quarantine handling entirely** (no `--no-quarantine` / `no_quarantine` arg), so it cannot be prevented at install time — and putting `args = { no_quarantine = true; }` in the nix casks list would pass an invalid flag to brew and could break `brew bundle` during `darwin-rebuild`.

## Fix

Add `.chezmoiscripts/run_after_13_cursor-cli-dequarantine.sh`: darwin-only, idempotent; strips `com.apple.quarantine` from `*/Caskroom/cursor-cli/*/dist-package`. It runs after the brew scripts (`02` darwin-rebuild install, `10` brew upgrade) on every `chezmoi apply`, so cursor-agent stays runnable across reinstalls/upgrades. `homebrew.yaml` gains only an explanatory comment; `apps.nix.tmpl` is unchanged.

## Verification

- `cursor-agent --version` → `2026.06.29-2ad2186` (exit 0)
- all 4 `.node` files clean after the script runs
- `shellcheck` clean; pre-commit hooks (treefmt, shellcheck, yaml, typos, gitleaks…) all pass
- `apps.nix.tmpl` renders identically and `nix-instantiate --parse` succeeds

## Known limitation

A direct `darwin-rebuild switch` (outside `chezmoi apply`) won't run script 13. Recover with `chezmoi apply`, or:

```
xattr -dr com.apple.quarantine /opt/homebrew/Caskroom/cursor-cli/*/dist-package
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
