### PR TITLE
chore(nix): update flake.lock for darwin (2026-08-04)

### DIFF
--- a/nix-config/.flake-darwin.lock
+++ b/nix-config/.flake-darwin.lock
@@ -145,11 +145,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1785716275,
-        "narHash": "sha256-3sA/4nqYQV6IGg/qH3ORR36aqrtxxMxMVxW4n122qVA=",
+        "lastModified": 1785798168,
+        "narHash": "sha256-u1WKx//iVQYOqzzt5Qn8UtXbo2WVKvdR6Tl2R4vB2iE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "8689f87a38012c829b867534773bd8a9bdd7bc2c",
+        "rev": "42a3114225f687ca5bbea6c19826fc5bd7c3097e",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1785716626,
-        "narHash": "sha256-p5VGqnqYbBf2LWJYwjduQtuC+nM220ytTym+5csuees=",
+        "lastModified": 1785801726,
+        "narHash": "sha256-EXyVwEOKaLzmciHdJ0pRxIN7DJoSNPW06P7sltYElqM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "aeb2175e5cee891b36266ae364c82f7d7694560e",
+        "rev": "b004a6bc5136b2b19f2c8d05cfe4cbd0ae6df2ac",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1785602060,
-        "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5cbcfe954791221bfffe2307f7d1a1bf61a871e",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update for darwin.

Updates all flake inputs to their latest versions.