### PR TITLE
chore(aqua): update pinned packages (2026-08-21)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,13 +21,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.37.2
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.38.0
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.15
+  - name: google-antigravity/antigravity-cli@1.1.17
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.236
-  - name: openai/codex@rust-v0.148.0
+  - name: anthropics/claude-code@v2.1.238
+  - name: openai/codex@rust-v0.149.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.9
+  - name: jdx/mise@v2026.8.10
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -61,7 +61,7 @@ packages:
   - name: sharkdp/fd@v10.4.2
   - name: junegunn/fzf@v0.74.3
   - name: gopasspw/gopass@v1.16.1
-  - name: cli/cli@v2.97.0
+  - name: cli/cli@v2.98.0
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
@@ -99,11 +99,11 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.3
+  - name: astral-sh/ruff@0.16.4
   - name: astral-sh/ty@0.0.73
   - name: j178/prek@v0.4.14
   - name: golang.org/x/tools/gopls@v0.23.0
-  - name: golangci/golangci-lint@v2.13.0
+  - name: golangci/golangci-lint@v2.13.1
   - name: goreleaser/goreleaser@v2.17.1
   - name: orhun/git-cliff@v2.13.1
   - name: numtide/treefmt@v2.5.0
@@ -118,10 +118,10 @@ packages:
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0
   - name: sxyazi/yazi@v26.8.15
-  - name: mikefarah/yq@v4.53.4
+  - name: mikefarah/yq@v4.53.6
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0
-  - name: kubernetes/kubernetes/kubectl@v1.36.3
+  - name: kubernetes/kubernetes/kubectl@v1.36.4
   - name: helm/helm@v4.2.4
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.6.0
@@ -131,7 +131,7 @@ packages:
   - name: anchore/syft@v1.51.0
   - name: anchore/grype@v0.117.0
   - name: LucasPickering/slumber@v5.3.0
-  - name: charmbracelet/gum@v0.17.0
+  - name: charmbracelet/gum@v2.0.0
   - name: charmbracelet/vhs@v0.11.0
   - name: terraform-linters/tflint@v0.64.0
   - name: quarto-dev/quarto-cli@v1.10.18


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.