### PR TITLE
fix(pi): set HYPA_BIN so hypa-rewritten grep/shell stop failing (127)

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -74,3 +74,7 @@ export SLUMBER_CONFIG_PATH="${SLUMBER_CONFIG_PATH:-${XDG_CONFIG_HOME}/slumber/co
 # Pi statusline (@narumitw/pi-statusline): classic preset follows the Pi theme
 # (signalridge-dracula); default tokyo-night is hardcoded blue-gray.
 export PI_STATUSLINE_PRESET="${PI_STATUSLINE_PRESET:-classic}"
+
+# pi-hypa rewrites shell/grep/find into a `hypa` CLI call; point it at the
+# bundled binary so bash finds it (the npm .bin dir isn't on PATH → code 127).
+export HYPA_BIN="${HYPA_BIN:-$HOME/.pi/agent/npm/node_modules/@hypabolic/hypa-darwin-arm64/bin/hypa}"


### PR DESCRIPTION
## Summary

`@hypabolic/pi-hypa` rewrites shell/grep/find/ls into a `hypa` CLI call, but the bun-managed npm `.bin` dir isn't on the shell PATH → `hypa: command not found` (code 127) + a ~117s timeout on **every grep** in a Pi session. pi-hypa reads its binary from the `HYPA_BIN` env (`policy.ts`), so `.zshenv` now points it at the bundled native binary.

**Verified**: `pi -p` grep now runs, 0×127, returns correct results.

Also audited all 11 plugins' external-command spawns: only `hypa` (fixed) and an optional `yt-dlp` (pi-web-access, YouTube frames only) are off-PATH; everything else (ffmpeg/gh/git/npm/man/which) resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)