### PR TITLE
chore(aqua): update pinned packages (2026-07-18)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -119,6 +119,6 @@ packages:
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0
-  - name: terraform-linters/tflint@v0.63.1
+  - name: terraform-linters/tflint@v0.64.0
   - name: quarto-dev/quarto-cli@v1.9.38
-  - name: typst/typst@v0.15.0
+  - name: typst/typst@v0.15.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.