### PR TITLE
feat(pi): proactive subagent-delegation policy in APPEND_SYSTEM

### DIFF
--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -32,3 +32,24 @@ User preference overrides; fall back when unavailable; no sensitive data in quer
 - Installs: detect lockfiles, resolve signal-vs-preference conflicts explicitly, no mixed managers without confirmation.
 - Use `slipway` for governed changes (multi-step features, sensitive domains, formal review); artifacts in `artifacts/changes/<slug>/`; skip trivial edits.
 - Sensitive domains (Auth/AuthZ, Credentials/PII, Financial, Schema migration, Irreversible ops, External API contracts): never bypass confirmation; never install without preflight.
+
+## Subagent delegation (proactive)
+
+Actively delegate to `subagent` (pi-subagents) instead of doing everything inline
+in the main loop. Reach for a subagent by default when the work fits one of these:
+
+- Cross-file / cross-directory recon where only the conclusion is needed -> `scout`
+  or `context-builder` (they read excerpts and return findings, not full dumps).
+- Reviewing a diff or code quality -> fresh-context `reviewer` (adversarial review,
+  file/line evidence, does NOT edit files unless explicitly asked).
+- Multi-step external research -> `researcher`, paired with `scout` for local code
+  context; combine when a question spans web evidence + repo state.
+- Multiple independent, non-conflicting tasks -> run them as parallel `subagent`
+  tasks rather than serially.
+
+Principles: parallelize when tasks are independent; use fresh context for review;
+do writes with a single `worker` only when implementation is explicitly requested
+(never several writers in one worktree); make cost visible via a normal
+`subagent(...)` call, not hidden background automation. Skip delegation for trivial
+or single-point questions, direct commands, highly private requests, or when the
+user asks not to delegate — then just do it yourself.


### PR DESCRIPTION
## Why

Pi rarely delegated to `pi-subagents` on its own. Root cause:

- The global system-prompt append (`dot_pi/agent/APPEND_SYSTEM.md`) had **no delegation guidance** — only a single incidental mention of scout/researcher under Tavily routing.
- The rich *"When to Use"* instructions live in the `pi-subagents` **skill**, which is only injected when the skill is loaded and is deliberately **conservative** ("opt-in hint", "skip for tiny questions").
- Main-loop model (GLM-5.2) isn't tuned to reach for a delegation tool unprompted.

Net effect: the main loop just did everything inline.

## What

Adds a `## Subagent delegation (proactive)` section to `APPEND_SYSTEM.md` that makes delegation the default for:

- Cross-file/cross-directory recon → `scout` / `context-builder`
- Diff / code-quality review → fresh-context `reviewer` (no edits unless asked)
- Multi-step external research → `researcher` (+ `scout` for local context)
- Independent, non-conflicting tasks → parallel `subagent` tasks

…while keeping conservative bounds: skip trivial/single-point/private/opt-out; single `worker` per worktree; cost visible via a normal `subagent(...)` call, not hidden automation.

## Why this file

`APPEND_SYSTEM.md` is appended to Pi's built-in system prompt **every session** (per `pi-coding-agent` README §context-files) and hot-reloads via `/reload` — the always-in-context lever, mirroring how Claude Code carries delegation guidance in its system prompt.

## Notes / limits

This raises proactivity but can't fully replicate Claude Code: it can't change the `subagent` tool's built-in (conservative) description or the base model's tendency. Pairs best with a Claude-family `/model` switch.

## Verification

- `chezmoi apply ~/.pi/agent/APPEND_SYSTEM.md` renders and lands the section (verified on live file).
- pre-commit (treefmt / typos / gitleaks / end-of-file) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)