### PR TITLE
chore(aqua): update pinned packages (2026-08-01)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,7 +18,7 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.31.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.31.1
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
@@ -52,9 +52,9 @@ packages:
   - name: crates.io/eza@0.23.5
   - name: fastfetch-cli/fastfetch@2.66.0
   - name: sharkdp/fd@v10.4.2
-  - name: junegunn/fzf@v0.74.1
+  - name: junegunn/fzf@v0.74.2
   - name: gopasspw/gopass@v1.16.1
-  - name: cli/cli@v2.96.0
+  - name: cli/cli@v2.97.0
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
@@ -72,7 +72,7 @@ packages:
   - name: LuaLS/lua-language-server@3.18.2
   - name: tree-sitter/tree-sitter@v0.26.11
   - name: jj-vcs/jj@v0.43.0
-  - name: rclone/rclone@v1.74.4
+  - name: rclone/rclone@v1.75.0
   - name: o2sh/onefetch@2.27.1
   - name: ip7z/7zip@26.02
   - name: ouch-org/ouch@0.8.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.