### PR TITLE
chore(aqua): update pinned packages (2026-07-29)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,13 +18,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.29.1
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.29.2
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
-  - name: atuinsh/atuin@v18.17.1
+  - name: atuinsh/atuin@v18.18.1
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -40,7 +40,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.14
+  - name: jdx/mise@v2026.7.15
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -82,7 +82,7 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: ducaale/xh@v0.26.2
   - name: watchexec/watchexec@v2.5.1
-  - name: joshmedeski/sesh@v2.27.0
+  - name: joshmedeski/sesh@v2.28.0
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
@@ -93,7 +93,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.0
-  - name: astral-sh/ty@0.0.63
+  - name: astral-sh/ty@0.0.64
   - name: j178/prek@v0.4.11
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
@@ -103,7 +103,7 @@ packages:
   - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
   - name: hatoo/oha@v1.15.0
-  - name: ClementTsang/bottom@0.14.6
+  - name: ClementTsang/bottom@0.14.7
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0
   - name: mr-karan/doggo@v1.2.0
@@ -121,8 +121,8 @@ packages:
   - name: ahmetb/kubectx@v0.11.0
   - name: kubernetes-sigs/krew@v0.5.0
   - name: aquasecurity/trivy@v0.72.0
-  - name: anchore/syft@v1.49.0
-  - name: anchore/grype@v0.116.0
+  - name: anchore/syft@v1.50.0
+  - name: anchore/grype@v0.116.1
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.