### PR TITLE
feat(mise): add hyperframes video-render CLI

### DIFF
--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -71,6 +71,18 @@ lua = "5.4"
 # to fetch Chrome for Testing (or it auto-detects an existing Chrome/Brave).
 "npm:agent-browser" = "latest"
 
+# hyperframes (HeyGen): render HTML/CSS/animations to deterministic MP4. Bin is
+# `hyperframes`. Needs node>=22 (satisfied above) + ffmpeg (nix profile);
+# puppeteer-core fetches Chrome for Testing on first render. AI-agent skills are
+# NOT managed as chezmoi externals — the CLI self-installs them globally into
+# ~/.claude/skills + ~/.agents/skills (fanned out to every agent) via a one-off
+# `hyperframes skills`; run `hyperframes skills update` to refresh.
+# NOTE: bun skips postinstall, so onnxruntime-node's native lib is not fetched.
+# Core render works without it; voiceover/transcription/background-removal (the
+# media skills) do not. If those error on a missing binary, switch this entry to
+#   "npm:hyperframes" = { version = "latest", bun_args = "--trust" }
+"npm:hyperframes" = "latest"
+
 [settings]
 # Keep auto_install enabled for normal mise workflow.
 # Process storms were caused by shell PATH/init ordering, not this flag.


### PR DESCRIPTION
## What
Add the `hyperframes` CLI (HeyGen **HyperFrames** — write HTML/CSS/animations, render deterministic MP4) to the mise `npm:` tool set.

## Why
Programmatic, reproducible video generation from HTML compositions, driven by AI agents. Requirements were already met by the existing toolchain, so this is a one-line tool addition (plus an explanatory comment).

## Verification
- `mise install` → `hyperframes@0.7.26` installed via the bun npm backend.
- `hyperframes doctor`: **Node v24.16.0 / FFmpeg 8.1.1 / system Chrome** all ✓ — core render path ready.
- Optional media deps flagged by doctor (whisper-cpp, Kokoro TTS, MusicGen) are external `brew`/`pip` installs, **not** required for rendering.

## Notes
- **Skills** are not managed as externals here — installed on demand via `hyperframes skills` (self-installs to `~/.claude/skills` + `~/.agents/skills`). Rationale is in the mise entry's comment.
- bun (the npm installer) skips postinstall scripts. Core render is unaffected; if local voiceover/transcription later errors on a missing `onnxruntime-node` binary, switch the entry to `{ version = "latest", bun_args = "--trust" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
