### PR TITLE
feat(pi): input-prefix extension (codex-style prompt marker)

### DIFF
--- a/dot_pi/agent/extensions/pi-input-prefix/index.ts
+++ b/dot_pi/agent/extensions/pi-input-prefix/index.ts
@@ -1,0 +1,67 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { CustomEditor } from "@earendil-works/pi-coding-agent";
+
+// Codex-style leading prompt marker for pi's input textbox.
+//
+// pi has NO config key for an input prefix: the interactive editor
+// (pi-tui Editor.render) draws only the text with left padding — no marker,
+// and footer.json `promptInput.prefix` is dead config (pi reads settings.json
+// only). The supported way to customize the input component is the extension
+// API `ctx.ui.setEditorComponent(factory)` (ExtensionContext passed to event
+// handlers), which the docs recommend driving by subclassing CustomEditor.
+//
+// The marker is rendered BOLD for a heavier look. Default glyph is "❯".
+// Override the glyph:  env PI_INPUT_PREFIX (single-width char recommended).
+// Disable entirely:    remove this extension dir + restart pi.
+
+// First code point of the configured marker, then a space -> 2 visible columns.
+const MARKER = (process.env.PI_INPUT_PREFIX || "❯").at(0) ?? "❯";
+const PREFIX = MARKER + " ";
+const PREFIX_COLS = 2;
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+class PrefixEditor extends CustomEditor {
+  // The host forces setPaddingX(defaultEditor.getPaddingX()) right after the
+  // factory runs (interactive-mode setCustomEditorComponent), and the default
+  // is 0. Floor it so there are always >= PREFIX_COLS left-padding columns to
+  // overwrite, keeping text columns and cursor math untouched.
+  setPaddingX(padding: number): void {
+    super.setPaddingX(Math.max(PREFIX_COLS, padding));
+  }
+
+  render(width: number): string[] {
+    const lines = super.render(width);
+    try {
+      // lines[0] = top border; lines[1] = first content line (always present:
+      // an empty editor still renders one cursor line). The content line begins
+      // with `paddingX` literal spaces, so replacing the first PREFIX_COLS of
+      // them with an equal-width bold+colored marker preserves total visible
+      // width (ANSI styling is zero-width; RESET keeps the input text clean).
+      if (lines.length >= 2 && this.getPaddingX() >= PREFIX_COLS) {
+        const color = this.borderColor ?? ((s: string) => s);
+        lines[1] =
+          `${BOLD}${color(PREFIX)}${RESET}` + lines[1].slice(PREFIX_COLS);
+      }
+    } catch {
+      // A cosmetic overlay must never break the input box: fall through to the
+      // untouched super.render() output on any error.
+    }
+    return lines;
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  // ctx.ui.setEditorComponent swaps the editor live (preserving text, border
+  // color, keybindings, autocomplete). `ui` lives on the ExtensionContext
+  // passed to the handler, NOT on the top-level ExtensionAPI.
+  pi.on("session_start", (_event, ctx) => {
+    try {
+      ctx.ui.setEditorComponent(
+        (tui, theme, keybindings) => new PrefixEditor(tui, theme, keybindings),
+      );
+    } catch {
+      // Non-interactive mode: no editor to swap.
+    }
+  });
+}

--- a/dot_pi/agent/extensions/pi-input-prefix/package.json
+++ b/dot_pi/agent/extensions/pi-input-prefix/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pi-ext-input-prefix",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Codex-style leading prompt marker for pi's input textbox",
+  "type": "module",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  }
+}


### PR DESCRIPTION
## What

Adds a local pi extension that renders a **leading prompt marker** (default `›`) in front of the input textbox — the codex/shell-style `›` that pi lacks.

## Why config doesn't exist

pi has **no config key** for an input prefix:
- The interactive editor (`pi-tui` `Editor.render`) draws only the text with left padding — no marker glyph anywhere in the code.
- `~/.pi/agent/footer.json` `promptInput.prefix` is **dead config**: pi 0.80.3 reads only `settings.json`; `promptInput` appears nowhere in the codebase.

The supported customization surface is the extension API `ui.setEditorComponent(factory)` (`core/extensions/types.d.ts`), which the docs recommend driving by subclassing `CustomEditor`.

## How

`dot_pi/agent/extensions/pi-input-prefix/` — auto-discovered from `~/.pi/agent/extensions/`. On `session_start` it swaps in a `CustomEditor` subclass that:

- **Stamps** the marker flush-left on the first input line, over-writing the first 2 left-padding columns so text columns and cursor math are unchanged.
- **Floors `paddingX`** to 2 (the host forces `setPaddingX(0)` right after the factory runs) so there's always room for the marker.
- **Colors** the marker with the live border color (so it tracks the frame).
- Wraps the overlay in `try/catch` — a cosmetic error can **never** break the input box (falls back to untouched `super.render()`).

## Config / disable

- Glyph: env `PI_INPUT_PREFIX` (single-width char recommended).
- Disable: remove the extension dir + restart pi.

## Testing

- `bun build` syntax check passes.
- Installed live to `~/.pi/agent/extensions/pi-input-prefix/` for interactive verification (restart pi to load).

> Note: pairs with #797 (constant codex-style gray input border).

🤖 Generated with [Claude Code](https://claude.com/claude-code)