### PR TITLE
feat(ai): add CodeGraph MCP configuration

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -31,7 +31,6 @@ versions:
   supabaseAgentSkillsRev: 1356046015476711a769601079262b5635929427
   expoSkillsRev: 1f9951197dc6acff61c4f0f19521fa0e62c33e51
   microsoftSkillsRev: 5a6104bd49d8fd4e733a30952953fd1cf9f16e62
-  sickn33AntigravitySkillsRev: 89c32f4c0b9ed015e32316ae24aade58628f919f
   xSkillsRev: 95f4c6e4221f785fbf13b4a365eb44771605c431
   xurlSkillRev: bfb0f365d14f5ed63416d29aa3abbb21a613f5cb
   dailyDevSkillsRev: 192dae2b904fd4a4e8b9d212474f34c70710e28d

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -647,17 +647,6 @@
     refreshPeriod = "168h"
 
 # ------------------------------------------------------------------------------
-# sickn33/antigravity-awesome-skills aws deployment workflow (non-MCP)
-# ------------------------------------------------------------------------------
-[".harnesses/skills/{{ index $cat "aws-serverless" }}/aws-serverless"]
-    type = "archive"
-    url = "https://github.com/sickn33/antigravity-awesome-skills/archive/{{ $.versions.sickn33AntigravitySkillsRev }}.tar.gz"
-    exact = true
-    stripComponents = 3
-    include = ["antigravity-awesome-skills-*/skills/aws-serverless/**"]
-    refreshPeriod = "168h"
-
-# ------------------------------------------------------------------------------
 # xdevplatform/xurl official X API skill
 # - Shared harness library under ~/.harnesses/skills/social/
 # - Pinned to the xurl v1.1.1 release commit so skill instructions match the CLI

--- a/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
+++ b/.chezmoiscripts/run_after_11_sync-claude-mcp.sh.tmpl
@@ -195,6 +195,7 @@ remove_user_mcp_if_present "codex-mcp"
 
 ensure_user_mcp_http "context7" "https://mcp.context7.com/mcp"
 ensure_user_mcp_json "serena" '{"command":"uvx","args":["--from","git+https://github.com/oraios/serena","serena","start-mcp-server","--context","ide-assistant","--project",".","--enable-web-dashboard","false"]}'
+ensure_user_mcp_json "codegraph" '{"type":"stdio","command":"bunx","args":["@colbymchenry/codegraph@1.2.0","serve","--mcp"]}'
 ensure_user_mcp_json "markitdown" '{"command":"uvx","args":["markitdown-mcp"]}'
 ensure_user_mcp_json "arxiv-mcp-server" '{"command":"uv","args":["tool","run","arxiv-mcp-server"]}'
 ensure_user_mcp_json "tavily" '{"command":"{{ .chezmoi.homeDir }}/.local/bin/mcp-tavily","args":[]}'

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -11,6 +11,7 @@ Repo-native first; defaults advisory (`uv/ruff`, `nix`, `aqua/mise`, `gh/ghq`); 
 - Docs/API -> Context7
 - Web/news -> Tavily
 - Code navigation -> Serena (symbolic/semantic; avoid full-file reads when a query suffices)
+- Code graph / impact analysis -> CodeGraph MCP (on-demand via `bunx @colbymchenry/codegraph@1.2.0`; initialize per repo with `bunx @colbymchenry/codegraph@1.2.0 init` when needed)
 - Browser/E2E -> agent-browser (CLI)
 - Paper/research -> arxiv
 - Repo Q&A -> DeepWiki (public) / gitmcp (private)

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -138,7 +138,8 @@
       "Bash(bun:*)",
       "Bash(bunx:*)",
       "Bash(nix:*)",
