### PR TITLE
feat(pi): flatten input-box border to constant codex-style gray

### DIFF
--- a/dot_pi/agent/themes/catppuccin-mocha.json
+++ b/dot_pi/agent/themes/catppuccin-mocha.json
@@ -72,13 +72,13 @@
     "syntaxType": "yellow",
     "syntaxOperator": "sky",
     "syntaxPunctuation": "overlay2",
-    "thinkingOff": "surface1",
-    "thinkingMinimal": "surface2",
-    "thinkingLow": "overlay0",
-    "thinkingMedium": "#7f88b3",
-    "thinkingHigh": "#9f93da",
-    "thinkingXhigh": "mauve",
-    "bashMode": "green"
+    "thinkingOff": "#6e6e6e",
+    "thinkingMinimal": "#6e6e6e",
+    "thinkingLow": "#6e6e6e",
+    "thinkingMedium": "#6e6e6e",
+    "thinkingHigh": "#6e6e6e",
+    "thinkingXhigh": "#6e6e6e",
+    "bashMode": "#6e6e6e"
   },
   "export": {
     "pageBg": "#181825",


### PR DESCRIPTION
## What

Make pi's interactive input-box border a **constant neutral gray** (`#6e6e6e`) instead of the thinking-level color gradient.

## Why

pi's editor top/bottom border color isn't a static token — `interactive-mode.js` sets it from the current thinking level via `getThinkingBorderColor()` (`thinkingOff`…`thinkingXhigh`), plus `bashMode` for `!` mode. With `defaultThinkingLevel: xhigh` the frame rendered **mauve/purple** and shifted color per level.

Codex CLI and Claude Code use a fixed neutral-gray input frame. This flattens all six thinking tokens + `bashMode` to `#6e6e6e` to match that look.

## Trade-off

- Loses the per-thinking-level color cue on the input frame.
- Loses the green `!` bash-mode indicator (also flattened to gray). Revert just `bashMode` to `green` if that cue is wanted.

## Scope

Single file: `dot_pi/agent/themes/catppuccin-mocha.json`. No prefix/`›` marker change — pi doesn't render an input prefix and has no config for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)