### PR TITLE
feat(pi): add pi-ultra-compact (pinned @1.2.1) for smarter auto-compaction

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -98,6 +98,15 @@ pi:
     # natively in Pi's TUI — no fzf/atuin binary, so it coexists with herdr/ghostty.
     # Ctrl+R is free (herdr is prefix=ctrl+b; no bare Ctrl+R binding). Zero deps.
     - npm:pi-input-history
+    # ultra-compact: smarter auto-compaction than Pi's built-in. Built-in does a
+    # single reactive threshold + always-LLM summarize; ultra-compact adds (1) a
+    # no-LLM "micro-compaction" tier at 60-90% ctx (strips reasoning + bulk tool
+    # output in microseconds, no summary call) and (2) a PREEMPTIVE 70% trigger
+    # that fires before the next turn, so long multi-tool turns don't overflow.
+    # Coexists with built-in compaction (fallback). PINNED @1.2.1: young, churny,
+    # single-maintainer pkg — pinning freezes it and makes `pi update` skip it.
+    # Rollback: delete this line, `chezmoi apply`, `pi remove npm:pi-ultra-compact`.
+    - npm:pi-ultra-compact@1.2.1
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
   # Model routing for pi-subagents builtins. Reasoning-heavy agents (worker/
   # reviewer/planner/oracle) + researcher run on deepseek-v4-pro (the defaultModel;


### PR DESCRIPTION
## Why

Pi's **built-in** auto-compaction (on by default) uses a single reactive threshold (`contextWindow − reserveTokens`, 16k reserve), **always** runs an LLM summarization pass, and only checks **after `agent_end`** — long multi-tool turns can overflow mid-turn.

## What

Adds `pi-ultra-compact` to the `packages` list. It complements the built-in:

- **No-LLM "micro-compaction"** at 60–90% ctx — strips reasoning blocks + bulk tool output in microseconds, no summary call.
- **Preemptive 70% trigger** — fires before the next turn (projects usage), so it compacts *before* overflow instead of reacting at the limit.
- Graduated eviction + circuit-breaker fallback; coexists with built-in compaction.

## Pinned on purpose

`@1.2.1`. The package is young (created 2026-06-13), churny (0.9 → 1.2.1 in ~2 weeks), single-maintainer (`realvendex`). Per pi docs, **pinned packages are skipped by `pi update`**, so this freezes it until we deliberately bump. First pinned entry in the list (the rest float by convention) — deliberate, for churn control.

## Rollback

Delete the line → `chezmoi apply` → `pi remove npm:pi-ultra-compact`. Built-in compaction remains as fallback.

## Verification

Diff is minimal (comment + one pinned entry, no format churn). Live install verified separately (`pi install npm:pi-ultra-compact@1.2.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)