### PR TITLE
feat(pi): krill gpt-5.5 + tiered subagents; add worktree-ban constitution

### DIFF
--- a/.chezmoidata/pi.yaml
+++ b/.chezmoidata/pi.yaml
@@ -108,22 +108,39 @@ pi:
     # Rollback: delete this line, `chezmoi apply`, `pi remove npm:pi-ultra-compact`.
     - npm:pi-ultra-compact@1.2.1
   # ===== Subagents config -> ~/.pi/agent/settings.json subagents =====
-  # Model routing for pi-subagents builtins. Reasoning-heavy agents (worker/
-  # reviewer/planner/oracle) + researcher run on deepseek-v4-pro (the defaultModel;
-  # quality-first, deliberately distinct from the GLM-5.2 main loop). Only the
-  # mechanical recon agents (scout=quick lookup, context-builder=assemble context,
-  # delegate=dispatch) drop to the cheap deepseek-v4-flash. researcher stays on pro
-  # because it does deep investigation + synthesis, not just lookup.
+  # Model routing for pi-subagents builtins, tiered across the three families so
+  # each agent runs on the cheapest model that still clears its bar — and so the
+  # quality gates run on a family DIFFERENT from the GLM-5.2 main loop (an
+  # independent perspective catches what the main model misses):
+  #
+  #   gpt-5.5 (krill)   -> oracle, reviewer. Premium reasoning reserved for the two
+  #                        rare, high-leverage roles (hardest one-shot question /
+  #                        adversarial review). Maximally distinct from the GLM main
+  #                        loop, so it's the strongest independent second opinion.
+  #   deepseek-v4-pro   -> worker, planner, researcher (the defaultModel). Strong,
+  #                        economical workhorse for the bulk of the coding/planning/
+  #                        investigation volume — too high-throughput for gpt pricing.
+  #   glm (newapi)      -> the cheap mechanical/recon tier, where diversity doesn't
+  #                        matter: scout=glm-4.7 (quick lookup), context-builder=
+  #                        glm-5.2 (its 1M window suits assembling large context),
+  #                        delegate=glm-4.7 (pure dispatch). Runs on the subscription
+  #                        gateway instead of burning metered deepseek-flash tokens.
+  #
+  # deepseek-v4-flash is no longer routed to any subagent (still a /model option).
+  # Bare model ids resolve to a provider automatically — each id here is unique to
+  # one provider (gpt-5.5=krill, glm-*=newapi, deepseek-*=deepseek).
   #
   # NOTE: modify_settings deep-merges (jq *), so REMOVING an override here does NOT
   # delete it from an existing ~/.pi/agent/settings.json — prune agentOverrides there
-  # too when narrowing (e.g. researcher).
+  # too when narrowing. (Changing a model VALUE is fine: jq * overwrites scalars.)
   subagents:
     defaultModel: deepseek-v4-pro
     agentOverrides:
-      scout: { model: deepseek-v4-flash }
-      context-builder: { model: deepseek-v4-flash }
-      delegate: { model: deepseek-v4-flash }
+      oracle: { model: gpt-5.5 }
+      reviewer: { model: gpt-5.5 }
+      scout: { model: glm-4.7 }
+      context-builder: { model: glm-5.2 }
+      delegate: { model: glm-4.7 }
   # ===== Custom providers -> ~/.pi/agent/models.json =====
   # Providers Pi does not know natively, OR built-in providers for which we want
   # to pin specific models Pi's built-in registry lacks (e.g. DeepSeek V4).
@@ -230,6 +247,41 @@ pi:
             thinkingFormat: deepseek
             reasoningEffortMap:
               { minimal: high, low: high, medium: high, high: high, xhigh: max }
