### PR TITLE
feat(pi): subagents default->glm-5.2 (recon stays deepseek-v4-flash)

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -99,14 +99,16 @@ pi:
     # Ctrl+R is free (herdr is prefix=ctrl+b; no bare Ctrl+R binding). Zero deps.
     - npm:pi-input-history
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
-  # Model routing for pi-subagents builtins. Quality-first: default pro, recon
-  # agents on flash. For cost-aggressive: defaultModel=flash + override
-  # oracle/reviewer/planner/worker to pro.
+  # Model routing for pi-subagents builtins. Reasoning-heavy agents (worker/
+  # reviewer/planner/oracle) + researcher run on GLM-5.2 (the defaultModel, same as
+  # the main loop). Only the mechanical recon agents (scout=quick lookup,
+  # context-builder=assemble context, delegate=dispatch) drop to the cheap
+  # deepseek-v4-flash. researcher stays on GLM-5.2 because it does deep
+  # investigation + synthesis, not just lookup.
   subagents:
-    defaultModel: deepseek-v4-pro
+    defaultModel: glm-5.2
     agentOverrides:
       scout: { model: deepseek-v4-flash }
-      researcher: { model: deepseek-v4-flash }
       context-builder: { model: deepseek-v4-flash }
       delegate: { model: deepseek-v4-flash }
   # ===== Custom providers -> ~/.pi/agent/models.json =====


### PR DESCRIPTION
Main loop stays on glm-5.2. subagents.defaultModel deepseek-v4-pro->glm-5.2 so worker/reviewer/planner/oracle + researcher match the main model; recon agents scout/context-builder/delegate stay on cheap deepseek-v4-flash. researcher pulled out of flash overrides (deep investigation, not lookup). Providers already wired (gopass). Verified live.

Generated with Claude Code