### PR TITLE
chore(aqua): update pinned packages (2026-08-08)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -18,14 +18,14 @@ packages:
   # note on retiring it. Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.10
+  - name: google-antigravity/antigravity-cli@1.1.11
     registry: third-party
   # Kimi Code CLI (K3). version_prefix in registry.yaml maps this semver onto the
   # `@moonshot-ai/kimi-code@<ver>` git tag; the binary itself is fetched from
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.33.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.34.0
     registry: third-party
   # ----- standard registry -----
   - name: nektos/act@v0.2.89
@@ -40,24 +40,24 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.222
-  - name: openai/codex@rust-v0.146.1
+  - name: anthropics/claude-code@v2.1.224
+  - name: openai/codex@rust-v0.147.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.2
+  - name: jdx/mise@v2026.8.3
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
   - name: bootandy/dust@v1.2.4
   - name: dandavison/delta@0.19.2
-  - name: Wilfred/difftastic@0.69.0
+  - name: Wilfred/difftastic@0.70.0
   # Darwin uses Cargo for eza. Track crates.io releases directly: GitHub tag
   # v0.23.5 existed before its crate, which made aqua's Cargo install impossible.
   - name: crates.io/eza@0.23.5
-  - name: fastfetch-cli/fastfetch@2.66.0
+  - name: fastfetch-cli/fastfetch@2.67.0
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.74.2
   - name: gopasspw/gopass@v1.16.1
@@ -71,14 +71,14 @@ packages:
   - name: jqlang/jq@jq-1.8.2
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
-  - name: ast-grep/ast-grep@0.45.0
+  - name: ast-grep/ast-grep@0.45.1
   - name: casey/just@1.58.0
   - name: jesseduffield/lazygit@v0.64.0
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.4
-  - name: LuaLS/lua-language-server@3.18.2
+  - name: LuaLS/lua-language-server@3.19.0
   - name: tree-sitter/tree-sitter@v0.26.11
-  - name: jj-vcs/jj@v0.43.0
+  - name: jj-vcs/jj@v0.44.0
   - name: rclone/rclone@v1.75.0
   - name: o2sh/onefetch@2.27.1
   - name: ip7z/7zip@26.02
@@ -99,8 +99,8 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.1
-  - name: astral-sh/ty@0.0.67
+  - name: astral-sh/ruff@0.16.2
+  - name: astral-sh/ty@0.0.69
   - name: j178/prek@v0.4.12
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
@@ -113,7 +113,7 @@ packages:
   - name: ClementTsang/bottom@0.14.7
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0
-  - name: mr-karan/doggo@v1.2.0
+  - name: mr-karan/doggo@v1.3.0
     registry: third-party
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.