+    krill: # Krill — gpt-5.5 served on an OpenAI-Responses endpoint
+      # (https://api.krill-ai.com). Same upstream Claude Code (anthropic-compatible
+      # /codex) and Codex (openai-responses /codex/v1) already use; here we take the
+      # Responses route because that's gpt-5.5's native transport, mirroring
+      # dot_codex [model_providers.krill] (base_url .../codex/v1, wire_api=responses).
+      # Pi's openai-responses api POSTs to <base_url>/responses, so keep the /codex/v1
+      # suffix. Key from gopass (claude/krill/private/api_key, the same secret the
+      # claude/codex configs read) → baked in at apply time, so
+      # `pi --provider krill --model gpt-5.5` works out of the box; the provider is
+      # silently skipped on a machine without the key. Pick at runtime with /model.
+      base_url: https://api.krill-ai.com/codex/v1
+      api: openai-responses
+      gopass: claude/krill/private/api_key
+      models:
+        - id: gpt-5.5
+          name: GPT-5.5 (krill)
+          # gpt-5 family = 400K total context. Set so Pi's auto-compaction can
+          # compute its threshold (contextWindow - reserveTokens); without it Pi
+          # never auto-compacts (same reason as the newapi GLM models, #795).
+          contextWindow: 400000
+          maxTokens: 128000
+          reasoning: true
+          # openai-responses sends reasoning natively as reasoning:{effort} — no
+          # thinkingFormat/compat plumbing needed (that's the openai-completions
+          # path used by newapi/deepseek). gpt-5.5 accepts effort up to xhigh
+          # (dot_codex sets model_reasoning_effort=xhigh), so map identity and do
+          # NOT let Pi clamp xhigh down to high.
+          thinkingLevelMap:
+            {
+              minimal: minimal,
+              low: low,
+              medium: medium,
+              high: high,
+              xhigh: xhigh,
+            }
     qwen: # Alibaba DashScope (OpenAI-compatible)
       base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
       api: openai-completions

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,6 +3,8 @@
 # ─────────────────────────────────────────────────────────────────────────────
 *.tmp
 README.md
+CLAUDE.md
+AGENTS.md
 
 # Python bytecode (defensive -- bundled skill scripts are currently bash, but
 # leave the ignore in place for future Python-backed helpers)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Project Constitution — chezmoi dotfiles (`~/.local/share/chezmoi`)
