### PR TITLE
fix(pi): add hypa PATH shim; drop pi-landstrip sandbox

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -72,10 +72,6 @@ pi:
     # readseek: hash-anchored read/edit/grep + structural code maps/search
     # (complements serena's semantic nav with hash-anchored edit safety).
     - npm:pi-readseek
-    # OS-level sandbox with interactive permission prompts (@landstrip/landstrip
-    # backend). NOTE: Landlock is Linux-only — verify the macOS backend actually
-    # sandboxes post-install before relying on it.
-    - npm:pi-landstrip
     # hypa: local context runtime — long-context compression, deterministic
     # reducers + evidence record; rewrites shell/read/grep/find/ls and proxies
     # MCP to cut context pollution. Top-downloaded Pi package; pairs with readseek.

--- a/dot_local/bin/executable_hypa
+++ b/dot_local/bin/executable_hypa
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# hypa CLI shim (chezmoi-managed) — makes `hypa` resolvable on PATH for Pi.
+#
+# Why this exists:
+#   @hypabolic/pi-hypa intercepts Pi's bash tool and rewrites commands through the
+#   `hypa rewrite` engine, which emits BARE `hypa` tokens, e.g.
+#       git status --short && echo hi
+#     → hypa git status --short && hypa -c "echo hi"
+#   Pi then runs that string via `/bin/bash -c ...`, so bash does a PATH lookup for
+#   `hypa`. With no `hypa` on PATH the command dies with "command not found" (127)
+#   and a long rewrite-timeout stall on every command.
+#
+#   pi-hypa's postinstall.js is meant to install exactly this shim to ~/.local/bin,
+#   but bun does not run dependency postinstall scripts, so the shim is never
+#   created. chezmoi owns it here instead (~/.local/bin is already on PATH).
+#
+#   NOTE: HYPA_BIN alone does NOT fix the 127 — pi-hypa only consults it for its own
+#   internal pi.exec() (the rewrite step + hypa_* tools), never for the rewritten
+#   bash string that bash actually executes. PATH is the only lever for that.
+#
+# Resolution order (fast path first — this runs once per rewritten command):
+#   1. $HYPA_BIN (dot_zshenv points it at the bundled native binary)
+#   2. the arch-matched bundled native binary (portable, no node startup)
+#   3. the bundled node launcher bin.js (arch-agnostic last resort)
+set -eu
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)              arch=darwin-arm64 ;;
+  Darwin-x86_64)             arch=darwin-x64 ;;
+  Linux-aarch64|Linux-arm64) arch=linux-arm64 ;;
+  Linux-x86_64)              arch=linux-x64 ;;
+  *)                         arch= ;;
+esac
+
+for candidate in \
+  "${HYPA_BIN:-}" \
+  "${arch:+$HOME/.pi/agent/npm/node_modules/@hypabolic/hypa-$arch/bin/hypa}"
+do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    exec "$candidate" "$@"
+  fi
+done
+
+launcher="$HOME/.pi/agent/npm/node_modules/@hypabolic/hypa/bin.js"
+if [ -f "$launcher" ]; then
+  exec node "$launcher" "$@"
+fi
+
+echo "hypa shim: no pi-bundled hypa binary found (checked \$HYPA_BIN, arch dir, bin.js)" >&2
+exit 127

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -75,6 +75,10 @@ export SLUMBER_CONFIG_PATH="${SLUMBER_CONFIG_PATH:-${XDG_CONFIG_HOME}/slumber/co
 # (catppuccin-mocha); default tokyo-night is hardcoded blue-gray.
 export PI_STATUSLINE_PRESET="${PI_STATUSLINE_PRESET:-classic}"
 
-# pi-hypa rewrites shell/grep/find into a `hypa` CLI call; point it at the
-# bundled binary so bash finds it (the npm .bin dir isn't on PATH → code 127).
+# pi-hypa rewrites Pi's bash commands into bare `hypa …` calls. Two separate needs:
+#   - the `hypa` token in the rewritten string must be on PATH (else code 127) —
+#     handled by the ~/.local/bin/hypa shim (dot_local/bin/executable_hypa);
+#   - pi-hypa's own pi.exec() (rewrite step + hypa_* tools) reads HYPA_BIN below.
+# HYPA_BIN does NOT satisfy the PATH need; it only points pi.exec/the shim's fast
+# path at the bundled native binary (skips the node launcher).
 export HYPA_BIN="${HYPA_BIN:-$HOME/.pi/agent/npm/node_modules/@hypabolic/hypa-darwin-arm64/bin/hypa}"


### PR DESCRIPTION
## What

- **hypa PATH shim** (`dot_local/bin/executable_hypa` → `~/.local/bin/hypa`): pi-hypa's rewrite engine emits bare `hypa …` tokens that Pi runs via `/bin/bash -c`; without `hypa` on PATH they fail with **127** (+ rewrite-timeout stall). bun doesn't run pi-hypa's postinstall that installs this shim, so chezmoi owns it. Resolves `$HYPA_BIN` → arch-native binary → `node bin.js`.
- **dot_zshenv**: corrected the misleading `HYPA_BIN` comment — `HYPA_BIN` never feeds the rewritten bash string (only pi-hypa's internal `pi.exec`); PATH is the real lever.
- **Drop `pi-landstrip`** from `.chezmoidata/pi.yaml`: macOS has no Landlock, so its Seatbelt backend only snapshot-expands `denyWrite` at `sandbox_init` — a noisy `WARN` on every command + weak enforcement. `@gotgenes/pi-permission-system` (fail-closed) stays as the portable guardrail.

## Verified

- `bash -c 'hypa git status && hypa -c "echo hi"'` → exit **0** (was 127); grep round-trip → 0. Live `chezmoi apply` done.
- `~/.pi/agent/settings.json` packages no longer list landstrip; orphaned `~/.pi/agent/sandbox.json` removed.

## Notes

- Full effect on next `pi` start (running sessions keep old extensions loaded).
- Dropping the OS layer means autonomous `pi-goal` runs have no kernel backstop on macOS — use a container for unattended isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)