### PR TITLE
fix(nix): disable darwin HTML manual broken by render-docs --toc-depth removal

### DIFF
--- a/nix-config/modules/system.nix.tmpl
+++ b/nix-config/modules/system.nix.tmpl
@@ -196,6 +196,22 @@
   security.pam.services.sudo_local.touchIdAuth = true;
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Documentation
+  # ─────────────────────────────────────────────────────────────────────────────
+  # nixpkgs-unstable's `nixos-render-docs` dropped `--toc-depth` (~2026-07-05),
+  # but nix-darwin's `doc/manual/default.nix` still passes it, so building
+  # `darwin-manual-html` fails with:
+  #   nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead
+  # Upstream nix-darwin has no fix yet (master == pinned rev), so disable the
+  # HTML manual until it adopts `--sidebar-depth`. `man`/`info` stay enabled.
+  documentation.doc.enable = false; # drop `darwin-help` HTML manual (the broken build)
+  # The darwin-uninstaller builds a *nested* default-config darwin system whose
+  # system-path re-pulls the same broken `darwin-manual-html`, so `doc.enable`
+  # alone is not enough — drop the prebuilt uninstaller too (still runnable via
+  # `nix run nix-darwin#darwin-uninstaller` if ever needed).
+  system.tools.darwin-uninstaller.enable = false;
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Programs
   # ─────────────────────────────────────────────────────────────────────────────
   programs = {


### PR DESCRIPTION
## Problem

`chezmoi apply` (session bootstrap) fails in `.chezmoiscripts/02_init.sh` because
`darwin-rebuild switch` cannot build `darwin-manual-html`:

```
nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead
```

## Root cause

- nixpkgs-unstable's `nixos-render-docs` **dropped `--toc-depth`** around 2026-07-05, pulled into this repo by the 2026-07-06 darwin `flake.lock` bump (#782: nixpkgs `d333699` → `c4013e5`).
- nix-darwin's `doc/manual/default.nix` still calls `nixos-render-docs manual html … --toc-depth 1`.
- `nix-darwin.nixpkgs` **follows** the root `nixpkgs`, so the old builder runs against the new tool → build failure.
- **Upstream nix-darwin has no fix yet** — master `HEAD == a1fa429`, the exact pinned rev — so bumping the input doesn't help.

## Fix

Config-level, in `nix-config/modules/system.nix.tmpl`:

```nix
documentation.doc.enable = false;                 # drop the broken darwin-help HTML manual
system.tools.darwin-uninstaller.enable = false;   # see below
```

Why the second toggle: `darwin-uninstaller` builds a **nested, default-config** darwin system whose `system-path` re-pulls the *same* broken `darwin-manual-html`. So `documentation.doc.enable = false` alone is **not** sufficient — the dependency chain is:

```
darwin-system (mine) → system-applications → darwin-uninstaller
  → darwin-system (nested, defaults) → system-path → darwin-manual-html.drv
```

The uninstaller is still available on demand via `nix run nix-darwin#darwin-uninstaller`. `man`/`info` remain enabled.

## Verification

- Reproduced the failure by building the derivation directly from the live config.
- With the fix, `nix-store -qR` on the system toplevel shows `darwin-manual-html` references **2 → 0**, and `nix build --dry-run` of the toplevel no longer builds it.
- `pre-commit` (incl. template render + check) passes.

Durable across `nix flake update`. **Revert both lines once nix-darwin adopts `--sidebar-depth` upstream.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