-      "Bash(chezmoi:*)"
+      "Bash(chezmoi:*)",
+      "mcp__codegraph__*"
     ],
     "deny": [
       "Bash(sudo rm -rf:*)",

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -11,6 +11,7 @@ Repo-native first; defaults advisory (`uv/ruff`, `nix`, `aqua/mise`, `gh/ghq`); 
 - Docs/API -> Context7
 - Web/news -> Tavily
 - Code navigation -> Serena (symbolic/semantic; avoid full-file reads when a query suffices)
+- Code graph / impact analysis -> CodeGraph MCP (on-demand via `bunx @colbymchenry/codegraph@1.2.0`; initialize per repo with `bunx @colbymchenry/codegraph@1.2.0 init` when needed)
 - Browser/E2E -> agent-browser (CLI)
 - Paper/research -> arxiv
 - Repo Q&A -> DeepWiki (public) / gitmcp (private)

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -197,6 +197,11 @@ startup_timeout_sec = 30
 [mcp_servers.serena.env]
 AQUA_GLOBAL_CONFIG = "{{ .chezmoi.homeDir }}/.config/aquaproj-aqua/aqua.yaml"
 
+[mcp_servers.codegraph]
+command = "bunx"
+args = ["@colbymchenry/codegraph@1.2.0", "serve", "--mcp"]
+startup_timeout_sec = 60
+
 [mcp_servers.tavily]
 command = "{{ .chezmoi.homeDir }}/.local/bin/mcp-tavily"
 args = []

--- a/dot_cursor/mcp.json.tmpl
+++ b/dot_cursor/mcp.json.tmpl
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "command": "bunx",
+      "args": ["@colbymchenry/codegraph@1.2.0", "serve", "--mcp"]
+    }
+  }
+}

--- a/dot_custom/exports.sh.tmpl
+++ b/dot_custom/exports.sh.tmpl
@@ -72,7 +72,7 @@ export FZF_CTRL_R_OPTS="
   --header 'Press CTRL-Y to copy command'
 "
 
-# AI commit message provider (codex, gemini, claude, auto)
+# AI commit message provider (codex, claude, auto)
 # Override in ~/.custom/local.sh if needed
 export AICOMMIT_PROVIDER="${AICOMMIT_PROVIDER:-claude}"
 

--- a/dot_custom/functions.sh
+++ b/dot_custom/functions.sh
@@ -236,7 +236,7 @@ alias take="mkcd" # Alternative name
 # ─────────────────────────────────────────────────────────────
 # aicommit - Generate commit message with AI CLI
 # Usage: aicommit [--dry-run|-n] [provider] [type]
-# Providers: codex (default), gemini, claude, auto
+# Providers: codex (default), claude, auto
 # Type: optional prefix override (wip, feat, fix, chore, etc.)
 # Config: AICOMMIT_PROVIDER env var
 # Note: For context-aware commits in Claude Code, use /commit command
@@ -250,7 +250,7 @@ aicommit() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --dry-run | -n) dry_run=true ;;
-        claude | codex | gemini | auto) provider="$1" ;;
+        claude | codex | auto) provider="$1" ;;
         *) [[ -z "$type_override" ]] && type_override="$1" ;;
         esac
         shift
@@ -299,7 +299,7 @@ Return ONLY the commit message, nothing else."
     # Determine provider order
     local providers=()
     if [[ "$provider" == "auto" ]]; then
-        providers=(gemini claude codex)
+        providers=(claude codex)
     else
         providers=("$provider")
     fi
@@ -326,14 +326,6 @@ Return ONLY the commit message, nothing else."
             message=$(head -1 "$tmp_out" 2>/dev/null)
             rm -f "$tmp_out"
             [[ -z "$message" ]] && continue
-            ;;
-        gemini)
-            command -v gemini &>/dev/null || continue
-            # gemini-2.5-flash: fast, 1M context; --sandbox disables agentic mode
-            error_output=$(gemini -m gemini-2.5-flash -o text --sandbox "$prompt" 2>&1) || continue
-            [[ "$error_output" == *"error"* || "$error_output" == *"Error"* ]] && continue
-            # Skip "Loaded cached credentials" line
-            message=$(echo "$error_output" | grep -v "^Loaded" | head -1)
             ;;
         esac
     done

--- a/dot_local/bin/executable_mcp-reaper.tmpl
+++ b/dot_local/bin/executable_mcp-reaper.tmpl
@@ -28,8 +28,8 @@ mkdir -p "$LOG_DIR"
 
 ts() { date '+%Y-%m-%dT%H:%M:%S%z'; }
 
