### PR TITLE
chore(aqua): manage cargo-dist via aqua (was live-only)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,6 +18,7 @@ packages:
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
   - name: atuinsh/atuin@v18.16.1
+  - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
   - name: eth-p/bat-extras@v2024.08.24


### PR DESCRIPTION
## Summary

`dist` (cargo-dist) was a **live-only** `cargo install` — outside the dotfiles, so it wouldn't reproduce on a fresh machine. Declared it in aqua (`axodotdev/cargo-dist@v0.32.0`) like the other CLI tools; removed the live cargo binary (`which dist` now resolves to the aqua-managed version).

Part of clearing live-only install drift:
- removed the unmanaged **remnic** memory stack (daemon + Pi connector + npm + gopass token — all live-only, never chezmoi-managed)
- deleted stray **semgrep** / **mkdocs** uv tools
- de-duplicated **git-cliff** (aqua already managed it; a redundant cargo copy existed)

After this, `~/.cargo/bin` holds only the Rust toolchain — zero stray binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)