### PR TITLE
chore(aqua): update pinned packages (2026-08-04)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -11,7 +11,7 @@ packages:
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
-  - name: ogulcancelik/herdr@v0.7.5
+  - name: ogulcancelik/herdr@v0.8.0
     registry: third-party
   # Kimi Code CLI (K3). version_prefix in registry.yaml maps this semver onto the
   # `@moonshot-ai/kimi-code@<ver>` git tag; the binary itself is fetched from
@@ -24,7 +24,7 @@ packages:
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
-  - name: atuinsh/atuin@v18.18.1
+  - name: atuinsh/atuin@v18.19.0
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -33,14 +33,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.220
+  - name: anthropics/claude-code@v2.1.221
   - name: openai/codex@rust-v0.146.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.0
+  - name: jdx/mise@v2026.8.1
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -65,7 +65,7 @@ packages:
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
   - name: ast-grep/ast-grep@0.45.0
-  - name: casey/just@1.57.0
+  - name: casey/just@1.58.0
   - name: jesseduffield/lazygit@v0.63.1
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.4
@@ -86,7 +86,7 @@ packages:
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.48.0
+  - name: crate-ci/typos@v1.49.0
   - name: zizmorcore/zizmor@v1.29.0
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
@@ -94,7 +94,7 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.1
   - name: astral-sh/ty@0.0.65
-  - name: j178/prek@v0.4.11
+  - name: j178/prek@v0.4.12
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.17.1
@@ -120,7 +120,7 @@ packages:
   - name: kubecolor/kubecolor@v0.6.0
   - name: ahmetb/kubectx@v0.11.0
   - name: kubernetes-sigs/krew@v0.5.0
-  - name: aquasecurity/trivy@v0.72.0
+  - name: aquasecurity/trivy@v0.73.0
   - name: anchore/syft@v1.50.0
   - name: anchore/grype@v0.116.1
   - name: LucasPickering/slumber@v5.3.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.