### PR TITLE
chore(aqua): update pinned packages (2026-07-27)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -40,7 +40,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.13
+  - name: jdx/mise@v2026.7.14
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -80,7 +80,7 @@ packages:
   - name: BurntSushi/ripgrep@15.2.0
   - name: phiresky/ripgrep-all@v0.10.10
   - name: chmln/sd@v1.1.0
-  - name: ducaale/xh@v0.26.1
+  - name: ducaale/xh@v0.26.2
   - name: watchexec/watchexec@v2.5.1
   - name: joshmedeski/sesh@v2.27.0
   - name: starship/starship@v1.26.0
@@ -97,7 +97,7 @@ packages:
   - name: j178/prek@v0.4.11
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
-  - name: goreleaser/goreleaser@v2.17.0
+  - name: goreleaser/goreleaser@v2.17.1
   - name: orhun/git-cliff@v2.13.1
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.