### PR TITLE
feat(pi): subagents default -> deepseek-v4-pro (recon stays flash)

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -100,13 +100,17 @@ pi:
     - npm:pi-input-history
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
   # Model routing for pi-subagents builtins. Reasoning-heavy agents (worker/
-  # reviewer/planner/oracle) + researcher run on GLM-5.2 (the defaultModel, same as
-  # the main loop). Only the mechanical recon agents (scout=quick lookup,
-  # context-builder=assemble context, delegate=dispatch) drop to the cheap
-  # deepseek-v4-flash. researcher stays on GLM-5.2 because it does deep
-  # investigation + synthesis, not just lookup.
+  # reviewer/planner/oracle) + researcher run on deepseek-v4-pro (the defaultModel;
+  # quality-first, deliberately distinct from the GLM-5.2 main loop). Only the
+  # mechanical recon agents (scout=quick lookup, context-builder=assemble context,
+  # delegate=dispatch) drop to the cheap deepseek-v4-flash. researcher stays on pro
+  # because it does deep investigation + synthesis, not just lookup.
+  #
+  # NOTE: modify_settings deep-merges (jq *), so REMOVING an override here does NOT
+  # delete it from an existing ~/.pi/agent/settings.json — prune agentOverrides there
+  # too when narrowing (e.g. researcher).
   subagents:
-    defaultModel: glm-5.2
+    defaultModel: deepseek-v4-pro
     agentOverrides:
       scout: { model: deepseek-v4-flash }
       context-builder: { model: deepseek-v4-flash }


### PR DESCRIPTION
## What

Sets `pi-subagents` `defaultModel` back to **deepseek-v4-pro** (reverting the #789 glm-5.2 default), while keeping the mechanical recon agents on the cheap `deepseek-v4-flash`.

| Agent | Model |
|---|---|
| worker / reviewer / planner / oracle / **researcher** | `deepseek-v4-pro` (default) |
| scout / context-builder / delegate | `deepseek-v4-flash` (override) |

Quality-first for the reasoning-heavy + synthesis agents, deliberately distinct from the GLM-5.2 main loop; cheap flash only for mechanical lookup/dispatch. Pairs with the now-proactive delegation policy (#787) — since subagents get invoked more, their output quality matters more.

## Deep-merge gotcha (documented in-file)

`dot_pi/agent/modify_settings.json.tmpl` deep-merges managed settings into `~/.pi/agent/settings.json` with `jq '.[0] * .[1]'`. **Removing** an `agentOverride` from `pi.yaml` does NOT delete it from an existing `settings.json` — the old key survives the merge. This already bit us: after #789 dropped the `researcher` override, live `settings.json` still carried `researcher: deepseek-v4-flash`. Added a `NOTE:` in the config so future narrowing prunes the live file too.

## Verification

- `chezmoi apply ~/.pi/agent/settings.json` + manual prune of the stale `researcher` key → live `subagents` now: `defaultModel=deepseek-v4-pro`, overrides = `{scout, context-builder, delegate}=flash` (verified via `jq`).
- pre-commit (check-yaml / treefmt / typos / gitleaks) passed; diff is minimal (no format churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)