### PR TITLE
chore(aqua): update pinned packages (2026-07-06)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -59,7 +59,7 @@ packages:
   - name: casey/just@1.55.1
   - name: jesseduffield/lazygit@v0.63.0
   - name: jesseduffield/lazydocker@v0.25.2
-  - name: neovim/neovim@v0.12.3
+  - name: neovim/neovim@v0.12.4
   - name: LuaLS/lua-language-server@3.18.2
   - name: tree-sitter/tree-sitter@v0.26.10
   - name: jj-vcs/jj@v0.43.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.