### PR TITLE
chore(aqua): update pinned packages (2026-07-31)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,7 +18,7 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.30.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.31.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
@@ -40,7 +40,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.7.16
+  - name: jdx/mise@v2026.7.18
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -92,7 +92,7 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.0
+  - name: astral-sh/ruff@0.16.1
   - name: astral-sh/ty@0.0.65
   - name: j178/prek@v0.4.11
   - name: golang.org/x/tools/gopls@v0.23.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.