-# node/bunx MCP servers + serena (uv/python) MCP servers.
-PATTERN='bunx-[0-9]+-.*mcp|serena.*start-mcp-server'
+# node/bunx MCP servers + serena (uv/python) + CodeGraph stdio MCP servers.
+PATTERN='bunx-[0-9]+-.*mcp|serena.*start-mcp-server|bunx.*@colbymchenry/codegraph|codegraph.*serve --mcp'
 
 match_procs() {
   ps -axww -o pid=,ppid=,pcpu=,pmem=,etime=,command= \

--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -13,6 +13,7 @@ MCP tools are provided by the `pi-mcp-adapter` extension; servers are configured
 - Docs/API -> Context7
 - Web/news -> Tavily
 - Code navigation -> Serena (symbolic/semantic; avoid full-file reads when a query suffices)
+- Code graph / impact analysis -> CodeGraph MCP (on-demand via `bunx @colbymchenry/codegraph@1.2.0`; initialize per repo with `bunx @colbymchenry/codegraph@1.2.0 init` when needed)
 - Browser/E2E -> agent-browser (CLI)
 - Repo Q&A -> DeepWiki (public) / gitmcp (private)
 - Notes/knowledge base -> Notion official MCP/plugin when available

--- a/dot_pi/agent/mcp.json.tmpl
+++ b/dot_pi/agent/mcp.json.tmpl
@@ -36,6 +36,11 @@
       },
       "lifecycle": "lazy"
     },
