### PR TITLE
feat(ai): scale reasoning effort by environment

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -16,6 +16,10 @@
 {{- $provider := index .claude.providers $providerName -}}
 {{- /* Get defaults */ -}}
 {{- $defaults := .claude.defaults -}}
+{{- /* work flag may be absent when rendered without chezmoi config data (tests);
+       default to the personal/hot profile in that case. */ -}}
+{{- $work := false -}}
+{{- if hasKey . "work" -}}{{- $work = .work -}}{{- end -}}
 
 {
   "apiKeyHelper": "{{- if and $provider (hasKey $provider "base_url") -}}~/.local/bin/claude-token{{- end -}}",
@@ -270,5 +274,5 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "alwaysThinkingEnabled": true,
-  "effortLevel": "{{ if .work }}medium{{ else }}max{{ end }}"
+  "effortLevel": "{{ if $work }}medium{{ else }}max{{ end }}"
 }

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -270,5 +270,5 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "alwaysThinkingEnabled": true,
-  "effortLevel": "xhigh"
+  "effortLevel": "{{ if .work }}medium{{ else }}max{{ end }}"
 }

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -17,6 +17,11 @@ cat <<'CHEZMOI_TEMPLATE_EOF'
 {{-   $accountKey = .codexProviderAccount -}}
 {{- end -}}
 {{- $providerName := (split "@" $accountKey)._0 -}}
+{{- /* work flag may be absent when the template is rendered without chezmoi
+       config data (e.g. tests via `chezmoi execute-template`); default to the
+       personal/hot profile in that case. */ -}}
+{{- $work := false -}}
+{{- if hasKey . "work" -}}{{- $work = .work -}}{{- end -}}
 
 # =============================================================================
 # Core Settings
@@ -54,7 +59,7 @@ suppress_unstable_features_warning = true
 
 # Reasoning effort: none | minimal | low | medium | high | xhigh
 # Work machines run medium; personal machines run xhigh.
-model_reasoning_effort = "{{ if .work }}medium{{ else }}xhigh{{ end }}"
+model_reasoning_effort = "{{ if $work }}medium{{ else }}xhigh{{ end }}"
 
 
 # Personality: none | friendly | pragmatic

--- a/dot_codex/modify_config.toml.tmpl
+++ b/dot_codex/modify_config.toml.tmpl
@@ -53,7 +53,8 @@ suppress_unstable_features_warning = true
 # =============================================================================
 
 # Reasoning effort: none | minimal | low | medium | high | xhigh
-model_reasoning_effort = "xhigh"
+# Work machines run medium; personal machines run xhigh.
+model_reasoning_effort = "{{ if .work }}medium{{ else }}xhigh{{ end }}"
 
 
 # Personality: none | friendly | pragmatic

--- a/tests/test_codex_config_rendering.sh
+++ b/tests/test_codex_config_rendering.sh
@@ -105,6 +105,37 @@ assert_file_not_contains "$KRILL_CLAUDE_SETTINGS" 'CLAUDE_CODE_EFFORT_LEVEL'
 assert_file_not_contains "$CLAUDE_SETTINGS" 'CLAUDE_CODE_ATTRIBUTION_HEADER'
 assert_file_not_contains "$CLAUDE_SETTINGS" 'SUPPORTED_CAPABILITIES'
 
+# Reasoning effort is per-environment (independent of the tester's own machine):
+# personal machines run hot, work machines run medium. Render both explicitly via
+# --override-data so the assertions don't depend on the ambient work/private value.
+
+# Personal render (work=false): Codex default is xhigh, and the named [profiles.*]
+# keep xhigh too, so "medium" must not appear anywhere. Claude runs max.
+PERSONAL_CODEX_MODIFY="$TMP_ROOT/modify_config-personal.sh"
+PERSONAL_CODEX="$TMP_ROOT/config-personal.toml"
+PERSONAL_CLAUDE_SETTINGS="$TMP_ROOT/settings-personal.json"
+chezmoi execute-template --source "$ROOT" --override-data '{"work":false}' \
+    <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$PERSONAL_CODEX_MODIFY"
+bash "$PERSONAL_CODEX_MODIFY" </dev/null >"$PERSONAL_CODEX"
+assert_file_contains "$PERSONAL_CODEX" 'model_reasoning_effort = "xhigh"'
+assert_file_not_contains "$PERSONAL_CODEX" 'model_reasoning_effort = "medium"'
+chezmoi execute-template --source "$ROOT" --override-data '{"work":false}' \
+    <"$ROOT/dot_claude/settings.json.tmpl" >"$PERSONAL_CLAUDE_SETTINGS"
+assert_file_contains "$PERSONAL_CLAUDE_SETTINGS" '"effortLevel": "max"'
+
+# Work render (work=true): Codex default drops to medium (deep-review/research
+# profiles still pin xhigh), and Claude drops to medium.
+WORK_CODEX_MODIFY="$TMP_ROOT/modify_config-work.sh"
+WORK_CODEX="$TMP_ROOT/config-work.toml"
+WORK_CLAUDE_SETTINGS="$TMP_ROOT/settings-work.json"
+chezmoi execute-template --source "$ROOT" --override-data '{"work":true}' \
+    <"$ROOT/dot_codex/modify_config.toml.tmpl" >"$WORK_CODEX_MODIFY"
+bash "$WORK_CODEX_MODIFY" </dev/null >"$WORK_CODEX"
+assert_file_contains "$WORK_CODEX" 'model_reasoning_effort = "medium"'
+chezmoi execute-template --source "$ROOT" --override-data '{"work":true}' \
+    <"$ROOT/dot_claude/settings.json.tmpl" >"$WORK_CLAUDE_SETTINGS"
+assert_file_contains "$WORK_CLAUDE_SETTINGS" '"effortLevel": "medium"'
+
 cat >"$TMP_ROOT/existing-config.toml" <<'EOF'
 model = "old-model"
 


### PR DESCRIPTION
## What

Reasoning effort for Claude Code and Codex was hardcoded to `xhigh` on every machine. This drives it off the existing `work` data flag so personal machines run hot and work machines run a lighter default.

| Environment | Claude (`effortLevel`) | Codex (`model_reasoning_effort`) |
|-------------|------------------------|----------------------------------|
| personal (`work=false`) | `max` | `xhigh` |
| work (`work=true`) | `medium` | `medium` |

## Changes

- `dot_claude/settings.json.tmpl` — `effortLevel` now `{{ if .work }}medium{{ else }}max{{ end }}`
- `dot_codex/modify_config.toml.tmpl` — top-level `model_reasoning_effort` now `{{ if .work }}medium{{ else }}xhigh{{ end }}`
- `tests/test_codex_config_rendering.sh` — asserts both environments via `--override-data`, independent of the tester's own machine

## Notes

- Codex's named `[profiles.deep-review]` / `[profiles.research]` intentionally keep `xhigh` — they are opt-in overrides, not the default.
- Verified: `test_codex_config_rendering`, `test_codex_model_selection`, `test_profile_alignment`, and `check_templates` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)