### PR TITLE
feat(pi): open permission defaults, keep sensitive-file deny

### DIFF
--- a/dot_pi/agent/extensions/pi-permission-system/config.json
+++ b/dot_pi/agent/extensions/pi-permission-system/config.json
@@ -12,21 +12,10 @@
       "**/.config/gopass/*": "deny"
     },
     "bash": {
-      "*": "allow",
-      "rm -rf *": "ask",
-      "rm -fr *": "ask",
-      "sudo *": "ask",
-      "git push --force*": "ask",
-      "git push -f *": "ask",
-      "git push * --force*": "ask",
-      "dd *": "deny",
-      "mkfs*": "deny"
+      "*": "allow"
     },
     "external_directory": {
-      "*": "ask",
-      "~/.pi/*": "allow",
-      "~/.cargo/registry/*": "allow",
-      "~/.local/share/mise/*": "allow"
+      "*": "allow"
     }
   }
 }


### PR DESCRIPTION
## Summary

Relax Pi's permission defaults to remove day-to-day friction, while sensitive files stay blocked.

**pi-permission-system `config.json`:**
- `bash`: now `"*": "allow"` (was: guarded `rm -rf`/`sudo`/`git push --force` → ask, `dd`/`mkfs` → deny).
- `external_directory`: now `"*": "allow"` (was `"*": "ask"` — the main source of prompts).
- **Path deny-list unchanged** — sensitive files remain blocked: `.env` / `.ssh` / `.gnupg` / gopass / `.aws/credentials`.

**landstrip `sandbox.json`** independently keeps its `denyWrite` for `.env` / `.pem` / `.key` / `.ssh` — a second layer over sensitive files.

Net: open-by-default, only sensitive files denied — per request.

## Verification
- `jq -e` confirms strict JSON (permission-system fails **closed**, so valid JSON is mandatory).
- Applied to live; live == source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)