### PR TITLE
chore(aqua): update pinned packages (2026-08-18)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.233
+  - name: anthropics/claude-code@v2.1.234
   - name: openai/codex@rust-v0.147.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.6
+  - name: jdx/mise@v2026.8.8
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -59,7 +59,7 @@ packages:
   - name: crates.io/eza@0.23.5
   - name: fastfetch-cli/fastfetch@2.67.1
   - name: sharkdp/fd@v10.4.2
-  - name: junegunn/fzf@v0.74.2
+  - name: junegunn/fzf@v0.74.3
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.97.0
   - name: dlvhdr/gh-dash@v4.25.2
@@ -101,7 +101,7 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.3
   - name: astral-sh/ty@0.0.72
-  - name: j178/prek@v0.4.13
+  - name: j178/prek@v0.4.14
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.12.2
   - name: goreleaser/goreleaser@v2.17.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.