### PR TITLE
feat(pi): add pi-input-history (cross-session ↑/↓ + Ctrl+R fzf popup)

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -89,6 +89,15 @@ pi:
     # or a token budget (--tokens) is hit. Pairs well with GLM-5.2's 1M context.
     # Zero deps; state is session-scoped.
     - npm:@narumitw/pi-goal
+    # input-history: cross-session prompt history. Pi's built-in ↑/↓ history is
+    # in-memory / current-session only; this preloads prior prompts (per-cwd, via
+    # SessionManager.list — reads Pi's own session JSONL, NO separate state file)
+    # into the native ↑/↓ history AND adds Ctrl+R: an fzf/atuin-style reverse-search
+    # overlay (bottom-center popup, fuzzy multi-token match + highlight, ↑/↓ or
+    # Ctrl+R/Ctrl+S to cycle, Enter fills the editor, Esc/Ctrl+G cancels). Renders
+    # natively in Pi's TUI — no fzf/atuin binary, so it coexists with herdr/ghostty.
+    # Ctrl+R is free (herdr is prefix=ctrl+b; no bare Ctrl+R binding). Zero deps.
+    - npm:pi-input-history
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
   # Model routing for pi-subagents builtins. Quality-first: default pro, recon
   # agents on flash. For cost-aggressive: defaultModel=flash + override


### PR DESCRIPTION
## What

Adds `npm:pi-input-history` to the managed Pi package list (`.chezmoidata/pi.yaml` → `settings.json` packages).

Pi's built-in prompt history is **in-memory / current-session only** — a fresh `pi` has no history and `↑/↓` recall nothing from prior sessions. This package fixes both:

- **`↑/↓` cross-session**: on `session_start` it preloads prior prompts (per-cwd, sourced from Pi's own session JSONL via `SessionManager.list` — **no separate state file**) into the native editor history.
- **`Ctrl+R` fzf/atuin-style popup**: bottom-center overlay, live fuzzy multi-token match + match highlighting, `↑/↓` (or `Ctrl+R`/`Ctrl+S`) to cycle, `Enter` fills the editor, `Esc`/`Ctrl+G` cancels.

## Why this package

Evaluated 4 candidates by reading source:

| pkg | verdict |
|---|---|
| **`pi-input-history`** ✅ | current `@earendil-works/*` namespace (updated 2026-06); gives both ↑/↓ preload **and** the Ctrl+R popup |
| `@zigai/pi-prompt-history` | cleanest, most-downloaded, but **no popup** (↑/↓ only) |
| `@jasonish/pi-prompt-history` | nicest popup design but on the **dead `@mariozechner/*` namespace** → won't load |
| `pi-input-history` alt / `@fgladisch` | Ctrl+S flow-control risk / own drifting state file |

## Coexistence with terminal stack

Renders natively in Pi's TUI (no `fzf`/`atuin` binary shell-out that would fight Pi's raw-mode), so it composes with **herdr + ghostty**. `Ctrl+R` is free — herdr uses `prefix=ctrl+b` with no bare `Ctrl+R` binding. Zero deps.

## Verification

- Installs clean via bun: `pi-input-history@1.0.0`; registered in `pi list`.
- pi runs headless with no extension load error.
- 20 prior sessions exist for the chezmoi cwd → Ctrl+R has content immediately.
- pre-commit hooks (treefmt / yaml / gitleaks / …) all green.

Note: per-cwd scoped (searches only the current project's prior prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)