### PR TITLE
fix(nix): roll back darwin nixpkgs to unbreak darwin-manual-html

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783296123,
-        "narHash": "sha256-lanaJdvaHyr0EPXf4NlpvZsAOzCAMFkddmgHmnwAkPY=",
+        "lastModified": 1783211262,
+        "narHash": "sha256-wzEB48VTKnGfm3aznXyGJLYY2myVerINeS7T7CBqK38=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "9ac2e99c2131883e3a47477ccc74b289557b74a0",
+        "rev": "261db94062fdb4aa2722aa8ed38b5f80e69f1b35",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783296523,
-        "narHash": "sha256-HwVQL1cVwnl8bZOaicQjzP71Xq7ddSEjokcoAWckDkw=",
+        "lastModified": 1783208796,
+        "narHash": "sha256-toKBXATO1nRxEjRmM0Xb49T0OyBKebiOtcSI6moYIG0=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bf4bae78c6ec8adcf7d7c315917426364db480b6",
+        "rev": "ae13c2b02ebaa86d872186be106b5bdbef0cf6dd",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1783247743,
-        "narHash": "sha256-9b2xGt5CAd6WriPJOZs/EYXq9fGVCeoisYo1P3nhL2Y=",
+        "lastModified": 1782978903,
+        "narHash": "sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4013e501c048ae7c4a8940c92837636042bf6c3",
+        "rev": "d33369954a67ae3322177dc9a3d564092912120c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Reverts the 2026-07-06 darwin `flake.lock` bump (#782). That bump moved nixpkgs to a 2026-07-05 rev whose `nixos-render-docs` dropped `--toc-depth`, which nix-darwin's `darwin-manual-html` builder still passes — breaking `darwin-rebuild switch` (and chezmoi `02_init`):

```
nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead
```

Rolls nixpkgs back to the last working rev (2026-07-04), keeping the darwin HTML manual + uninstaller intact.

⚠️ **Stopgap:** the daily flake-lock auto-update (scheduler → `nix flake update`) will re-propose the broken nixpkgs. Hold/skip the nix update PR until nix-darwin adopts `--sidebar-depth` upstream, then let it move forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)