### PR TITLE
chore(aqua): update pinned packages (2026-07-15)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -17,7 +17,7 @@ packages:
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
-  - name: atuinsh/atuin@v18.17.0
+  - name: atuinsh/atuin@v18.17.1
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -26,14 +26,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.207
-  - name: openai/codex@rust-v0.144.1
+  - name: anthropics/claude-code@v2.1.210
+  - name: openai/codex@rust-v0.144.4
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.5
+  - name: jdx/mise@v2026.7.6
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -75,12 +75,12 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: ducaale/xh@v0.26.1
   - name: watchexec/watchexec@v2.5.1
-  - name: joshmedeski/sesh@v2.26.2
+  - name: joshmedeski/sesh@v2.27.0
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
   - name: crate-ci/typos@v1.48.0
-  - name: zizmorcore/zizmor@v1.26.1
+  - name: zizmorcore/zizmor@v1.27.0
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.