### PR TITLE
feat(pi): add 3 zero-dep extensions — retry, caffeinate, goal

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -74,6 +74,19 @@ pi:
     # reducers + evidence record; rewrites shell/read/grep/find/ls and proxies
     # MCP to cut context pollution. Top-downloaded Pi package; pairs with readseek.
     - npm:@hypabolic/pi-hypa
+    # retry: widens what counts as retryable (provider "unknown error", Codex
+    # ws-limit, and a stall watchdog that aborts a frozen stream after ~90s) and
+    # hands off to Pi's built-in retry path. COMPLEMENTS defaults.retry above
+    # (that caps backoff; this adds trigger conditions). Zero deps/config.
+    - npm:@narumitw/pi-retry
+    # caffeinate: inhibits macOS sleep (system `caffeinate`) while the agent is
+    # processing a long turn; releases on idle/shutdown. /caffeinate to control.
+    # Zero deps. Disable with PI_CAFFEINATE_DISABLED=1.
+    - npm:@narumitw/pi-caffeinate
+    # goal: `/goal <objective>` autonomous mode — keeps working until goal_complete
+    # or a token budget (--tokens) is hit. Pairs well with GLM-5.2's 1M context.
+    # Zero deps; state is session-scoped.
+    - npm:@narumitw/pi-goal
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
   # Model routing for pi-subagents builtins. Quality-first: default pro, recon
   # agents on flash. For cost-aggressive: defaultModel=flash + override


### PR DESCRIPTION
## Summary

Audited all 10 extensions in [narumiruna/pi-extensions](https://github.com/narumiruna/pi-extensions) and added the 3 that are zero-dependency, macOS-native, and don't overlap the existing stack.

| Added | What it does |
|---|---|
| **@narumitw/pi-retry** | Widens retryable conditions (provider "unknown error", Codex ws-limit, 90s stall watchdog) → hands to Pi's built-in retry. **Complements** `defaults.retry` (which only caps backoff) — not redundant. |
| **@narumitw/pi-caffeinate** | Inhibits macOS sleep during long agent turns (system `caffeinate`). `/caffeinate` to control; `PI_CAFFEINATE_DISABLED=1` to disable. |
| **@narumitw/pi-goal** | `/goal <objective>` autonomous mode until `goal_complete` or a `--tokens` budget. Pairs with GLM-5.2's 1M context. |

**Skipped** (with reasons): firecrawl (needs paid Firecrawl API key; pi-web-access covers), chrome-devtools (overlaps agent-browser CLI), sync (needs Cloudflare R2 — conflicts with chezmoi), codex-usage (Codex-only; we use GLM/DeepSeek), lsp (repo is shell/nix/yaml — low value), btw (partial overlap w/ hypa), @narumitw/pi-subagents (overlaps existing pi-subagents; not worth replacement risk).

## Verification
- Installed via bun (`npmCommand=["bun"]`); all in `bun.lock`, no postinstall scripts, clean.
- `pi -p` smoke: 11 packages load, returns OK, no hang.
- Pre-commit hooks pass (treefmt, gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)