### PR TITLE
chore(aqua): update pinned packages (2026-08-24)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,7 +27,7 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.17
+  - name: google-antigravity/antigravity-cli@1.1.19
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.238
+  - name: anthropics/claude-code@v2.1.241
   - name: openai/codex@rust-v0.149.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.10
+  - name: jdx/mise@v2026.8.11
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -71,13 +71,13 @@ packages:
   - name: jqlang/jq@jq-1.8.2
   - name: ynqa/jnv@v0.7.1
   - name: tldr-pages/tlrc@v1.13.1
-  - name: ast-grep/ast-grep@0.45.1
+  - name: ast-grep/ast-grep@0.45.2
   - name: casey/just@1.58.0
   - name: jesseduffield/lazygit@v0.64.1
   - name: jesseduffield/lazydocker@v0.25.2
-  - name: neovim/neovim@v0.12.4
+  - name: neovim/neovim@v0.12.5
   - name: LuaLS/lua-language-server@3.19.1
-  - name: tree-sitter/tree-sitter@v0.26.12
+  - name: tree-sitter/tree-sitter@v0.26.13
   - name: jj-vcs/jj@v0.44.0
   - name: rclone/rclone@v1.75.0
   - name: o2sh/onefetch@2.27.1
@@ -88,7 +88,7 @@ packages:
   - name: phiresky/ripgrep-all@v0.10.10
   - name: chmln/sd@v1.1.0
   - name: ducaale/xh@v0.26.2
-  - name: watchexec/watchexec@v2.5.1
+  - name: watchexec/watchexec@v2.6.1
   - name: joshmedeski/sesh@v2.28.0
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
@@ -100,7 +100,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.4
-  - name: astral-sh/ty@0.0.73
+  - name: astral-sh/ty@0.0.74
   - name: j178/prek@v0.4.14
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.1
@@ -109,7 +109,7 @@ packages:
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
-  - name: hatoo/oha@v1.15.0
+  - name: hatoo/oha@v1.16.0
   - name: ClementTsang/bottom@0.14.8
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.