### PR TITLE
chore(aqua): update pinned packages (2026-07-07)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.41.0
+  - name: signalridge/slipway@v0.41.1
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
@@ -26,14 +26,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.201
+  - name: anthropics/claude-code@v2.1.202
   - name: openai/codex@rust-v0.142.5
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.0
+  - name: jdx/mise@v2026.7.1
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -43,7 +43,7 @@ packages:
   - name: eza-community/eza@v0.23.4
   - name: fastfetch-cli/fastfetch@2.65.2
   - name: sharkdp/fd@v10.4.2
-  - name: junegunn/fzf@v0.73.1
+  - name: junegunn/fzf@v0.74.0
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.96.0
   - name: dlvhdr/gh-dash@v4.25.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.