### PR TITLE
chore(aqua): update pinned packages (2026-08-27)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,11 +27,11 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.20
+  - name: google-antigravity/antigravity-cli@1.1.21
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.1
   - name: asciinema/asciinema@v3.2.1
-  - name: atuinsh/atuin@v18.20.0
+  - name: atuinsh/atuin@v18.20.1
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.246
-  - name: openai/codex@rust-v0.149.1
+  - name: anthropics/claude-code@v2.1.247
+  - name: openai/codex@rust-v0.150.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.13
+  - name: jdx/mise@v2026.8.14
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -58,7 +58,7 @@ packages:
   # v0.23.5 existed before its crate, which made aqua's Cargo install impossible.
   - name: crates.io/eza@0.23.5
   - name: fastfetch-cli/fastfetch@2.67.1
-  - name: sharkdp/fd@v10.4.2
+  - name: sharkdp/fd@v10.5.0
   - name: junegunn/fzf@v0.74.3
   - name: gopasspw/gopass@v1.16.1
   - name: cli/cli@v2.98.0
@@ -100,7 +100,7 @@ packages:
   - name: mvdan/sh@v3.13.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.4
-  - name: astral-sh/ty@0.0.74
+  - name: astral-sh/ty@0.0.75
   - name: j178/prek@v0.4.14
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.1
@@ -121,7 +121,7 @@ packages:
   - name: mikefarah/yq@v4.53.6
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0
-  - name: kubernetes/kubernetes/kubectl@v1.36.4
+  - name: kubernetes/kubernetes/kubectl@v1.37.0
   - name: helm/helm@v4.2.4
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.7.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.