### PR TITLE
chore: remove obsidian config

### DIFF
--- a/.chezmoidata/hammerspoon.yaml
+++ b/.chezmoidata/hammerspoon.yaml
@@ -32,8 +32,6 @@ hammerspoon:
     work:
       - app: DBeaver
         ime: en
-      - app: Obsidian
-        ime: jp
       # Browsers/Communication -> Japanese for work
       - app: Slack
         ime: jp

--- a/.chezmoidata/homebrew.yaml
+++ b/.chezmoidata/homebrew.yaml
@@ -49,7 +49,6 @@ homebrew:
       - google-chrome
     work:
       - dbeaver-community
-      - obsidian
       # cursor-cli ships Anysphere-signed native .node modules. macOS/MDM tags the
       # freshly-installed files with com.apple.quarantine, so Gatekeeper blocks
       # dlopen ("library load disallowed by system policy") and cursor-agent crashes.


### PR DESCRIPTION
## Summary
- Remove the `obsidian` Homebrew cask from the `work` profile (`.chezmoidata/homebrew.yaml`)
- Remove the Obsidian per-app IME mapping (jp) from the `work` profile (`.chezmoidata/hammerspoon.yaml`)

Verified there are no remaining `obsidian` references anywhere in the source tree.

## Notes
- Already-installed Obsidian is not auto-removed; run `brew uninstall --cask obsidian` manually if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)