### PR TITLE
chore(aqua): update pinned packages (2026-08-14)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,7 +21,7 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.35.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.36.0
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
@@ -40,7 +40,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.229
+  - name: anthropics/claude-code@v2.1.232
   - name: openai/codex@rust-v0.147.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
@@ -76,7 +76,7 @@ packages:
   - name: jesseduffield/lazygit@v0.64.1
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.4
-  - name: LuaLS/lua-language-server@3.19.0
+  - name: LuaLS/lua-language-server@3.19.1
   - name: tree-sitter/tree-sitter@v0.26.12
   - name: jj-vcs/jj@v0.44.0
   - name: rclone/rclone@v1.75.0
@@ -99,8 +99,8 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.2
-  - name: astral-sh/ty@0.0.70
+  - name: astral-sh/ruff@0.16.3
+  - name: astral-sh/ty@0.0.71
   - name: j178/prek@v0.4.13
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
@@ -110,7 +110,7 @@ packages:
   - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
   - name: hatoo/oha@v1.15.0
-  - name: ClementTsang/bottom@0.14.7
+  - name: ClementTsang/bottom@0.14.8
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0
   - name: mr-karan/doggo@v1.3.0
@@ -122,7 +122,7 @@ packages:
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0
   - name: kubernetes/kubernetes/kubectl@v1.36.3
-  - name: helm/helm@v4.2.3
+  - name: helm/helm@v4.2.4
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.6.0
   - name: ahmetb/kubectx@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.