### PR TITLE
chore(aqua): update pinned packages (2026-08-13)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -10,7 +10,7 @@ registries:
     path: registry.yaml
 packages:
   # ----- third-party registry (see registry.yaml) -----
-  - name: signalridge/slipway@v0.41.1
+  - name: signalridge/slipway@v1.0.0
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
@@ -21,13 +21,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.34.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.35.0
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.11
+  - name: google-antigravity/antigravity-cli@1.1.12
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.226
+  - name: anthropics/claude-code@v2.1.229
   - name: openai/codex@rust-v0.147.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.3
+  - name: jdx/mise@v2026.8.5
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -66,14 +66,14 @@ packages:
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
   - name: git-lfs/git-lfs@v3.7.1
-  - name: charmbracelet/glow@v2.1.2
+  - name: charmbracelet/glow@v3.0.0
   - name: carapace-sh/carapace-bin@v1.7.3
   - name: jqlang/jq@jq-1.8.2
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
   - name: ast-grep/ast-grep@0.45.1
   - name: casey/just@1.58.0
-  - name: jesseduffield/lazygit@v0.64.0
+  - name: jesseduffield/lazygit@v0.64.1
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.4
   - name: LuaLS/lua-language-server@3.19.0
@@ -100,8 +100,8 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.2
-  - name: astral-sh/ty@0.0.69
-  - name: j178/prek@v0.4.12
+  - name: astral-sh/ty@0.0.70
+  - name: j178/prek@v0.4.13
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.17.1
@@ -128,8 +128,8 @@ packages:
   - name: ahmetb/kubectx@v0.11.0
   - name: kubernetes-sigs/krew@v0.5.0
   - name: aquasecurity/trivy@v0.73.0
-  - name: anchore/syft@v1.50.0
-  - name: anchore/grype@v0.116.1
+  - name: anchore/syft@v1.51.0
+  - name: anchore/grype@v0.117.0
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v0.17.0
   - name: charmbracelet/vhs@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.