+    "codegraph": {
+      "command": "bunx",
+      "args": ["@colbymchenry/codegraph@1.2.0", "serve", "--mcp"],
+      "lifecycle": "lazy"
+    },
     "deepwiki": {
       "url": "https://mcp.deepwiki.com/mcp",
       "lifecycle": "lazy"

--- a/private_dot_config/aquaproj-aqua/registry.yaml
+++ b/private_dot_config/aquaproj-aqua/registry.yaml
@@ -7,7 +7,7 @@ packages:
   - type: github_release
     repo_owner: signalridge
     repo_name: slipway
-    description: Spec-driven development with full lifecycle accountability for Claude, Codex, Cursor & Gemini
+    description: Spec-driven development with full lifecycle accountability for Claude, Codex & Cursor
     asset: "slipway_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
     format: tar.gz
     files:

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -58,9 +58,6 @@ lua = "5.4"
 # HAPI CLI for remote control of local AI coding sessions
 "npm:@twsxtd/hapi" = "latest"
 
-# Gemini CLI managed via npm backend (replaces nix gemini-cli)
-"npm:@google/gemini-cli" = "latest"
-
 # Pi coding agent (earendil-works). Binary is `pi`. Requires node >=22.19,
 # satisfied by `node = "lts"` above. Auth/config under ~/.pi/agent (chezmoi-managed).
 "npm:@earendil-works/pi-coding-agent" = "latest"
@@ -102,9 +99,7 @@ always_keep_install = false
 # CAVEAT: this switch is global (no per-package opt-out). bun also skips
 # package lifecycle scripts by default — if a tool that downloads a binary in
 # postinstall goes missing after `mise install`, add `bun_args = "--trust"` to
-# that specific tool entry. Known risk: @google/gemini-cli has bun-install
-# issues; verify `gemini --version` after switching, and revert this to "npm"
-# if it breaks.
+# that specific tool entry.
 package_manager = "bun"
 
 [env]

--- a/tests/test_codex_config_rendering.sh
+++ b/tests/test_codex_config_rendering.sh
@@ -49,9 +49,13 @@ MODIFY_SCRIPT="$TMP_ROOT/modify_config.sh"
 RENDERED="$TMP_ROOT/config.toml"
 CLAUDE_SETTINGS="$TMP_ROOT/settings.json"
 DEEPSEEK_CLAUDE_SETTINGS="$TMP_ROOT/settings-deepseek.json"
+PI_MCP="$TMP_ROOT/pi-mcp.json"
+CURSOR_MCP="$TMP_ROOT/cursor-mcp.json"
 chezmoi execute-template --source "$ROOT" <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$MODIFY_SCRIPT"
 bash "$MODIFY_SCRIPT" </dev/null >"$RENDERED"
 chezmoi execute-template --source "$ROOT" <"$ROOT/dot_claude/settings.json.tmpl" >"$CLAUDE_SETTINGS"
+chezmoi execute-template --source "$ROOT" <"$ROOT/dot_pi/agent/mcp.json.tmpl" >"$PI_MCP"
+chezmoi execute-template --source "$ROOT" <"$ROOT/dot_cursor/mcp.json.tmpl" >"$CURSOR_MCP"
 
 assert_file_contains "$RENDERED" 'model = "gpt-5.5"'
 assert_file_contains "$RENDERED" 'model_reasoning_effort = "xhigh"'
@@ -68,6 +72,9 @@ assert_file_contains "$RENDERED" '[model_providers.krill]'
 assert_file_contains "$RENDERED" 'base_url = "https://api.krill-ai.com/codex/v1"'
 assert_file_contains "$RENDERED" 'requires_openai_auth = true'
 assert_file_contains "$RENDERED" 'wire_api = "responses"'
+assert_file_contains "$RENDERED" '[mcp_servers.codegraph]'
+assert_file_contains "$RENDERED" 'command = "bunx"'
+assert_file_contains "$RENDERED" 'args = ["@colbymchenry/codegraph@1.2.0", "serve", "--mcp"]'
 
 assert_file_contains "$CLAUDE_SETTINGS" '"UserPromptSubmit"'
 assert_file_contains "$CLAUDE_SETTINGS" 'tmux-ai-agent-state claude busy'
@@ -75,6 +82,19 @@ assert_file_contains "$CLAUDE_SETTINGS" '"SessionEnd"'
 assert_file_contains "$CLAUDE_SETTINGS" '"Stop"'
 assert_file_contains "$CLAUDE_SETTINGS" 'tmux-ai-agent-state claude idle'
 assert_file_not_contains "$CLAUDE_SETTINGS" '"SubagentStop"'
+assert_file_not_contains "$CLAUDE_SETTINGS" '"Bash(codegraph:*)"'
+assert_file_contains "$CLAUDE_SETTINGS" '"mcp__codegraph__*"'
+
+assert_file_contains "$PI_MCP" '"codegraph"'
+assert_file_contains "$PI_MCP" '"command": "bunx"'
+assert_file_contains "$PI_MCP" '"@colbymchenry/codegraph@1.2.0"'
+assert_file_contains "$PI_MCP" '"serve"'
+assert_file_contains "$PI_MCP" '"--mcp"'
+assert_file_contains "$CURSOR_MCP" '"codegraph"'
+assert_file_contains "$CURSOR_MCP" '"command": "bunx"'
+assert_file_contains "$CURSOR_MCP" '"@colbymchenry/codegraph@1.2.0"'
+assert_file_contains "$CURSOR_MCP" '"serve"'
+assert_file_contains "$CURSOR_MCP" '"--mcp"'
 
 chezmoi execute-template --source "$ROOT" \
     --override-data '{"claudeProviderAccount":"deepseek@private"}' \


### PR DESCRIPTION
## Summary
- configure CodeGraph MCP for Codex, Claude, Pi, and Cursor through on-demand `bunx @colbymchenry/codegraph@1.2.0 serve --mcp`
- keep CodeGraph guidance in the shared AI instructions, with per-repo init via `bunx @colbymchenry/codegraph@1.2.0 init`
- remove Gemini CLI and Antigravity managed surfaces from the dotfiles setup

## Validation
- `bash tests/test_codex_config_rendering.sh`
- `bash tests/check_templates.sh`
- `bash tests/test_toolchain_bootstrap.sh`
- `bash tests/test_skill_library.sh`
- `git diff --check`
- `git diff --cached --check`
- pre-commit hooks from amended commit

## Local Apply
- applied Codex, Pi, Cursor, Claude instruction, mise, and mcp-reaper targets with `chezmoi apply`
- synced Claude user MCP registry so `codegraph` now runs `bunx @colbymchenry/codegraph@1.2.0 serve --mcp`
- removed local CodeGraph wrapper and mise-installed CodeGraph versions/caches