### PR TITLE
chore(aqua): update pinned packages (2026-08-15)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,13 +21,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.36.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.36.1
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.12
+  - name: google-antigravity/antigravity-cli@1.1.13
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.232
+  - name: anthropics/claude-code@v2.1.233
   - name: openai/codex@rust-v0.147.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.5
+  - name: jdx/mise@v2026.8.6
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -57,7 +57,7 @@ packages:
   # Darwin uses Cargo for eza. Track crates.io releases directly: GitHub tag
   # v0.23.5 existed before its crate, which made aqua's Cargo install impossible.
   - name: crates.io/eza@0.23.5
-  - name: fastfetch-cli/fastfetch@2.67.0
+  - name: fastfetch-cli/fastfetch@2.67.1
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.74.2
   - name: gopasspw/gopass@v1.16.1
@@ -100,7 +100,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.3
-  - name: astral-sh/ty@0.0.71
+  - name: astral-sh/ty@0.0.72
   - name: j178/prek@v0.4.13
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
@@ -127,7 +127,7 @@ packages:
   - name: kubecolor/kubecolor@v0.6.0
   - name: ahmetb/kubectx@v0.11.0
   - name: kubernetes-sigs/krew@v0.5.0
-  - name: aquasecurity/trivy@v0.73.0
+  - name: aquasecurity/trivy@v0.74.0
   - name: anchore/syft@v1.51.0
   - name: anchore/grype@v0.117.0
   - name: LucasPickering/slumber@v5.3.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.