+
+These are **inviolable** rules for ANY agent (Claude Code, Codex, pi, etc.) working
+in this repository. They **override** default behaviors, convenience, and general
+instincts. When anything conflicts with this file, **this file wins**. The same
+constitution is mirrored in `CLAUDE.md`; keep the two in sync.
+
+---
+
+## Article 1 — NO git worktrees. Ever. 🚫🌳
+
+- **NEVER** run `git worktree add` in this repo.
+- **NEVER** create a `.worktrees/` directory, or place any worktree, **anywhere
+  inside the source tree** (`~/.local/share/chezmoi`).
+- **Why (do not "optimize" this away):** chezmoi reads **every** `.chezmoidata/`
+  directory in the source tree **recursively** — it does not skip dot-dirs, and
+  `.chezmoiignore` **cannot** exclude it (the data pass runs earlier and separately).
+  An in-source worktree's `.chezmoidata/*.yaml` is merged into global template data
+  and **silently clobbers** the main checkout's config on every `chezmoi apply` /
+  `chezmoi execute-template` (the alphabetically-last worktree wins). This has
+  corrupted `pi`/`claude` config in practice.
+- If you find a worktree here, treat it as a **defect**: surface it, then — with all
+  commits/branches preserved — remove it (`git worktree remove [--force] <path>`;
+  `--force` discards that worktree's _uncommitted_ changes, so check
+  `git -C <path> status` first).
+
+## Article 2 — NEVER switch the shared main checkout.
+
+- Do **not** `git switch` / `git checkout -b` on this checkout. chezmoi's **live
+  source IS this working tree**; moving `HEAD` yanks files out from under the user
+  and breaks their live `dot apply`.
+- To make a change: **edit on `main` and commit small**, or work in a **separate
+  clone outside** `~/.local/share/chezmoi`. Branch isolation via an in-source
+  worktree is forbidden by Article 1.
+
+## Article 3 — Merging & sync.
+
+- Native auto-merge is **disabled**. Squash-merge a PR only when
+  `mergeStateStatus=CLEAN`: `gh pr merge <n> --squash --delete-branch`, then
+  `git pull --ff-only origin main` to sync the local main checkout (a
+  `darwin-rebuild` / `dot apply` from stale local main can reinstall/rewrite things).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Project Constitution — chezmoi dotfiles (`~/.local/share/chezmoi`)
+
+These are **inviolable** rules for ANY agent (Claude Code, Codex, pi, etc.) working
+in this repository. They **override** default behaviors, convenience, and general
+instincts. When anything conflicts with this file, **this file wins**. The same
+constitution is mirrored in `AGENTS.md`; keep the two in sync.
+
+---
+
+## Article 1 — NO git worktrees. Ever. 🚫🌳
+
+- **NEVER** run `git worktree add` in this repo.
+- **NEVER** create a `.worktrees/` directory, or place any worktree, **anywhere
+  inside the source tree** (`~/.local/share/chezmoi`).
+- **Why (do not "optimize" this away):** chezmoi reads **every** `.chezmoidata/`
+  directory in the source tree **recursively** — it does not skip dot-dirs, and
+  `.chezmoiignore` **cannot** exclude it (the data pass runs earlier and separately).
+  An in-source worktree's `.chezmoidata/*.yaml` is merged into global template data
+  and **silently clobbers** the main checkout's config on every `chezmoi apply` /
+  `chezmoi execute-template` (the alphabetically-last worktree wins). This has
+  corrupted `pi`/`claude` config in practice.
+- If you find a worktree here, treat it as a **defect**: surface it, then — with all
+  commits/branches preserved — remove it (`git worktree remove [--force] <path>`;
+  `--force` discards that worktree's *uncommitted* changes, so check
+  `git -C <path> status` first).
+
+## Article 2 — NEVER switch the shared main checkout.
+
+- Do **not** `git switch` / `git checkout -b` on this checkout. chezmoi's **live
+  source IS this working tree**; moving `HEAD` yanks files out from under the user
+  and breaks their live `dot apply`.
+- To make a change: **edit on `main` and commit small**, or work in a **separate
+  clone outside** `~/.local/share/chezmoi`. Branch isolation via an in-source
+  worktree is forbidden by Article 1.
+
+## Article 3 — Merging & sync.
+
+- Native auto-merge is **disabled**. Squash-merge a PR only when
+  `mergeStateStatus=CLEAN`: `gh pr merge <n> --squash --delete-branch`, then
+  `git pull --ff-only origin main` to sync the local main checkout (a
+  `darwin-rebuild` / `dot apply` from stale local main can reinstall/rewrite things).


### PR DESCRIPTION
## Summary
Two related changes (one PR per request):

### 1. pi: krill gpt-5.5 + tiered subagent routing
- **krill provider**: gpt-5.5 via `openai-responses` at `https://api.krill-ai.com/codex/v1` (mirrors the Codex `wire_api=responses` setup). Key from gopass `claude/krill/private/api_key`; silently skipped when absent. Selectable at runtime with `/model`.
- **Subagent routing** tiered across three families (cheapest model that clears each role's bar; quality gates kept independent of the GLM main loop):
  - `oracle`, `reviewer` → **gpt-5.5** (premium, rare, most distinct from GLM)
  - `worker`, `planner`, `researcher` → **deepseek-v4-pro** (defaultModel)
  - `scout`=glm-4.7, `context-builder`=glm-5.2, `delegate`=glm-4.7 (cheap recon tier)
  - `deepseek-v4-flash` retired from subagents (still a `/model` option)

### 2. Project constitution banning in-source worktrees
- New `CLAUDE.md` + `AGENTS.md` (identical): ban `git worktree`/`.worktrees/` inside the source, and switching the main checkout.
- **Root cause it prevents:** chezmoi reads *every* nested `.chezmoidata/` recursively; `.chezmoiignore` can't stop it. Worktrees under the source silently clobbered main's pi/claude config on every apply. All 15 stray worktrees were removed (branches preserved).
- Both files added to `.chezmoiignore` so they aren't applied to `$HOME`.

## Verification
`chezmoi execute-template` renders correct values: `krill` present, subagents = gpt/deepseek/glm as above, no stray `pi-landstrip`/`researcher` from worktree pollution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
