### PR TITLE
fix(gopass): don't treat empty store dir as initialized

### DIFF
--- a/.chezmoiscripts/run_onchange_after_06_setup-gopass.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_06_setup-gopass.sh.tmpl
@@ -17,10 +17,18 @@ fi
 
 echo ":: [06] Setting up gopass password store"
 
-# Check if gopass store already exists
-if [[ -d ~/.local/share/gopass/stores/root ]]; then
+# Check if gopass store already exists.
+# A valid store is a cloned git repo; a bare empty directory (e.g. left behind by
+# a failed clone or created by `gopass config`) must NOT count as "already set up",
+# otherwise this script silently skips the clone and the store never initializes.
+store_dir=~/.local/share/gopass/stores/root
+if [[ -d "$store_dir/.git" ]]; then
     echo "✓ gopass store already exists"
     exit 0
+fi
+if [[ -d "$store_dir" ]] && [[ -z "$(ls -A "$store_dir" 2>/dev/null)" ]]; then
+    echo "⚠ Removing empty gopass store directory (not a valid store): $store_dir"
+    rmdir "$store_dir"
 fi
 
 # Check if age key exists


### PR DESCRIPTION
## Problem

On a new device, `06_setup-gopass` guarded only on the store **directory existing**:

```bash
if [[ -d ~/.local/share/gopass/stores/root ]]; then
    echo "✓ gopass store already exists"
    exit 0
fi
```

An **empty** directory — left behind by a failed clone, or created as a side effect of `gopass config` — satisfies this check. So bootstrap printed `✓ gopass store already exists` and exited **without ever cloning**. The store stayed uninitialized (`gopass ls` → `password-store is not initialized`), and anything reading secrets from it (e.g. MCP wrappers) failed silently.

## Fix

- Guard on `$store_dir/.git` presence — the real marker of a cloned store — instead of bare directory existence.
- If a stray **empty** store dir is found, `rmdir` it so the subsequent `gopass clone` can proceed on re-run.

Rendered output passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)