### PR TITLE
feat: add vibetunnel via cross-platform npm script

### DIFF
--- a/.chezmoidata/versions.yaml
+++ b/.chezmoidata/versions.yaml
@@ -12,6 +12,7 @@ versions:
   aquaVersion: v2.60.1
   nixIndexDb: 2026-07-02-200945
   paperlib: 3.1.12
+  vibetunnel: 1.0.0-beta.17
   claudeWshobsonAgentsRev: 5cc2549a50fc672230efd0a0307e2fd27ffba792
   claudeWshobsonAgentsSha256: c65f98eaede6979e684def3d7c97c0327cef9cdeb9fb66b18fe63c5369004ee3
   claudeAnthropicsSkillsRev: 9d2f1ae187231d8199c64b5b762e1bdf2244733d

--- a/.chezmoiscripts/run_onchange_after_20_install-vibetunnel.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20_install-vibetunnel.sh.tmpl
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# VibeTunnel: browser-accessible terminal server. Wraps a local shell / AI coding
+# session and exposes it on a web dashboard (default http://localhost:4020) so it
+# can be driven from any device's browser. Cross-platform (darwin + linux).
+#
+# Why a bespoke script instead of mise or the Homebrew cask:
+#   - The Homebrew cask is macOS-only; we want one channel for every machine.
+#   - vibetunnel publishes ONLY prereleases to npm (no stable release yet). mise's
+#     npm backend hides prereleases behind the *global* `prereleases` setting, so
+#     enabling it for vibetunnel would also let node/bun/go/rust/... resolve to
+#     prereleases. Not worth it for one tool.
+#   - So install via npm straight into ~/.local (stable, already on PATH). npm runs
+#     the package's native-module postinstall by default — no bun `--trust` dance.
+#
+# Upgrade by bumping `versions.vibetunnel` in .chezmoidata/versions.yaml
+# (that changes this rendered script, so run_onchange re-runs it).
+
+VERSION="{{ .versions.vibetunnel }}"
+
+echo ":: [20] Installing VibeTunnel (vibetunnel@${VERSION})"
+
+# npm comes from mise-managed node; make it discoverable in this non-interactive shell.
+if ! command -v npm >/dev/null 2>&1; then
+    mise_cmd="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/mise"
+    [[ -x "$mise_cmd" ]] && eval "$("$mise_cmd" activate bash)" 2>/dev/null || true
+fi
+if ! command -v npm >/dev/null 2>&1; then
+    echo "    Skipped (npm not found; needs mise-managed node)"
+    exit 0
+fi
+
+# Idempotent: skip when the pinned version is already the one installed.
+installed="$(vibetunnel version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | head -1 || true)"
+if [[ "$installed" == "$VERSION" ]]; then
+    echo "    Already at ${VERSION}"
+    exit 0
+fi
+
+npm install -g --prefix "$HOME/.local" "vibetunnel@${VERSION}"
+echo "    Installed → $HOME/.local/bin/vibetunnel (vibetunnel@${VERSION})"


### PR DESCRIPTION
## What

Adds **VibeTunnel** (browser-accessible terminal server — drive shells / AI coding sessions from any device's web dashboard) as a uniform **darwin + linux** channel.

- `.chezmoidata/versions.yaml`: pin `vibetunnel: 1.0.0-beta.17`
- `.chezmoiscripts/run_onchange_after_20_install-vibetunnel.sh.tmpl`: install via `npm install -g --prefix ~/.local`

## Why not the cask or mise

- The Homebrew **cask is macOS-only**; goal is one channel per machine.
- vibetunnel publishes **only prereleases** to npm (`1.0.0-beta.x`, no stable). mise's npm backend hides prereleases behind the **global-only** `prereleases` setting — enabling it would also let `node/bun/go/rust = "latest"` resolve to prereleases. Not worth it for one tool.
- So npm-into-`~/.local`: bin lands on PATH, stable across node bumps, and npm runs the package's native-module `postinstall` by default (no bun `--trust` needed). This repo has no bun-global-on-PATH setup, so `bun add -g` isn't a viable target.

## Notes

- Idempotent: `run_onchange` re-runs when the pinned version changes; same version is skipped.
- Upgrade by bumping `versions.vibetunnel`.
- Usage: `vibetunnel` (server, :4020) · `vibetunnel fwd <cmd>` (= the Mac app's `vt`) · `vibetunnel systemd install` (Linux service). The npm build ships the `vibetunnel` server only — the menu-bar UI / `vt` wrapper are cask-exclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)