### PR TITLE
chore(aqua): update pinned packages (2026-07-25)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,7 +18,7 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.29.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.29.1
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
@@ -33,14 +33,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.218
+  - name: anthropics/claude-code@v2.1.219
   - name: openai/codex@rust-v0.145.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.11
+  - name: jdx/mise@v2026.7.13
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -64,7 +64,7 @@ packages:
   - name: jqlang/jq@jq-1.8.2
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
-  - name: ast-grep/ast-grep@0.44.1
+  - name: ast-grep/ast-grep@0.45.0
   - name: casey/just@1.57.0
   - name: jesseduffield/lazygit@v0.63.1
   - name: jesseduffield/lazydocker@v0.25.2
@@ -92,9 +92,9 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.15.22
-  - name: astral-sh/ty@0.0.62
-  - name: j178/prek@v0.4.10
+  - name: astral-sh/ruff@0.16.0
+  - name: astral-sh/ty@0.0.63
+  - name: j178/prek@v0.4.11
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.17.0
@@ -114,7 +114,7 @@ packages:
   - name: mikefarah/yq@v4.53.3
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0
-  - name: kubernetes/kubernetes/kubectl@v1.36.2
+  - name: kubernetes/kubernetes/kubectl@v1.36.3
   - name: helm/helm@v4.2.3
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.6.0
@@ -127,5 +127,5 @@ packages:
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0
   - name: terraform-linters/tflint@v0.64.0
-  - name: quarto-dev/quarto-cli@v1.9.38
+  - name: quarto-dev/quarto-cli@v1.10.18
   - name: typst/typst@v0.15.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.