### PR TITLE
fix(lazygit): use lowercase <c-r> for resetCherryPick keybinding

### DIFF
--- a/private_dot_config/lazygit/config.yml
+++ b/private_dot_config/lazygit/config.yml
@@ -430,7 +430,7 @@ keybinding:
     markCommitAsBaseForRebase: B
     tagCommit: T
     checkoutCommit: <space>
-    resetCherryPick: <c-R>
+    resetCherryPick: <c-r>
     copyCommitAttributeToClipboard: "y"
     openLogMenu: <c-l>
     openInBrowser: o


### PR DESCRIPTION
## Problem

`lazygit` (0.62.2) prints a config validation error on every launch:

```
The config at `~/.config/lazygit/config.yml` has a validation error.
Unrecognized key '<c-R>' for keybinding 'Commits.ResetCherryPick[0]'.
```

## Root cause

This config is a full dump of lazygit defaults. Older lazygit wrote the
`resetCherryPick` default as the uppercase `<c-R>` (to visually distinguish
it from `openRecentRepos`'s `<c-r>`). Newer lazygit tightened config
validation, and its permitted-key set only accepts the lowercase `<c-r>` —
terminals can't distinguish ctrl+shift+r from ctrl+r. Out-of-the-box users
never see this because the value isn't in their YAML; it only surfaces here
because the defaults were written out explicitly.

## Fix

Lowercase line 433: `resetCherryPick: <c-R>` → `<c-r>`.

- Matches the `<c-x>` notation used everywhere else in this file.
- The overlap with the universal `openRecentRepos: <c-r>` is intentional and
  mirrors lazygit's own defaults (both default to ctrl+r) — the
  commits-context binding wins inside the commits panel, so no behavior
  changes.

## Verification

Tested against the installed lazygit 0.62.2 binary:

| value       | validator result        |
|-------------|-------------------------|
| `<c-R>`     | validation error (repro)|
| `<c-r>`     | clean                   |
| `<ctrl+r>`  | clean (current default) |

Real config now loads with no validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
