### PR TITLE
feat(pi): default effort xhigh; statusline back to default preset

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -16,7 +16,9 @@ pi:
     # hot-reloads on edit). All footer/TUI semantic colors follow this theme —
     # no per-plugin color config or seed script needed.
     theme: signalridge-dracula
-    defaultThinkingLevel: medium
+    # Max reasoning effort by default (off<minimal<low<medium<high<xhigh).
+    # Override per-turn in the TUI; subagents still use their own model routing.
+    defaultThinkingLevel: xhigh
     # GLM-5.2 via the NewAPI gateway (https://newapi.3689403.xyz/) is the startup
     # default: key baked into models.json from gopass (claude/newapi/private/
     # api_key), so plain `pi` works out of the box. DeepSeek V4 also wired (gopass)
@@ -43,13 +45,11 @@ pi:
   # dedicated chezmoi installer script.
   packages:
     - npm:pi-mcp-adapter
-    # Information-rich statusline footer (@narumitw/pi-statusline). classic preset
-    # (env PI_STATUSLINE_PRESET=classic) uses Pi THEME colors → follows
-    # signalridge-dracula; emoji segment icons (🤖🧠📁🌿🪟🔢💸🕒) render in any
-    # font (no Nerd-glyph mojibake). Has own model/dir/git/context/tokens/cost/
-    # clock segments + 2nd line for other-extension statuses. Config:
+    # Information-rich statusline footer (@narumitw/pi-statusline). Uses its
+    # default preset (tokyo-night). To make it follow the Pi theme instead, set
+    # env PI_STATUSLINE_PRESET=classic. Segments: model/dir/git/context/tokens/
+    # cost/clock + 2nd line for other-extension statuses. Config:
     # ~/.pi/agent/pi-statusline-settings.json (extensionStatusIcons emoji map).
-    # Replaces pi-powerline-footer (hardcoded pink/teal + nerd-glyph mojibake).
     - npm:@narumitw/pi-statusline
     # Subagent delegation: child Pi sessions (NOT worktrees) for scout/researcher/
     # planner/worker/reviewer/oracle/context-builder/delegate. Natural-language

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -66,11 +66,6 @@ fi
 export TLRC_CONFIG="${TLRC_CONFIG:-${XDG_CONFIG_HOME}/tlrc/config.toml}"
 export SLUMBER_CONFIG_PATH="${SLUMBER_CONFIG_PATH:-${XDG_CONFIG_HOME}/slumber/config.yml}"
 
-# Pi statusline (@narumitw/pi-statusline): `classic` preset uses Pi theme colors
-# (follows signalridge-dracula); the plugin default is `tokyo-night` (hardcoded
-# palette), so pin classic here — the plugin only reads this from the env.
-export PI_STATUSLINE_PRESET="${PI_STATUSLINE_PRESET:-classic}"
-
 # Mermaid CLI (mmdc): the nix mermaid-cli ships no Chromium on macOS, so puppeteer
 # can't launch a browser. Point it at the installed Google Chrome (no-op elsewhere).
 [[ -z "${PUPPETEER_EXECUTABLE_PATH:-}" && -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]] \


### PR DESCRIPTION
## Summary

`defaultThinkingLevel: medium → xhigh` — the highest level Pi accepts.

Pi's thinking-level enum is `off < minimal < low < medium < high < xhigh`; there is **no** `max` thinking level. For DeepSeek, the existing compat `reasoningEffortMap` maps `xhigh → max`, so this reaches the provider's top effort; for GLM (the default via newapi) it's Pi's native max. Override per-turn in the TUI; subagents keep their own model routing.

## Verification
- Applied to live; `jq .defaultThinkingLevel ~/.pi/agent/settings.json` → `xhigh`.
- Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)